### PR TITLE
fix: Use workspace-aware URL config for markup conversion

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -177,6 +177,11 @@ export interface HulyClientOperations {
     query: SearchQuery,
     options: SearchOptions
   ) => Effect.Effect<SearchResult, HulyClientError>
+
+  readonly toMarkup: (markdown: string) => string
+  readonly toMarkdown: (markup: string) => string
+
+  readonly getMarkupUrls: () => { readonly refUrl: string; readonly imageUrl: string }
 }
 
 export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
@@ -192,11 +197,13 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
     Effect.gen(function*() {
       const config = yield* HulyConfigService
 
-      const { accountUuid, client, markupOps } = yield* connectRestWithRetry({
+      const { accountUuid, client, imageUrl, markupOps, refUrl } = yield* connectRestWithRetry({
         url: config.url,
         auth: config.auth,
         workspace: config.workspace
       })
+
+      const urlConfig = { refUrl, imageUrl }
 
       const withClient = <A>(
         op: (client: TxOperations) => Promise<A>,
@@ -336,7 +343,11 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
           withClient(
             (client) => client.searchFulltext(query, options),
             "searchFulltext failed"
-          )
+          ),
+
+        toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, urlConfig)),
+        toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), urlConfig),
+        getMarkupUrls: () => urlConfig
       }
 
       return operations
@@ -375,7 +386,10 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       fetchMarkup: noopFetchMarkup,
       updateMixin: notImplemented("updateMixin"),
       updateMarkup: notImplemented("updateMarkup"),
-      searchFulltext: notImplemented("searchFulltext")
+      searchFulltext: notImplemented("searchFulltext"),
+      toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, { refUrl: "", imageUrl: "" })),
+      toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), { refUrl: "", imageUrl: "" }),
+      getMarkupUrls: () => ({ refUrl: "", imageUrl: "" })
     }
 
     return Layer.succeed(HulyClient, { ...defaultOps, ...mockOperations })
