### PR TITLE
fix: move bundled dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,28 @@
   "author": "dearlordylord",
   "license": "MIT",
   "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "lint-staged": {
+    "*.ts": "eslint --fix"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js",
+      "esbuild",
+      "@parcel/watcher",
+      "msgpackr-extract",
+      "unrs-resolver"
+    ]
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.30.0",
+    "@effect/eslint-plugin": "^0.3.2",
+    "@effect/language-service": "^0.73.1",
     "@effect/platform": "^0.94.2",
     "@effect/platform-node": "^0.104.1",
+    "@effect/vitest": "latest",
+    "@eslint/compat": "^2.0.2",
     "@hcengineering/account-client": "0.7.25",
     "@hcengineering/activity": "0.7.0",
     "@hcengineering/api-client": "0.7.19",
@@ -79,31 +99,11 @@
     "@hcengineering/tracker": "0.7.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@total-typescript/ts-reset": "^0.6.1",
-    "effect": "^3.19.15",
-    "posthog-node": "^5.24.11"
-  },
-  "lint-staged": {
-    "*.ts": "eslint --fix"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "core-js",
-      "esbuild",
-      "@parcel/watcher",
-      "msgpackr-extract",
-      "unrs-resolver"
-    ]
-  },
-  "devDependencies": {
-    "@changesets/cli": "^2.30.0",
-    "@effect/eslint-plugin": "^0.3.2",
-    "@effect/language-service": "^0.73.1",
-    "@effect/vitest": "latest",
-    "@eslint/compat": "^2.0.2",
     "@types/express": "^5.0.6",
     "@types/node": "^25.1.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/parser": "^8.54.0",
+    "effect": "^3.19.15",
     "esbuild": "^0.27.2",
     "eslint": "^9.39.2",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -116,6 +116,7 @@
     "jscpd": "^4.0.8",
     "lint-staged": "^16.2.7",
     "madge": "^8.0.0",
+    "posthog-node": "^5.24.11",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,31 @@ importers:
 
   .:
     dependencies:
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@changesets/cli':
+        specifier: ^2.30.0
+        version: 2.30.0(@types/node@25.2.0)
+      '@effect/eslint-plugin':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@effect/language-service':
+        specifier: ^0.73.1
+        version: 0.73.1
       '@effect/platform':
         specifier: ^0.94.2
         version: 0.94.5(effect@3.19.19)
       '@effect/platform-node':
         specifier: ^0.104.1
         version: 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/vitest':
+        specifier: latest
+        version: 0.27.0(effect@3.19.19)(vitest@4.0.18(@types/node@25.2.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@eslint/compat':
+        specifier: ^2.0.2
+        version: 2.0.2(eslint@9.39.2)
       '@hcengineering/account-client':
         specifier: 0.7.25
         version: 0.7.25
@@ -80,28 +99,6 @@ importers:
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
         version: 0.6.1
-      effect:
-        specifier: ^3.19.15
-        version: 3.19.19
-      posthog-node:
-        specifier: ^5.24.11
-        version: 5.24.11
-    devDependencies:
-      '@changesets/cli':
-        specifier: ^2.30.0
-        version: 2.30.0(@types/node@25.2.0)
-      '@effect/eslint-plugin':
-        specifier: ^0.3.2
-        version: 0.3.2
-      '@effect/language-service':
-        specifier: ^0.73.1
-        version: 0.73.1
-      '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@3.19.19)(vitest@4.0.18(@types/node@25.2.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@eslint/compat':
-        specifier: ^2.0.2
-        version: 2.0.2(eslint@9.39.2)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -114,6 +111,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      effect:
+        specifier: ^3.19.15
+        version: 3.19.19
       esbuild:
         specifier: ^0.27.2
         version: 0.27.2
@@ -150,6 +150,9 @@ importers:
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.9.3)
+      posthog-node:
+        specifier: ^5.24.11
+        version: 5.24.11
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

- Move all dependencies (except `ws`) to `devDependencies` since they are bundled into `dist/index.cjs` by esbuild
- Add `ws` as the only runtime dependency (required because esbuild marks it as `--external:ws`)
- Resolves #10, Resolves #9 — `npx` installation no longer pulls broken `@hcengineering/*@latest` packages with unresolved `workspace:` references

## Context

The project uses esbuild to bundle everything into a single `dist/index.cjs` file (~7MB). The only external dependency is `ws` (WebSocket client used by `@hcengineering/api-client` at runtime). All other packages — `@hcengineering/*`, `effect`, `@effect/*`, `@modelcontextprotocol/sdk`, `posthog-node` — are fully inlined into the bundle.

However, they were listed under `dependencies`, which caused npm/pnpm to install the entire transitive tree (~200MB+) including upstream `@hcengineering/*@0.7.382` packages that contain unresolved `workspace:` protocol references.

## Test plan

- [x] `pnpm build` produces a working bundle with `require("ws")` as the only external
- [x] Build, typecheck, and tests pass (lint has pre-existing failures on master — 214 errors unrelated to this change)
- [x] Clean install test: `npm install` in empty dir with only `ws` as dep — 196KB, bundle starts correctly