### PR TITLE
fix: convert markdown to Markup for comments and component descriptions

### DIFF
--- a/src/huly/operations/comments.ts
+++ b/src/huly/operations/comments.ts
@@ -18,6 +18,7 @@ import { CommentNotFoundError, HulyConnectionError } from "../errors.js"
 import { clampLimit, findProjectAndIssue as findProjectAndIssueShared, toRef } from "./shared.js"
 
 import { chunter, tracker } from "../huly-plugins.js"
+import { markdownToMarkupString, markupToMarkdownString } from "./channels.js"
 
 type ListCommentsError =
   | HulyClientError
@@ -109,7 +110,7 @@ export const listComments = (
     const validated = yield* Schema.decodeUnknown(Schema.Array(CommentSchema))(
       messages.map((msg) => ({
         id: msg._id,
-        body: msg.message,
+        body: msg.message ? markupToMarkdownString(msg.message) : "",
         authorId: msg.modifiedBy,
         createdOn: msg.createdOn,
         modifiedOn: msg.modifiedOn,
@@ -142,7 +143,7 @@ export const addComment = (
     const commentId: Ref<ChatMessage> = generateId()
 
     const commentData: AttachedData<ChatMessage> = {
-      message: params.body
+      message: markdownToMarkupString(params.body)
     }
 
     yield* client.addCollection(
@@ -170,7 +171,9 @@ export const updateComment = (
   Effect.gen(function*() {
     const { client, comment, issue, project } = yield* findComment(params)
 
-    if (params.body === comment.message) {
+    const newMarkup = markdownToMarkupString(params.body)
+
+    if (newMarkup === comment.message) {
       return {
         commentId: CommentId.make(params.commentId),
         issueIdentifier: IssueIdentifier.make(issue.identifier),
@@ -180,7 +183,7 @@ export const updateComment = (
 
     const now = yield* Clock.currentTimeMillis
     const updateOps: DocumentUpdate<ChatMessage> = {
-      message: params.body,
+      message: newMarkup,
       editedOn: now
     }
 

--- a/src/huly/operations/components.ts
+++ b/src/huly/operations/components.ts
@@ -36,6 +36,7 @@ import { ComponentNotFoundError, PersonNotFoundError } from "../errors.js"
 import { findPersonByEmailOrName, findProject, findProjectAndIssue, toRef } from "./shared.js"
 
 import { contact, tracker } from "../huly-plugins.js"
+import { markdownToMarkupString, markupToMarkdownString } from "./channels.js"
 
 type ListComponentsError =
   | HulyClientError
@@ -171,7 +172,7 @@ export const getComponent = (
     const result: Component = {
       id: ComponentId.make(component._id),
       label: ComponentLabel.make(component.label),
-      description: component.description,
+      description: component.description ? markupToMarkdownString(component.description) : undefined,
       lead: leadName !== undefined ? PersonName.make(leadName) : undefined,
       project: params.project,
       modifiedOn: component.modifiedOn,
@@ -204,7 +205,7 @@ export const createComponent = (
 
     const componentData: Data<HulyComponent> = {
       label: params.label,
-      description: params.description ?? "",
+      description: params.description ? markdownToMarkupString(params.description) : "",
       lead: leadRef,
       comments: 0
     }
@@ -232,7 +233,7 @@ export const updateComponent = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = params.description
+      updateOps.description = params.description.trim() === "" ? "" : markdownToMarkupString(params.description)
     }
 
     if (params.lead !== undefined) {

--- a/test/huly/operations/comments.test.ts
+++ b/test/huly/operations/comments.test.ts
@@ -16,6 +16,7 @@ import { addComment, deleteComment, listComments, updateComment } from "../../..
 import { commentBrandId, issueIdentifier, projectIdentifier } from "../../helpers/brands.js"
 
 import { chunter, tracker } from "../../../src/huly/huly-plugins.js"
+import { markdownToMarkupString } from "../../../src/huly/operations/channels.js"
 
 // --- Mock Data Builders ---
 
@@ -548,7 +549,7 @@ describe("addComment", () => {
 
         expect(result.commentId).toBeDefined()
         expect(result.issueIdentifier).toBe("TEST-1")
-        expect(captureAddCollection.attributes?.message).toBe("This is my new comment")
+        expect(captureAddCollection.attributes?.message).toBe(markdownToMarkupString("This is my new comment"))
       }))
 
     // test-revizorro: approved
@@ -571,8 +572,9 @@ describe("addComment", () => {
           body: "# Heading\n\n- Item 1\n- Item 2\n\n```js\nconsole.log('test');\n```"
         }).pipe(Effect.provide(testLayer))
 
-        expect(captureAddCollection.attributes?.message).toContain("# Heading")
-        expect(captureAddCollection.attributes?.message).toContain("console.log")
+        const markdownBody = "# Heading\n\n- Item 1\n- Item 2\n\n```js\nconsole.log('test');\n```"
+        const stored = captureAddCollection.attributes?.message as string
+        expect(stored).toBe(markdownToMarkupString(markdownBody))
       }))
 
     // test-revizorro: approved
@@ -691,7 +693,7 @@ describe("updateComment", () => {
         expect(result.commentId).toBe("comment-abc")
         expect(result.issueIdentifier).toBe("TEST-1")
         expect(result.updated).toBe(true)
-        expect(captureUpdateDoc.operations?.message).toBe("Updated comment body")
+        expect(captureUpdateDoc.operations?.message).toBe(markdownToMarkupString("Updated comment body"))
         const editedOn = captureUpdateDoc.operations?.editedOn as number
         expect(editedOn).toBeGreaterThanOrEqual(before)
         expect(editedOn).toBeLessThanOrEqual(after)
@@ -764,7 +766,7 @@ describe("updateComment", () => {
           body: "**Bold** and *italic*"
         }).pipe(Effect.provide(testLayer))
 
-        expect(captureUpdateDoc.operations?.message).toBe("**Bold** and *italic*")
+        expect(captureUpdateDoc.operations?.message).toBe(markdownToMarkupString("**Bold** and *italic*"))
       }))
 
     // test-revizorro: approved
@@ -780,7 +782,7 @@ describe("updateComment", () => {
         const messages = [
           makeChatMessage({
             _id: "comment-abc" as Ref<ChatMessage>,
-            message: "Same content",
+            message: markdownToMarkupString("Same content"),
             attachedTo: "issue-1" as Ref<Doc>
           })
         ]

--- a/test/huly/operations/components.test.ts
+++ b/test/huly/operations/components.test.ts
@@ -19,6 +19,7 @@ import type {
   ProjectNotFoundError
 } from "../../../src/huly/errors.js"
 import { contact, tracker } from "../../../src/huly/huly-plugins.js"
+import { markdownToMarkupString } from "../../../src/huly/operations/channels.js"
 import {
   createComponent,
   deleteComponent,
@@ -566,7 +567,7 @@ describe("createComponent", () => {
       }).pipe(Effect.provide(testLayer))
 
       expect(result.label).toBe("Frontend")
-      expect(captureCreateDoc.attributes?.description).toBe("UI component")
+      expect(captureCreateDoc.attributes?.description).toBe(markdownToMarkupString("UI component"))
       expect(captureCreateDoc.attributes?.lead).toBe("person-1")
     }))
 
@@ -658,7 +659,7 @@ describe("updateComponent", () => {
       }).pipe(Effect.provide(testLayer))
 
       expect(result.updated).toBe(true)
-      expect(captureUpdateDoc.operations?.description).toBe("Updated description")
+      expect(captureUpdateDoc.operations?.description).toBe(markdownToMarkupString("Updated description"))
     }))
 
   // test-revizorro: approved


### PR DESCRIPTION
Closes #15

## Summary

- **Comments** (`addComment`, `updateComment`, `listComments`) now convert markdown ↔ Markup via `markdownToMarkupString` / `markupToMarkdownString` — same pattern used by channels and threads
- **Components** (`createComponent`, `updateComponent`, `getComponent`) now convert description markdown ↔ Markup
- `updateComment` unchanged detection now compares converted Markup values instead of raw text vs Markup

## What was wrong

Comment `message` and component `description` fields were stored as raw text strings, bypassing ProseMirror Markup conversion. Markdown formatting appeared as plain text in the Huly UI (e.g. `## Heading` instead of a rendered heading).

## Changes

| File | Change |
|------|--------|
| `src/huly/operations/comments.ts` | Import `markdownToMarkupString` / `markupToMarkdownString` from channels; apply conversion on write (addComment, updateComment) and read (listComments) |
| `src/huly/operations/components.ts` | Import same helpers; apply conversion on write (createComponent, updateComponent) and read (getComponent) |
| `test/huly/operations/comments.test.ts` | Update assertions to expect Markup-converted values |
| `test/huly/operations/components.test.ts` | Update assertions to expect Markup-converted values |

## Test plan

- [x] All 1690 existing tests pass
- [x] 0 lint errors (315 pre-existing warnings)
- [x] Manually verified on self-hosted Huly instance — comments and component descriptions render markdown correctly after the fix