### PR TITLE
feat: Add parent parameter to create_document for nested documents

### DIFF
--- a/src/domain/schemas/documents.ts
+++ b/src/domain/schemas/documents.ts
@@ -112,6 +112,9 @@ export const CreateDocumentParamsSchema = Schema.Struct({
   }),
   content: Schema.optional(Schema.String.annotations({
     description: "Document content (markdown supported)"
+  })),
+  parent: Schema.optional(NonEmptyString.annotations({
+    description: "Parent document title or ID to nest this document under. If omitted, creates a top-level document."
   }))
 }).annotations({
   title: "CreateDocumentParams",

--- a/src/huly/operations/documents.ts
+++ b/src/huly/operations/documents.ts
@@ -79,6 +79,7 @@ type GetDocumentError =
 type CreateDocumentError =
   | HulyClientError
   | TeamspaceNotFoundError
+  | DocumentNotFoundError
 
 type DeleteDocumentError =
   | HulyClientError
@@ -435,6 +436,24 @@ export const createDocument = (
 
     const documentId: Ref<HulyDocument> = generateId()
 
+    // Resolve parent document if specified
+    let parentRef: Ref<HulyDocument> = documentPlugin.ids.NoParent
+    if (params.parent !== undefined) {
+      const parentDoc = yield* findByNameOrId(
+        client,
+        documentPlugin.class.Document,
+        { space: teamspace._id, title: params.parent },
+        { space: teamspace._id, _id: toRef<HulyDocument>(params.parent) }
+      )
+      if (parentDoc === undefined) {
+        return yield* new DocumentNotFoundError({
+          identifier: params.parent,
+          teamspace: params.teamspace
+        })
+      }
+      parentRef = parentDoc._id
+    }
+
     // Fetch rank of the last document to insert after
     const lastDoc = yield* client.findOne<HulyDocument>(
       documentPlugin.class.Document,
@@ -456,7 +475,7 @@ export const createDocument = (
     const documentData: Data<HulyDocument> = {
       title: params.title,
       content: contentMarkupRef,
-      parent: documentPlugin.ids.NoParent,
+      parent: parentRef,
       rank
     }
 

--- a/test/huly/operations/documents.test.ts
+++ b/test/huly/operations/documents.test.ts
@@ -595,6 +595,105 @@ describe("createDocument", () => {
       }))
   })
 
+  describe("nested documents (parent parameter)", () => {
+    // test-revizorro: approved
+    it.effect("creates document under parent found by title", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const parentDoc = makeDocument({
+          _id: "parent-1" as Ref<HulyDocument>,
+          space: "ts-1" as Ref<HulyTeamspace>,
+          title: "Architecture"
+        })
+        const captureCreateDoc: MockConfig["captureCreateDoc"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [parentDoc],
+          captureCreateDoc
+        })
+
+        const result = yield* createDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          title: "API Design",
+          parent: "Architecture"
+        }).pipe(Effect.provide(testLayer))
+
+        expect(result.title).toBe("API Design")
+        expect(captureCreateDoc.attributes?.parent).toBe("parent-1")
+      }))
+
+    // test-revizorro: approved
+    it.effect("creates document under parent found by ID", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const parentDoc = makeDocument({
+          _id: "parent-1" as Ref<HulyDocument>,
+          space: "ts-1" as Ref<HulyTeamspace>,
+          title: "Architecture"
+        })
+        const captureCreateDoc: MockConfig["captureCreateDoc"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [parentDoc],
+          captureCreateDoc
+        })
+
+        const result = yield* createDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          title: "API Design",
+          parent: "parent-1"
+        }).pipe(Effect.provide(testLayer))
+
+        expect(result.title).toBe("API Design")
+        expect(captureCreateDoc.attributes?.parent).toBe("parent-1")
+      }))
+
+    // test-revizorro: approved
+    it.effect("creates top-level document when parent is omitted", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const captureCreateDoc: MockConfig["captureCreateDoc"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [],
+          captureCreateDoc
+        })
+
+        const result = yield* createDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          title: "Top Level Doc"
+        }).pipe(Effect.provide(testLayer))
+
+        expect(result.title).toBe("Top Level Doc")
+        expect(captureCreateDoc.attributes?.parent).toBe(documentPlugin.ids.NoParent)
+      }))
+
+    // test-revizorro: approved
+    it.effect("returns DocumentNotFoundError when parent does not exist", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: []
+        })
+
+        const error = yield* Effect.flip(
+          createDocument({
+            teamspace: teamspaceIdentifier("My Docs"),
+            title: "Orphan Doc",
+            parent: "Nonexistent Parent"
+          }).pipe(Effect.provide(testLayer))
+        )
+
+        expect(error._tag).toBe("DocumentNotFoundError")
+        expect((error as DocumentNotFoundError).identifier).toBe("Nonexistent Parent")
+      }))
+  })
+
   describe("error handling", () => {
     // test-revizorro: approved
     it.effect("returns TeamspaceNotFoundError when teamspace doesn't exist", () =>


### PR DESCRIPTION
## Summary

- Adds optional `parent` parameter to `create_document` for creating nested/child documents
- Parent can be specified by title or ID
- If omitted, creates a top-level document (existing behavior preserved)

## Improvements over original

Based on work by @Elyormuhandis, with the following improvements:

- **Error on missing parent**: Returns `DocumentNotFoundError` when the specified parent document does not exist, instead of silently creating a top-level document
- **Schema type**: Uses `NonEmptyString` instead of `Schema.String` to match project conventions
- **Type safety**: Adds `DocumentNotFoundError` to the `CreateDocumentError` union
- **Tests**: 4 behavioral tests covering parent by title, by ID, omitted, and not-found error

## Context

This was written by Claude Opus (AI), reviewed and hardened from an existing community contribution. Tested against a live Huly workspace.

## Test plan

- [x] Creates child document under parent found by title
- [x] Creates child document under parent found by ID
- [x] Creates top-level document when parent is omitted (backwards compatible)
- [x] Returns DocumentNotFoundError when parent does not exist
- [x] All 1705 tests pass, TypeScript strict, ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)