### PR TITLE
feat: add dueDate and estimation support for issues

### DIFF
--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -211,6 +211,14 @@ export const CreateIssueParamsSchema = Schema.Struct({
   })),
   parentIssue: Schema.optional(IssueIdentifier.annotations({
     description: "Parent issue identifier (e.g., 'HULY-42') to create as sub-issue"
+  })),
+  dueDate: Schema.optional(
+    Schema.NullOr(Timestamp).annotations({
+      description: "Due date as Unix timestamp in milliseconds (e.g., 1719792000000 for 2024-07-01), or null to clear"
+    })
+  ),
+  estimation: Schema.optional(PositiveNumber.annotations({
+    description: "Time estimation in hours"
   }))
 }).annotations({
   title: "CreateIssueParams",
@@ -242,7 +250,17 @@ export const UpdateIssueParamsSchema = Schema.Struct({
   ),
   status: Schema.optional(StatusName.annotations({
     description: "New status"
-  }))
+  })),
+  dueDate: Schema.optional(
+    Schema.NullOr(Timestamp).annotations({
+      description: "Due date as Unix timestamp in milliseconds (e.g., 1719792000000 for 2024-07-01), or null to clear"
+    })
+  ),
+  estimation: Schema.optional(
+    Schema.NullOr(PositiveNumber).annotations({
+      description: "Time estimation in hours, or null to clear"
+    })
+  )
 }).annotations({
   title: "UpdateIssueParams",
   description: "Parameters for updating an issue"

--- a/src/huly/operations/issues-write.ts
+++ b/src/huly/operations/issues-write.ts
@@ -183,14 +183,14 @@ export const createIssue = (
       priority,
       assignee: assigneeRef,
       component: null,
-      estimation: 0,
+      estimation: params.estimation ?? 0,
       remainingTime: 0,
       reportedTime: 0,
       reports: 0,
       subIssues: 0,
       parents,
       childInfo: [],
-      dueDate: null,
+      dueDate: params.dueDate ?? null,
       rank
     }
     yield* client.addCollection(
@@ -277,6 +277,14 @@ export const updateIssue = (
         const person = yield* resolveAssignee(client, params.assignee)
         updateOps.assignee = person._id
       }
+    }
+
+    if (params.dueDate !== undefined) {
+      updateOps.dueDate = params.dueDate
+    }
+
+    if (params.estimation !== undefined) {
+      updateOps.estimation = params.estimation ?? 0
     }
 
     if (Object.keys(updateOps).length === 0 && !descriptionUpdatedInPlace) {


### PR DESCRIPTION
## Summary

- Add optional `dueDate` (Unix timestamp in ms, or `null` to clear) and `estimation` (hours, positive number) fields to `CreateIssueParams` and `UpdateIssueParams` schemas
- Wire them through in `createIssue` and `updateIssue` operations
- Previously `dueDate` was hardcoded to `null` and `estimation` to `0`

Closes #11

## Integration test results

Tested against a live Huly instance via the MCP server:

1. **Create issue with dueDate + estimation** — `create_issue` with `dueDate: 1751328000000` (2025-07-01) and `estimation: 4` → created `HULY-3` successfully
2. **Update dueDate + estimation** — `update_issue` with `dueDate: 1753920000000` (2025-07-31) and `estimation: 8` → `updated: true`
3. **Clear dueDate + estimation** — `update_issue` with `dueDate: null, estimation: null` → `updated: true`
4. **Cleanup** — `delete_issue` → `deleted: true`

All operations completed without errors. Schema validation works correctly for both timestamp and null values.