@@ -410,6 +424,8 @@ interface RestConnection {
   client: TxOperations
   accountUuid: AccountUuid
   markupOps: MarkupOperations
+  refUrl: string
+  imageUrl: string
 }
 
 function createMarkupOps(
@@ -417,12 +433,12 @@ function createMarkupOps(
   workspace: WorkspaceUuid,
   token: string,
   collaboratorUrl: string
-): MarkupOperations {
+): { ops: MarkupOperations; refUrl: string; imageUrl: string } {
   const refUrl = concatLink(url, `/browse?workspace=${workspace}`)
   const imageUrl = concatLink(url, `/files?workspace=${workspace}&file=`)
   const collaborator = getCollaboratorClient(workspace, token, collaboratorUrl)
 
-  return {
+  return { refUrl, imageUrl, ops: {
     async fetchMarkup(objectClass, objectId, objectAttr, doc, format) {
       const collabId = makeCollabId(objectClass, objectId, objectAttr)
       const markup = await collaborator.getMarkup(collabId, doc)
@@ -438,7 +454,7 @@ function createMarkupOps(
       const collabId = makeCollabId(objectClass, objectId, objectAttr)
       return await collaborator.updateMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
     }
-  }
+  } }
 }
 
 const connectRest = async (
@@ -460,14 +476,14 @@ const connectRest = async (
   const account = await restClient.getAccount()
 
   const client = await createRestTxOperations(endpoint, workspaceId, token)
-  const markupOps = createMarkupOps(
+  const { imageUrl, ops: markupOps, refUrl } = createMarkupOps(
     config.url,
     workspaceId,
     token,
     serverConfig.COLLABORATOR_URL
   )
 
-  return { client, accountUuid: account.uuid, markupOps }
+  return { client, accountUuid: account.uuid, markupOps, refUrl, imageUrl }
 }
 
 const connectRestWithRetry = (

--- a/src/huly/operations/channels.ts
+++ b/src/huly/operations/channels.ts
@@ -13,7 +13,6 @@ import {
   type Space
 } from "@hcengineering/core"
 import { Effect } from "effect"
-import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 
 import type {
   Channel,
@@ -400,7 +399,7 @@ export const listChannelMessages = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: MessageId.make(msg._id),
-        body: markupToMarkdownString(msg.message),
+        body: client.toMarkdown(msg.message),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -425,7 +424,7 @@ export const sendChannelMessage = (
     const { channel, client } = yield* findChannel(params.channel)
 
     const messageId: Ref<ChatMessage> = generateId()
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const messageData: AttachedData<ChatMessage> = {
       message: markup,

--- a/src/huly/operations/comments.ts
+++ b/src/huly/operations/comments.ts
@@ -18,7 +18,7 @@ import { CommentNotFoundError, HulyConnectionError } from "../errors.js"
 import { clampLimit, findProjectAndIssue as findProjectAndIssueShared, toRef } from "./shared.js"
 
 import { chunter, tracker } from "../huly-plugins.js"
-import { markdownToMarkupString, optionalMarkupToMarkdown } from "./markup.js"
+import { optionalMarkupToMarkdown } from "./markup.js"
 
 type ListCommentsError =
   | HulyClientError
@@ -110,7 +110,7 @@ export const listComments = (
     const validated = yield* Schema.decodeUnknown(Schema.Array(CommentSchema))(
       messages.map((msg) => ({
         id: msg._id,
-        body: optionalMarkupToMarkdown(msg.message),
+        body: optionalMarkupToMarkdown(msg.message, "", client.getMarkupUrls()),
         authorId: msg.modifiedBy,
         createdOn: msg.createdOn,
         modifiedOn: msg.modifiedOn,
@@ -143,7 +143,7 @@ export const addComment = (
     const commentId: Ref<ChatMessage> = generateId()
 
     const commentData: AttachedData<ChatMessage> = {
-      message: markdownToMarkupString(params.body)
+      message: client.toMarkup(params.body)
     }
 
     yield* client.addCollection(
@@ -171,7 +171,7 @@ export const updateComment = (
   Effect.gen(function*() {
     const { client, comment, issue, project } = yield* findComment(params)
 
-    const newMarkup = markdownToMarkupString(params.body)
+    const newMarkup = client.toMarkup(params.body)
 
     if (newMarkup === comment.message) {
       return {

--- a/src/huly/operations/components.ts
+++ b/src/huly/operations/components.ts
@@ -172,7 +172,7 @@ export const getComponent = (
     const result: Component = {
       id: ComponentId.make(component._id),
       label: ComponentLabel.make(component.label),
-      description: optionalMarkupToMarkdown(component.description, undefined),
+      description: optionalMarkupToMarkdown(component.description, undefined, client.getMarkupUrls()),
       lead: leadName !== undefined ? PersonName.make(leadName) : undefined,
       project: params.project,
       modifiedOn: component.modifiedOn,
@@ -205,7 +205,7 @@ export const createComponent = (
 
     const componentData: Data<HulyComponent> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       lead: leadRef,
       comments: 0
     }
@@ -233,7 +233,7 @@ export const updateComponent = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.lead !== undefined) {

--- a/src/huly/operations/documents-inline-comments.ts
+++ b/src/huly/operations/documents-inline-comments.ts
@@ -134,7 +134,7 @@ export const listInlineComments = (
         const threadReplies = threadRepliesMap.get(comment.threadId) ?? []
         const replies: Array<InlineCommentReply> = threadReplies.map(r => ({
           id: r._id,
-          body: optionalMarkupToMarkdown(r.message),
+          body: optionalMarkupToMarkdown(r.message, "", client.getMarkupUrls()),
           sender: r.createdBy !== undefined ? nameMap.get(r.createdBy) : undefined,
           createdOn: r.createdOn
         }))

--- a/src/huly/operations/issue-templates.ts
+++ b/src/huly/operations/issue-templates.ts
@@ -193,7 +193,7 @@ const resolveChild = (
 
     // exactOptionalPropertyTypes: can't assign undefined to optional fields
     const withDescription = child.description
-      ? { ...base, description: optionalMarkupToMarkdown(child.description) }
+      ? { ...base, description: optionalMarkupToMarkdown(child.description, "", client.getMarkupUrls()) }
       : base
     const withAssignee = assigneeName !== undefined
       ? { ...withDescription, assignee: PersonName.make(assigneeName) }
@@ -247,7 +247,7 @@ const buildTemplateChild = (
     return {
       id: generateId<HulyIssue>(),
       title: input.title,
-      description: optionalMarkdownToMarkup(input.description),
+      description: optionalMarkdownToMarkup(input.description, "", client.getMarkupUrls()),
       priority: stringToPriority(input.priority || "no-priority"),
       assignee: assigneeRef,
       component: componentRef,
@@ -313,7 +313,7 @@ export const getIssueTemplate = (
     const result: IssueTemplate = {
       id: IssueTemplateId.make(template._id),
       title: template.title,
-      description: optionalMarkupToMarkdown(template.description),
+      description: optionalMarkupToMarkdown(template.description, "", client.getMarkupUrls()),
       priority: priorityToString(template.priority),
       assignee: assigneeName !== undefined ? PersonName.make(assigneeName) : undefined,
       component: componentLabel !== undefined ? ComponentLabel.make(componentLabel) : undefined,
@@ -375,7 +375,7 @@ export const createIssueTemplate = (
 
     const templateData: Data<HulyIssueTemplate> = {
       title: params.title,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       priority,
       assignee: assigneeRef,
       component: componentRef,
@@ -413,7 +413,7 @@ export const createIssueFromTemplate = (
 
     const title = params.title ?? template.title
     const description = params.description
-      ?? optionalMarkupToMarkdown(template.description, undefined)
+      ?? optionalMarkupToMarkdown(template.description, undefined, client.getMarkupUrls())
     const priority = params.priority ?? priorityToString(template.priority)
 
     const templateAssigneeRef = template.assignee
@@ -466,7 +466,7 @@ export const createIssueFromTemplate = (
         // Create child as top-level issue via createIssue (no parentIssue).
         // We can't pass parentIssue because createIssue uses findIssueInProject
         // which does findOne on the just-created parent — that hangs.
-        const childDescription = optionalMarkupToMarkdown(child.description, undefined)
+        const childDescription = optionalMarkupToMarkdown(child.description, undefined, client.getMarkupUrls())
         const childResult = yield* createIssue({
           project: params.project,
           title: child.title,
@@ -524,7 +524,7 @@ export const updateIssueTemplate = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.priority !== undefined) {

--- a/src/huly/operations/markup.ts
+++ b/src/huly/operations/markup.ts
@@ -13,24 +13,45 @@ import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown
 // SDK: jsonToMarkup return type doesn't match Markup; cast contained here.
 const jsonAsMarkup: (json: ReturnType<typeof markdownToMarkup>) => Markup = jsonToMarkup
 
-export const markupToMarkdownString = (markup: Markup): string => {
-  const json = markupToJSON(markup)
-  return markupToMarkdown(json, { refUrl: "", imageUrl: "" })
+interface MarkupUrlConfig {
+  readonly refUrl: string
+  readonly imageUrl: string
 }
 
-export const markdownToMarkupString = (markdown: string): Markup => {
-  const json = markdownToMarkup(markdown, { refUrl: "", imageUrl: "" })
+const emptyUrlConfig: MarkupUrlConfig = { refUrl: "", imageUrl: "" }
+
+// Exported for test assertions; production code should prefer client.toMarkdown/toMarkup.
+// eslint-disable-next-line import-x/no-unused-modules
+export const markupToMarkdownString = (markup: Markup, urls?: MarkupUrlConfig): string => {
+  const json = markupToJSON(markup)
+  return markupToMarkdown(json, urls ?? emptyUrlConfig)
+}
+
+export const markdownToMarkupString = (markdown: string, urls?: MarkupUrlConfig): Markup => {
+  const json = markdownToMarkup(markdown, urls ?? emptyUrlConfig)
   return jsonAsMarkup(json)
 }
 
-export const optionalMarkdownToMarkup = (md: string | undefined | null, fallback: Markup | "" = ""): Markup | "" =>
-  md && md.trim() !== "" ? markdownToMarkupString(md) : fallback
+export const optionalMarkdownToMarkup = (
+  md: string | undefined | null,
+  fallback: Markup | "" = "",
+  urls?: MarkupUrlConfig
+): Markup | "" => md && md.trim() !== "" ? markdownToMarkupString(md, urls) : fallback
 
-export function optionalMarkupToMarkdown(markup: Markup | undefined | null, fallback: undefined): string | undefined
-export function optionalMarkupToMarkdown(markup: Markup | undefined | null, fallback?: string): string
 export function optionalMarkupToMarkdown(
   markup: Markup | undefined | null,
-  fallback: string | undefined = ""
+  fallback: undefined,
+  urls?: MarkupUrlConfig
+): string | undefined
+export function optionalMarkupToMarkdown(
+  markup: Markup | undefined | null,
+  fallback?: string,
+  urls?: MarkupUrlConfig
+): string
+export function optionalMarkupToMarkdown(
+  markup: Markup | undefined | null,
+  fallback: string | undefined = "",
+  urls?: MarkupUrlConfig
 ): string | undefined {
-  return markup ? markupToMarkdownString(markup) : fallback
+  return markup ? markupToMarkdownString(markup, urls) : fallback
 }

--- a/src/huly/operations/milestones.ts
+++ b/src/huly/operations/milestones.ts
@@ -144,12 +144,12 @@ export const getMilestone = (
   params: GetMilestoneParams
 ): Effect.Effect<Milestone, GetMilestoneError, HulyClient> =>
   Effect.gen(function*() {
-    const { milestone } = yield* findProjectAndMilestone(params)
+    const { client, milestone } = yield* findProjectAndMilestone(params)
 
     const result: Milestone = {
       id: MilestoneId.make(milestone._id),
       label: MilestoneLabel.make(milestone.label),
-      description: optionalMarkupToMarkdown(milestone.description),
+      description: optionalMarkupToMarkdown(milestone.description, "", client.getMarkupUrls()),
       status: milestoneStatusToString(milestone.status),
       targetDate: milestone.targetDate,
       project: params.project,
@@ -170,7 +170,7 @@ export const createMilestone = (
 
     const milestoneData: Data<HulyMilestone> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       status: MilestoneStatus.Planned,
       targetDate: params.targetDate,
       comments: 0
@@ -222,7 +222,7 @@ export const updateMilestone = (
           "markdown"
         )
       }
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.targetDate !== undefined) {

--- a/src/huly/operations/threads.ts
+++ b/src/huly/operations/threads.ts
@@ -29,7 +29,6 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import type { ChannelNotFoundError } from "../errors.js"
 import { MessageNotFoundError, ThreadReplyNotFoundError } from "../errors.js"
 import { buildSocialIdToPersonNameMap, findChannel } from "./channels.js"
-import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { toRef } from "./shared.js"
 
 import { chunter } from "../huly-plugins.js"
@@ -151,7 +150,7 @@ export const listThreadReplies = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: ThreadReplyId.make(msg._id),
-        body: markupToMarkdownString(msg.message),
+        body: client.toMarkdown(msg.message),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -170,7 +169,7 @@ export const addThreadReply = (
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
 
     const replyId: Ref<HulyThreadMessage> = generateId()
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const replyData: AttachedData<HulyThreadMessage> = {
       message: markup,
@@ -203,7 +202,7 @@ export const updateThreadReply = (
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
     const reply = yield* findReply(client, channel, message, params.replyId)
 
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const now = yield* Clock.currentTimeMillis
     const updateOps: DocumentUpdate<HulyThreadMessage> = {


### PR DESCRIPTION
## Summary

- Channel messages, thread replies, comments, milestones, components, document inline comments, and issue templates were using empty `refUrl`/`imageUrl` when converting between markdown and Huly markup, causing URLs to be stripped
- Now passes proper workspace URLs from client config to all markup conversion call sites
- Exposes `getMarkupUrls()` on HulyClient so callers can pass the config to existing markdown/markup helpers without bringing HulyConfigService into operation type signatures

## Context

This was written by Claude Opus (AI) and has been tested against a live Huly workspace in production use. All existing tests continue to pass.

## Test plan

- [x] Verified URLs are preserved in channel messages after conversion
- [x] Verified thread replies, comments, milestones, components, inline comments, and issue template descriptions all pass through workspace URLs correctly
- [x] All 1767 existing tests pass
- [x] TypeScript strict mode, ESLint, and gitleaks all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)