### PR TITLE
Fix update_issue assignee resolution for workspace social identity emails

### DIFF
--- a/src/huly/operations/issues-write.ts
+++ b/src/huly/operations/issues-write.ts
@@ -3,7 +3,7 @@
  *
  * @module
  */
-import type { Person } from "@hcengineering/contact"
+import type { Person, SocialIdentity } from "@hcengineering/contact"
 import {
   type AttachedData,
   type Class,
@@ -26,7 +26,7 @@ import { IssueId, IssueIdentifier } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
 import type { IssueNotFoundError, ProjectNotFoundError } from "../errors.js"
 import { InvalidStatusError, PersonNotFoundError } from "../errors.js"
-import { tracker } from "../huly-plugins.js"
+import { contact, tracker } from "../huly-plugins.js"
 import {
   findIssueInProject,
   findPersonByEmailOrName,
@@ -70,16 +70,50 @@ const extractUpdatedSequence = (txResult: unknown): number | undefined => {
   return decoded._tag === "Some" ? decoded.value.object.sequence : undefined
 }
 
+const looksLikeEmail = (value: string): boolean => value.includes("@")
+
+const findPersonBySocialIdentityEmail = (
+  client: HulyClient["Type"],
+  email: string
+): Effect.Effect<Person | undefined, HulyClientError> =>
+  Effect.gen(function*() {
+    const socialIdentity = yield* client.findOne<SocialIdentity>(contact.class.SocialIdentity, {
+      type: "email",
+      value: email
+    })
+
+    if (socialIdentity === undefined) {
+      return undefined
+    }
+
+    const personId = socialIdentity.personUuid ?? socialIdentity.person ?? socialIdentity.attachedTo
+    if (personId === undefined) {
+      return undefined
+    }
+
+    return yield* client.findOne<Person>(contact.class.Person, {
+      _id: toRef<Person>(personId)
+    })
+  })
+
 const resolveAssignee = (
   client: HulyClient["Type"],
   assigneeIdentifier: string
 ): Effect.Effect<Person, PersonNotFoundError | HulyClientError> =>
   Effect.gen(function*() {
     const person = yield* findPersonByEmailOrName(client, assigneeIdentifier)
-    if (person === undefined) {
-      return yield* new PersonNotFoundError({ identifier: assigneeIdentifier })
+    if (person !== undefined) {
+      return person
     }
-    return person
+
+    if (looksLikeEmail(assigneeIdentifier)) {
+      const socialIdentityPerson = yield* findPersonBySocialIdentityEmail(client, assigneeIdentifier)
+      if (socialIdentityPerson !== undefined) {
+        return socialIdentityPerson
+      }
+    }
+
+    return yield* new PersonNotFoundError({ identifier: assigneeIdentifier })
   })
 
 /**


### PR DESCRIPTION
## Summary

This fixes a mismatch in `update_issue` assignee resolution.

Before this change, `update_issue` resolved assignees only through contact email channels or person name lookups. In self-hosted setups, a valid workspace member email can exist in social identity / workspace member data without a matching contact email channel, causing:

`Person '<email>' not found`

This patch keeps the existing `findPersonByEmailOrName(...)` path first, then adds a narrow fallback for email-shaped identifiers using `contact.class.SocialIdentity`, mapping back to `contact.class.Person`.

## What changed

- kept existing assignee resolution behavior first
- added fallback lookup by social identity email
- only returns a `Person` if the social identity can be mapped back to one

## Why

`list_workspace_members` can show a valid member email from social identity data, while `update_issue` previously only checked contact email channels. That made valid workspace members unassignable by email in some environments.

## Validation

- `pnpm build` passed
- `pnpm typecheck` passed
- `pnpm test` passed

## Notes

I verified this locally against a self-hosted Huly setup where:
- `update_issue` for `status` succeeded
- `update_issue` for `assignee` failed with `Person '<email>' not found`
- after the patch, assignee resolution succeeded for that workspace member email