### PR TITLE
fix: Use workspace-aware URL config for markup conversion

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -9,6 +9,7 @@
  *
  * @module
  */
+/* eslint-disable max-lines -- connection setup and client operation wiring live in one module */
 import {
   createRestClient,
   createRestTxOperations,
@@ -48,9 +49,11 @@ import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown
 import { absurd, Context, Effect, Layer } from "effect"
 
 import { HulyConfigService } from "../config/config.js"
+import { UrlString } from "../domain/schemas/shared.js"
 import { concatLink } from "../utils/url.js"
 import { authToOptions, type ConnectionConfig, type ConnectionError, connectWithRetry } from "./auth-utils.js"
 import { HulyConnectionError } from "./errors.js"
+import { type MarkupUrlConfig, testMarkupUrlConfig } from "./operations/markup.js"
 
 interface MarkupConvertOptions {
   readonly refUrl: string
@@ -95,7 +98,11 @@ function fromInternalMarkup(
 
 export type HulyClientError = ConnectionError
 
-export interface HulyClientOperations {
+interface HulyClientContext {
+  readonly markupUrlConfig: MarkupUrlConfig
+}
+
+export interface HulyClientOperations extends HulyClientContext {
   readonly getAccountUuid: () => AccountUuid
 
   readonly findAll: <T extends Doc>(
@@ -177,11 +184,6 @@ export interface HulyClientOperations {
     query: SearchQuery,
     options: SearchOptions
   ) => Effect.Effect<SearchResult, HulyClientError>
-
-  readonly toMarkup: (markdown: string) => string
-  readonly toMarkdown: (markup: string) => string
-
-  readonly getMarkupUrls: () => { readonly refUrl: string; readonly imageUrl: string }
 }
 
 export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
@@ -192,7 +194,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
     HulyClient,
     HulyClientError,
     HulyConfigService
-  > = Layer.scoped(
+  > = Layer.effect(
     HulyClient,
     Effect.gen(function*() {
       const config = yield* HulyConfigService
@@ -203,7 +205,10 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
         workspace: config.workspace
       })
 
-      const urlConfig = { refUrl, imageUrl }
+      const markupUrlConfig: MarkupUrlConfig = {
+        refUrl: UrlString.make(refUrl),
+        imageUrl: UrlString.make(imageUrl)
+      }
 
       const withClient = <A>(
         op: (client: TxOperations) => Promise<A>,
@@ -220,6 +225,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
 
       const operations: HulyClientOperations = {
         getAccountUuid: () => accountUuid,
+        markupUrlConfig,
 
         findAll: <T extends Doc>(
           _class: Ref<Class<T>>,
@@ -343,11 +349,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
           withClient(
             (client) => client.searchFulltext(query, options),
             "searchFulltext failed"
-          ),
-
-        toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, urlConfig)),
-        toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), urlConfig),
-        getMarkupUrls: () => urlConfig
+          )
       }
 
       return operations
@@ -376,6 +378,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       // AccountUuid is a double-branded string type with no public constructor
       // eslint-disable-next-line no-restricted-syntax -- see above
       getAccountUuid: () => "test-account-uuid" as AccountUuid,
+      markupUrlConfig: testMarkupUrlConfig,
       findAll: noopFindAll,
       findOne: noopFindOne,
       createDoc: notImplemented("createDoc"),
@@ -386,10 +389,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       fetchMarkup: noopFetchMarkup,
       updateMixin: notImplemented("updateMixin"),
       updateMarkup: notImplemented("updateMarkup"),
-      searchFulltext: notImplemented("searchFulltext"),
-      toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, { refUrl: "", imageUrl: "" })),
-      toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), { refUrl: "", imageUrl: "" }),
-      getMarkupUrls: () => ({ refUrl: "", imageUrl: "" })
+      searchFulltext: notImplemented("searchFulltext")
     }
 
     return Layer.succeed(HulyClient, { ...defaultOps, ...mockOperations })
@@ -434,27 +434,35 @@ function createMarkupOps(
   token: string,
   collaboratorUrl: string
 ): { ops: MarkupOperations; refUrl: string; imageUrl: string } {
+  // @hcengineering/text-markdown expects refUrl/imageUrl option names, but the Huly SDK does not
+  // expose helpers or constants for the concrete workspace browse/files routes. We derive those
+  // Huly-specific URLs here from the connected base URL and workspace id so markdown round-trips
+  // preserve links and images across entities.
   const refUrl = concatLink(url, `/browse?workspace=${workspace}`)
   const imageUrl = concatLink(url, `/files?workspace=${workspace}&file=`)
   const collaborator = getCollaboratorClient(workspace, token, collaboratorUrl)
 
-  return { refUrl, imageUrl, ops: {
-    async fetchMarkup(objectClass, objectId, objectAttr, doc, format) {
-      const collabId = makeCollabId(objectClass, objectId, objectAttr)
-      const markup = await collaborator.getMarkup(collabId, doc)
-      return fromInternalMarkup(markup, format, { refUrl, imageUrl })
-    },
+  return {
+    refUrl,
+    imageUrl,
+    ops: {
+      async fetchMarkup(objectClass, objectId, objectAttr, doc, format) {
+        const collabId = makeCollabId(objectClass, objectId, objectAttr)
+        const markup = await collaborator.getMarkup(collabId, doc)
+        return fromInternalMarkup(markup, format, { refUrl, imageUrl })
+      },
 
-    async uploadMarkup(objectClass, objectId, objectAttr, value, format) {
-      const collabId = makeCollabId(objectClass, objectId, objectAttr)
-      return await collaborator.createMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
-    },
+      async uploadMarkup(objectClass, objectId, objectAttr, value, format) {
+        const collabId = makeCollabId(objectClass, objectId, objectAttr)
+        return await collaborator.createMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
+      },
 
-    async updateMarkup(objectClass, objectId, objectAttr, value, format) {
-      const collabId = makeCollabId(objectClass, objectId, objectAttr)
-      return await collaborator.updateMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
+      async updateMarkup(objectClass, objectId, objectAttr, value, format) {
+        const collabId = makeCollabId(objectClass, objectId, objectAttr)
+        return await collaborator.updateMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
+      }
     }
-  } }
+  }
 }
 
 const connectRest = async (

--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -177,6 +177,11 @@ export interface HulyClientOperations {
     query: SearchQuery,
     options: SearchOptions
   ) => Effect.Effect<SearchResult, HulyClientError>
+
+  readonly toMarkup: (markdown: string) => string
+  readonly toMarkdown: (markup: string) => string
+
+  readonly getMarkupUrls: () => { readonly refUrl: string; readonly imageUrl: string }
 }
 
 export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
@@ -192,11 +197,13 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
     Effect.gen(function*() {
       const config = yield* HulyConfigService
 
-      const { accountUuid, client, markupOps } = yield* connectRestWithRetry({
+      const { accountUuid, client, imageUrl, markupOps, refUrl } = yield* connectRestWithRetry({
         url: config.url,
         auth: config.auth,
         workspace: config.workspace
       })
+
+      const urlConfig = { refUrl, imageUrl }
 
       const withClient = <A>(
         op: (client: TxOperations) => Promise<A>,
@@ -336,7 +343,11 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
           withClient(
             (client) => client.searchFulltext(query, options),
             "searchFulltext failed"
-          )
+          ),
+
+        toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, urlConfig)),
+        toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), urlConfig),
+        getMarkupUrls: () => urlConfig
       }
 
       return operations
@@ -375,7 +386,10 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       fetchMarkup: noopFetchMarkup,
       updateMixin: notImplemented("updateMixin"),
       updateMarkup: notImplemented("updateMarkup"),
-      searchFulltext: notImplemented("searchFulltext")
+      searchFulltext: notImplemented("searchFulltext"),
+      toMarkup: (md: string) => jsonToMarkup(markdownToMarkup(md, { refUrl: "", imageUrl: "" })),
+      toMarkdown: (markup: string) => markupToMarkdown(markupToJSON(markup), { refUrl: "", imageUrl: "" }),
+      getMarkupUrls: () => ({ refUrl: "", imageUrl: "" })
     }
 
     return Layer.succeed(HulyClient, { ...defaultOps, ...mockOperations })
@@ -410,6 +424,8 @@ interface RestConnection {
   client: TxOperations
   accountUuid: AccountUuid
   markupOps: MarkupOperations
+  refUrl: string
+  imageUrl: string
 }
 
 function createMarkupOps(
@@ -417,12 +433,12 @@ function createMarkupOps(
   workspace: WorkspaceUuid,
   token: string,
   collaboratorUrl: string
-): MarkupOperations {
+): { ops: MarkupOperations; refUrl: string; imageUrl: string } {
   const refUrl = concatLink(url, `/browse?workspace=${workspace}`)
   const imageUrl = concatLink(url, `/files?workspace=${workspace}&file=`)
   const collaborator = getCollaboratorClient(workspace, token, collaboratorUrl)
 
-  return {
+  return { refUrl, imageUrl, ops: {
     async fetchMarkup(objectClass, objectId, objectAttr, doc, format) {
       const collabId = makeCollabId(objectClass, objectId, objectAttr)
       const markup = await collaborator.getMarkup(collabId, doc)
@@ -438,7 +454,7 @@ function createMarkupOps(
       const collabId = makeCollabId(objectClass, objectId, objectAttr)
       return await collaborator.updateMarkup(collabId, toInternalMarkup(value, format, { refUrl, imageUrl }))
     }
-  }
+  } }
 }
 
 const connectRest = async (
@@ -460,14 +476,14 @@ const connectRest = async (
   const account = await restClient.getAccount()
 
   const client = await createRestTxOperations(endpoint, workspaceId, token)
-  const markupOps = createMarkupOps(
+  const { imageUrl, ops: markupOps, refUrl } = createMarkupOps(
     config.url,
     workspaceId,
     token,
     serverConfig.COLLABORATOR_URL
   )
 
-  return { client, accountUuid: account.uuid, markupOps }
+  return { client, accountUuid: account.uuid, markupOps, refUrl, imageUrl }
 }
 
 const connectRestWithRetry = (

--- a/src/huly/operations/channels.ts
+++ b/src/huly/operations/channels.ts
@@ -39,6 +39,7 @@ import type {
 import { AccountUuid, ChannelId, ChannelName, MessageId, PersonName } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import { ChannelNotFoundError } from "../errors.js"
+import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { escapeLikeWildcards } from "./query-helpers.js"
 import { clampLimit, findByNameOrId, toRef } from "./shared.js"
 
@@ -368,6 +369,7 @@ export const listChannelMessages = (
 ): Effect.Effect<ListChannelMessagesResult, ListChannelMessagesError, HulyClient> =>
   Effect.gen(function*() {
     const { channel, client } = yield* findChannel(params.channel)
+    const markupUrlConfig = client.markupUrlConfig
 
     const limit = clampLimit(params.limit)
 
@@ -399,7 +401,7 @@ export const listChannelMessages = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: MessageId.make(msg._id),
-        body: client.toMarkdown(msg.message),
+        body: markupToMarkdownString(msg.message, markupUrlConfig),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -422,9 +424,10 @@ export const sendChannelMessage = (
 ): Effect.Effect<SendChannelMessageResult, SendChannelMessageError, HulyClient> =>
   Effect.gen(function*() {
     const { channel, client } = yield* findChannel(params.channel)
+    const markupUrlConfig = client.markupUrlConfig
 
     const messageId: Ref<ChatMessage> = generateId()
-    const markup = client.toMarkup(params.body)
+    const markup = markdownToMarkupString(params.body, markupUrlConfig)
 
     const messageData: AttachedData<ChatMessage> = {
       message: markup,

--- a/src/huly/operations/channels.ts
+++ b/src/huly/operations/channels.ts
@@ -13,7 +13,6 @@ import {
   type Space
 } from "@hcengineering/core"
 import { Effect } from "effect"
-import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 
 import type {
   Channel,
@@ -400,7 +399,7 @@ export const listChannelMessages = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: MessageId.make(msg._id),
-        body: markupToMarkdownString(msg.message),
+        body: client.toMarkdown(msg.message),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -425,7 +424,7 @@ export const sendChannelMessage = (
     const { channel, client } = yield* findChannel(params.channel)
 
     const messageId: Ref<ChatMessage> = generateId()
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const messageData: AttachedData<ChatMessage> = {
       message: markup,

--- a/src/huly/operations/comments.ts
+++ b/src/huly/operations/comments.ts
@@ -18,7 +18,7 @@ import { CommentNotFoundError, HulyConnectionError } from "../errors.js"
 import { clampLimit, findProjectAndIssue as findProjectAndIssueShared, toRef } from "./shared.js"
 
 import { chunter, tracker } from "../huly-plugins.js"
-import { optionalMarkupToMarkdown } from "./markup.js"
+import { markdownToMarkupString, optionalMarkupToMarkdown } from "./markup.js"
 
 type ListCommentsError =
   | HulyClientError
@@ -89,6 +89,7 @@ export const listComments = (
       project: params.project,
       issueIdentifier: params.issueIdentifier
     })
+    const markupUrlConfig = client.markupUrlConfig
 
     const limit = clampLimit(params.limit)
 
@@ -110,7 +111,7 @@ export const listComments = (
     const validated = yield* Schema.decodeUnknown(Schema.Array(CommentSchema))(
       messages.map((msg) => ({
         id: msg._id,
-        body: optionalMarkupToMarkdown(msg.message, "", client.getMarkupUrls()),
+        body: optionalMarkupToMarkdown(msg.message, markupUrlConfig, ""),
         authorId: msg.modifiedBy,
         createdOn: msg.createdOn,
         modifiedOn: msg.modifiedOn,
@@ -139,11 +140,12 @@ export const addComment = (
       project: params.project,
       issueIdentifier: params.issueIdentifier
     })
+    const markupUrlConfig = client.markupUrlConfig
 
     const commentId: Ref<ChatMessage> = generateId()
 
     const commentData: AttachedData<ChatMessage> = {
-      message: client.toMarkup(params.body)
+      message: markdownToMarkupString(params.body, markupUrlConfig)
     }
 
     yield* client.addCollection(
@@ -170,8 +172,9 @@ export const updateComment = (
 ): Effect.Effect<UpdateCommentResult, UpdateCommentError, HulyClient> =>
   Effect.gen(function*() {
     const { client, comment, issue, project } = yield* findComment(params)
+    const markupUrlConfig = client.markupUrlConfig
 
-    const newMarkup = client.toMarkup(params.body)
+    const newMarkup = markdownToMarkupString(params.body, markupUrlConfig)
 
     if (newMarkup === comment.message) {
       return {

--- a/src/huly/operations/comments.ts
+++ b/src/huly/operations/comments.ts
@@ -18,7 +18,7 @@ import { CommentNotFoundError, HulyConnectionError } from "../errors.js"
 import { clampLimit, findProjectAndIssue as findProjectAndIssueShared, toRef } from "./shared.js"
 
 import { chunter, tracker } from "../huly-plugins.js"
-import { markdownToMarkupString, optionalMarkupToMarkdown } from "./markup.js"
+import { optionalMarkupToMarkdown } from "./markup.js"
 
 type ListCommentsError =
   | HulyClientError
@@ -110,7 +110,7 @@ export const listComments = (
     const validated = yield* Schema.decodeUnknown(Schema.Array(CommentSchema))(
       messages.map((msg) => ({
         id: msg._id,
-        body: optionalMarkupToMarkdown(msg.message),
+        body: optionalMarkupToMarkdown(msg.message, "", client.getMarkupUrls()),
         authorId: msg.modifiedBy,
         createdOn: msg.createdOn,
         modifiedOn: msg.modifiedOn,
@@ -143,7 +143,7 @@ export const addComment = (
     const commentId: Ref<ChatMessage> = generateId()
 
     const commentData: AttachedData<ChatMessage> = {
-      message: markdownToMarkupString(params.body)
+      message: client.toMarkup(params.body)
     }
 
     yield* client.addCollection(
@@ -171,7 +171,7 @@ export const updateComment = (
   Effect.gen(function*() {
     const { client, comment, issue, project } = yield* findComment(params)
 
-    const newMarkup = markdownToMarkupString(params.body)
+    const newMarkup = client.toMarkup(params.body)
 
     if (newMarkup === comment.message) {
       return {

--- a/src/huly/operations/components.ts
+++ b/src/huly/operations/components.ts
@@ -164,6 +164,7 @@ export const getComponent = (
 ): Effect.Effect<Component, GetComponentError, HulyClient> =>
   Effect.gen(function*() {
     const { client, component } = yield* findProjectAndComponent(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const leadName = component.lead !== null
       ? (yield* client.findOne<Person>(contact.class.Person, { _id: component.lead }))?.name
@@ -172,7 +173,7 @@ export const getComponent = (
     const result: Component = {
       id: ComponentId.make(component._id),
       label: ComponentLabel.make(component.label),
-      description: optionalMarkupToMarkdown(component.description, undefined, client.getMarkupUrls()),
+      description: optionalMarkupToMarkdown(component.description, markupUrlConfig, undefined),
       lead: leadName !== undefined ? PersonName.make(leadName) : undefined,
       project: params.project,
       modifiedOn: component.modifiedOn,
@@ -187,6 +188,7 @@ export const createComponent = (
 ): Effect.Effect<CreateComponentResult, CreateComponentError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project } = yield* findProject(params.project)
+    const markupUrlConfig = client.markupUrlConfig
 
     const componentId: Ref<HulyComponent> = generateId()
 
@@ -205,7 +207,7 @@ export const createComponent = (
 
     const componentData: Data<HulyComponent> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
+      description: optionalMarkdownToMarkup(params.description, markupUrlConfig, ""),
       lead: leadRef,
       comments: 0
     }
@@ -225,6 +227,7 @@ export const updateComponent = (
 ): Effect.Effect<UpdateComponentResult, UpdateComponentError, HulyClient> =>
   Effect.gen(function*() {
     const { client, component, project } = yield* findProjectAndComponent(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const updateOps: DocumentUpdate<HulyComponent> = {}
 
@@ -233,7 +236,7 @@ export const updateComponent = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
+      updateOps.description = optionalMarkdownToMarkup(params.description, markupUrlConfig, "")
     }
 
     if (params.lead !== undefined) {

--- a/src/huly/operations/components.ts
+++ b/src/huly/operations/components.ts
@@ -172,7 +172,7 @@ export const getComponent = (
     const result: Component = {
       id: ComponentId.make(component._id),
       label: ComponentLabel.make(component.label),
-      description: optionalMarkupToMarkdown(component.description, undefined),
+      description: optionalMarkupToMarkdown(component.description, undefined, client.getMarkupUrls()),
       lead: leadName !== undefined ? PersonName.make(leadName) : undefined,
       project: params.project,
       modifiedOn: component.modifiedOn,
@@ -205,7 +205,7 @@ export const createComponent = (
 
     const componentData: Data<HulyComponent> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       lead: leadRef,
       comments: 0
     }
@@ -233,7 +233,7 @@ export const updateComponent = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.lead !== undefined) {

--- a/src/huly/operations/documents-inline-comments.ts
+++ b/src/huly/operations/documents-inline-comments.ts
@@ -134,7 +134,7 @@ export const listInlineComments = (
         const threadReplies = threadRepliesMap.get(comment.threadId) ?? []
         const replies: Array<InlineCommentReply> = threadReplies.map(r => ({
           id: r._id,
-          body: optionalMarkupToMarkdown(r.message),
+          body: optionalMarkupToMarkdown(r.message, "", client.getMarkupUrls()),
           sender: r.createdBy !== undefined ? nameMap.get(r.createdBy) : undefined,
           createdOn: r.createdOn
         }))

--- a/src/huly/operations/documents-inline-comments.ts
+++ b/src/huly/operations/documents-inline-comments.ts
@@ -74,6 +74,7 @@ export const listInlineComments = (
       teamspace: params.teamspace,
       document: params.document
     })
+    const markupUrlConfig = client.markupUrlConfig
 
     if (!doc.content) {
       return { comments: [], total: 0 }
@@ -134,7 +135,7 @@ export const listInlineComments = (
         const threadReplies = threadRepliesMap.get(comment.threadId) ?? []
         const replies: Array<InlineCommentReply> = threadReplies.map(r => ({
           id: r._id,
-          body: optionalMarkupToMarkdown(r.message, "", client.getMarkupUrls()),
+          body: optionalMarkupToMarkdown(r.message, markupUrlConfig, ""),
           sender: r.createdBy !== undefined ? nameMap.get(r.createdBy) : undefined,
           createdOn: r.createdOn
         }))

--- a/src/huly/operations/issue-templates.ts
+++ b/src/huly/operations/issue-templates.ts
@@ -193,7 +193,7 @@ const resolveChild = (
 
     // exactOptionalPropertyTypes: can't assign undefined to optional fields
     const withDescription = child.description
-      ? { ...base, description: optionalMarkupToMarkdown(child.description) }
+      ? { ...base, description: optionalMarkupToMarkdown(child.description, "", client.getMarkupUrls()) }
       : base
     const withAssignee = assigneeName !== undefined
       ? { ...withDescription, assignee: PersonName.make(assigneeName) }
@@ -247,7 +247,7 @@ const buildTemplateChild = (
     return {
       id: generateId<HulyIssue>(),
       title: input.title,
-      description: optionalMarkdownToMarkup(input.description),
+      description: optionalMarkdownToMarkup(input.description, "", client.getMarkupUrls()),
       priority: stringToPriority(input.priority || "no-priority"),
       assignee: assigneeRef,
       component: componentRef,
@@ -313,7 +313,7 @@ export const getIssueTemplate = (
     const result: IssueTemplate = {
       id: IssueTemplateId.make(template._id),
       title: template.title,
-      description: optionalMarkupToMarkdown(template.description),
+      description: optionalMarkupToMarkdown(template.description, "", client.getMarkupUrls()),
       priority: priorityToString(template.priority),
       assignee: assigneeName !== undefined ? PersonName.make(assigneeName) : undefined,
       component: componentLabel !== undefined ? ComponentLabel.make(componentLabel) : undefined,
@@ -375,7 +375,7 @@ export const createIssueTemplate = (
 
     const templateData: Data<HulyIssueTemplate> = {
       title: params.title,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       priority,
       assignee: assigneeRef,
       component: componentRef,
@@ -413,7 +413,7 @@ export const createIssueFromTemplate = (
 
     const title = params.title ?? template.title
     const description = params.description
-      ?? optionalMarkupToMarkdown(template.description, undefined)
+      ?? optionalMarkupToMarkdown(template.description, undefined, client.getMarkupUrls())
     const priority = params.priority ?? priorityToString(template.priority)
 
     const templateAssigneeRef = template.assignee
@@ -466,7 +466,7 @@ export const createIssueFromTemplate = (
         // Create child as top-level issue via createIssue (no parentIssue).
         // We can't pass parentIssue because createIssue uses findIssueInProject
         // which does findOne on the just-created parent — that hangs.
-        const childDescription = optionalMarkupToMarkdown(child.description, undefined)
+        const childDescription = optionalMarkupToMarkdown(child.description, undefined, client.getMarkupUrls())
         const childResult = yield* createIssue({
           project: params.project,
           title: child.title,
@@ -524,7 +524,7 @@ export const updateIssueTemplate = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.priority !== undefined) {

--- a/src/huly/operations/issue-templates.ts
+++ b/src/huly/operations/issue-templates.ts
@@ -71,7 +71,7 @@ import {
 } from "./shared.js"
 
 import { contact, tracker } from "../huly-plugins.js"
-import { optionalMarkdownToMarkup, optionalMarkupToMarkdown } from "./markup.js"
+import { type MarkupUrlConfig, optionalMarkdownToMarkup, optionalMarkupToMarkdown } from "./markup.js"
 
 type ListIssueTemplatesError =
   | HulyClientError
@@ -174,6 +174,7 @@ const findProjectAndTemplate = (
  */
 const resolveChild = (
   client: HulyClient["Type"],
+  markupUrlConfig: MarkupUrlConfig,
   child: HulyIssueTemplateChild
 ): Effect.Effect<IssueTemplateChild, HulyClientError> =>
   Effect.gen(function*() {
@@ -193,7 +194,7 @@ const resolveChild = (
 
     // exactOptionalPropertyTypes: can't assign undefined to optional fields
     const withDescription = child.description
-      ? { ...base, description: optionalMarkupToMarkdown(child.description, "", client.getMarkupUrls()) }
+      ? { ...base, description: optionalMarkupToMarkdown(child.description, markupUrlConfig, "") }
       : base
     const withAssignee = assigneeName !== undefined
       ? { ...withDescription, assignee: PersonName.make(assigneeName) }
@@ -214,6 +215,7 @@ const resolveChild = (
  */
 const buildTemplateChild = (
   client: HulyClient["Type"],
+  markupUrlConfig: MarkupUrlConfig,
   projectId: Ref<HulyProject>,
   projectIdentifier: string,
   input: ChildTemplateInput
@@ -247,7 +249,7 @@ const buildTemplateChild = (
     return {
       id: generateId<HulyIssue>(),
       title: input.title,
-      description: optionalMarkdownToMarkup(input.description, "", client.getMarkupUrls()),
+      description: optionalMarkdownToMarkup(input.description, markupUrlConfig, ""),
       priority: stringToPriority(input.priority || "no-priority"),
       assignee: assigneeRef,
       component: componentRef,
@@ -296,6 +298,7 @@ export const getIssueTemplate = (
 ): Effect.Effect<IssueTemplate, GetIssueTemplateError, HulyClient> =>
   Effect.gen(function*() {
     const { client, template } = yield* findProjectAndTemplate(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const assigneeName = template.assignee !== null
       ? (yield* client.findOne<Person>(contact.class.Person, { _id: template.assignee }))?.name
@@ -307,13 +310,13 @@ export const getIssueTemplate = (
 
     const resolvedChildren: Array<IssueTemplateChild> = []
     for (const child of template.children) {
-      resolvedChildren.push(yield* resolveChild(client, child))
+      resolvedChildren.push(yield* resolveChild(client, markupUrlConfig, child))
     }
 
     const result: IssueTemplate = {
       id: IssueTemplateId.make(template._id),
       title: template.title,
-      description: optionalMarkupToMarkdown(template.description, "", client.getMarkupUrls()),
+      description: optionalMarkupToMarkdown(template.description, markupUrlConfig, ""),
       priority: priorityToString(template.priority),
       assignee: assigneeName !== undefined ? PersonName.make(assigneeName) : undefined,
       component: componentLabel !== undefined ? ComponentLabel.make(componentLabel) : undefined,
@@ -335,6 +338,7 @@ export const createIssueTemplate = (
 ): Effect.Effect<CreateIssueTemplateResult, CreateIssueTemplateError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project } = yield* findProject(params.project)
+    const markupUrlConfig = client.markupUrlConfig
 
     const templateId: Ref<HulyIssueTemplate> = generateId()
 
@@ -369,13 +373,13 @@ export const createIssueTemplate = (
     const children: Array<HulyIssueTemplateChild> = []
     if (params.children !== undefined) {
       for (const childInput of params.children) {
-        children.push(yield* buildTemplateChild(client, project._id, params.project, childInput))
+        children.push(yield* buildTemplateChild(client, markupUrlConfig, project._id, params.project, childInput))
       }
     }
 
     const templateData: Data<HulyIssueTemplate> = {
       title: params.title,
-      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
+      description: optionalMarkdownToMarkup(params.description, markupUrlConfig, ""),
       priority,
       assignee: assigneeRef,
       component: componentRef,
@@ -410,10 +414,11 @@ export const createIssueFromTemplate = (
 ): Effect.Effect<CreateIssueFromTemplateResult, CreateIssueFromTemplateError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project, template } = yield* findProjectAndTemplate(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const title = params.title ?? template.title
     const description = params.description
-      ?? optionalMarkupToMarkdown(template.description, undefined, client.getMarkupUrls())
+      ?? optionalMarkupToMarkdown(template.description, markupUrlConfig, undefined)
     const priority = params.priority ?? priorityToString(template.priority)
 
     const templateAssigneeRef = template.assignee
@@ -466,7 +471,7 @@ export const createIssueFromTemplate = (
         // Create child as top-level issue via createIssue (no parentIssue).
         // We can't pass parentIssue because createIssue uses findIssueInProject
         // which does findOne on the just-created parent — that hangs.
-        const childDescription = optionalMarkupToMarkdown(child.description, undefined, client.getMarkupUrls())
+        const childDescription = optionalMarkupToMarkdown(child.description, markupUrlConfig, undefined)
         const childResult = yield* createIssue({
           project: params.project,
           title: child.title,
@@ -516,6 +521,7 @@ export const updateIssueTemplate = (
 ): Effect.Effect<UpdateIssueTemplateResult, UpdateIssueTemplateError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project, template } = yield* findProjectAndTemplate(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const updateOps: DocumentUpdate<HulyIssueTemplate> = {}
 
@@ -524,7 +530,7 @@ export const updateIssueTemplate = (
     }
 
     if (params.description !== undefined) {
-      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
+      updateOps.description = optionalMarkdownToMarkup(params.description, markupUrlConfig, "")
     }
 
     if (params.priority !== undefined) {
@@ -596,8 +602,9 @@ export const addTemplateChild = (
 ): Effect.Effect<AddTemplateChildResult, AddTemplateChildError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project, template } = yield* findProjectAndTemplate(params)
+    const markupUrlConfig = client.markupUrlConfig
 
-    const child = yield* buildTemplateChild(client, project._id, params.project, {
+    const child = yield* buildTemplateChild(client, markupUrlConfig, project._id, params.project, {
       title: params.title,
       description: params.description,
       priority: params.priority,

--- a/src/huly/operations/markup.ts
+++ b/src/huly/operations/markup.ts
@@ -10,48 +10,52 @@ import type { Markup } from "@hcengineering/core"
 import { jsonToMarkup, markupToJSON } from "@hcengineering/text"
 import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown"
 
+import { type UrlString, UrlString as UrlStringSchema } from "../../domain/schemas/shared.js"
+
 // SDK: jsonToMarkup return type doesn't match Markup; cast contained here.
 const jsonAsMarkup: (json: ReturnType<typeof markdownToMarkup>) => Markup = jsonToMarkup
 
-interface MarkupUrlConfig {
-  readonly refUrl: string
-  readonly imageUrl: string
+export interface MarkupUrlConfig {
+  readonly refUrl: UrlString
+  readonly imageUrl: UrlString
 }
 
-const emptyUrlConfig: MarkupUrlConfig = { refUrl: "", imageUrl: "" }
+// Test-only fixture for callers that need deterministic conversion without a real Huly workspace.
+export const testMarkupUrlConfig: MarkupUrlConfig = {
+  refUrl: UrlStringSchema.make("https://test.invalid/browse?workspace=test"),
+  imageUrl: UrlStringSchema.make("https://test.invalid/files?workspace=test&file=")
+}
 
-// Exported for test assertions; production code should prefer client.toMarkdown/toMarkup.
-// eslint-disable-next-line import-x/no-unused-modules
-export const markupToMarkdownString = (markup: Markup, urls?: MarkupUrlConfig): string => {
+export const markupToMarkdownString = (markup: Markup, urls: MarkupUrlConfig): string => {
   const json = markupToJSON(markup)
-  return markupToMarkdown(json, urls ?? emptyUrlConfig)
+  return markupToMarkdown(json, urls)
 }
 
-export const markdownToMarkupString = (markdown: string, urls?: MarkupUrlConfig): Markup => {
-  const json = markdownToMarkup(markdown, urls ?? emptyUrlConfig)
+export const markdownToMarkupString = (markdown: string, urls: MarkupUrlConfig): Markup => {
+  const json = markdownToMarkup(markdown, urls)
   return jsonAsMarkup(json)
 }
 
 export const optionalMarkdownToMarkup = (
   md: string | undefined | null,
-  fallback: Markup | "" = "",
-  urls?: MarkupUrlConfig
+  urls: MarkupUrlConfig,
+  fallback: Markup | "" = ""
 ): Markup | "" => md && md.trim() !== "" ? markdownToMarkupString(md, urls) : fallback
 
 export function optionalMarkupToMarkdown(
   markup: Markup | undefined | null,
-  fallback: undefined,
-  urls?: MarkupUrlConfig
+  urls: MarkupUrlConfig,
+  fallback: undefined
 ): string | undefined
 export function optionalMarkupToMarkdown(
   markup: Markup | undefined | null,
-  fallback?: string,
-  urls?: MarkupUrlConfig
+  urls: MarkupUrlConfig,
+  fallback?: string
 ): string
 export function optionalMarkupToMarkdown(
   markup: Markup | undefined | null,
-  fallback: string | undefined = "",
-  urls?: MarkupUrlConfig
+  urls: MarkupUrlConfig,
+  fallback: string | undefined = ""
 ): string | undefined {
-  return markup ? markupToMarkdownString(markup, urls) : fallback
+  return markup === null || markup === undefined ? fallback : markupToMarkdownString(markup, urls)
 }

--- a/src/huly/operations/markup.ts
+++ b/src/huly/operations/markup.ts
@@ -13,24 +13,45 @@ import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown
 // SDK: jsonToMarkup return type doesn't match Markup; cast contained here.
 const jsonAsMarkup: (json: ReturnType<typeof markdownToMarkup>) => Markup = jsonToMarkup
 
-export const markupToMarkdownString = (markup: Markup): string => {
-  const json = markupToJSON(markup)
-  return markupToMarkdown(json, { refUrl: "", imageUrl: "" })
+interface MarkupUrlConfig {
+  readonly refUrl: string
+  readonly imageUrl: string
 }
 
-export const markdownToMarkupString = (markdown: string): Markup => {
-  const json = markdownToMarkup(markdown, { refUrl: "", imageUrl: "" })
+const emptyUrlConfig: MarkupUrlConfig = { refUrl: "", imageUrl: "" }
+
+// Exported for test assertions; production code should prefer client.toMarkdown/toMarkup.
+// eslint-disable-next-line import-x/no-unused-modules
+export const markupToMarkdownString = (markup: Markup, urls?: MarkupUrlConfig): string => {
+  const json = markupToJSON(markup)
+  return markupToMarkdown(json, urls ?? emptyUrlConfig)
+}
+
+export const markdownToMarkupString = (markdown: string, urls?: MarkupUrlConfig): Markup => {
+  const json = markdownToMarkup(markdown, urls ?? emptyUrlConfig)
   return jsonAsMarkup(json)
 }
 
-export const optionalMarkdownToMarkup = (md: string | undefined | null, fallback: Markup | "" = ""): Markup | "" =>
-  md && md.trim() !== "" ? markdownToMarkupString(md) : fallback
+export const optionalMarkdownToMarkup = (
+  md: string | undefined | null,
+  fallback: Markup | "" = "",
+  urls?: MarkupUrlConfig
+): Markup | "" => md && md.trim() !== "" ? markdownToMarkupString(md, urls) : fallback
 
-export function optionalMarkupToMarkdown(markup: Markup | undefined | null, fallback: undefined): string | undefined
-export function optionalMarkupToMarkdown(markup: Markup | undefined | null, fallback?: string): string
 export function optionalMarkupToMarkdown(
   markup: Markup | undefined | null,
-  fallback: string | undefined = ""
+  fallback: undefined,
+  urls?: MarkupUrlConfig
+): string | undefined
+export function optionalMarkupToMarkdown(
+  markup: Markup | undefined | null,
+  fallback?: string,
+  urls?: MarkupUrlConfig
+): string
+export function optionalMarkupToMarkdown(
+  markup: Markup | undefined | null,
+  fallback: string | undefined = "",
+  urls?: MarkupUrlConfig
 ): string | undefined {
-  return markup ? markupToMarkdownString(markup) : fallback
+  return markup ? markupToMarkdownString(markup, urls) : fallback
 }

--- a/src/huly/operations/milestones.ts
+++ b/src/huly/operations/milestones.ts
@@ -144,12 +144,12 @@ export const getMilestone = (
   params: GetMilestoneParams
 ): Effect.Effect<Milestone, GetMilestoneError, HulyClient> =>
   Effect.gen(function*() {
-    const { milestone } = yield* findProjectAndMilestone(params)
+    const { client, milestone } = yield* findProjectAndMilestone(params)
 
     const result: Milestone = {
       id: MilestoneId.make(milestone._id),
       label: MilestoneLabel.make(milestone.label),
-      description: optionalMarkupToMarkdown(milestone.description),
+      description: optionalMarkupToMarkdown(milestone.description, "", client.getMarkupUrls()),
       status: milestoneStatusToString(milestone.status),
       targetDate: milestone.targetDate,
       project: params.project,
@@ -170,7 +170,7 @@ export const createMilestone = (
 
     const milestoneData: Data<HulyMilestone> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description),
+      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
       status: MilestoneStatus.Planned,
       targetDate: params.targetDate,
       comments: 0
@@ -222,7 +222,7 @@ export const updateMilestone = (
           "markdown"
         )
       }
-      updateOps.description = optionalMarkdownToMarkup(params.description)
+      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
     }
 
     if (params.targetDate !== undefined) {

--- a/src/huly/operations/milestones.ts
+++ b/src/huly/operations/milestones.ts
@@ -145,11 +145,12 @@ export const getMilestone = (
 ): Effect.Effect<Milestone, GetMilestoneError, HulyClient> =>
   Effect.gen(function*() {
     const { client, milestone } = yield* findProjectAndMilestone(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const result: Milestone = {
       id: MilestoneId.make(milestone._id),
       label: MilestoneLabel.make(milestone.label),
-      description: optionalMarkupToMarkdown(milestone.description, "", client.getMarkupUrls()),
+      description: optionalMarkupToMarkdown(milestone.description, markupUrlConfig, ""),
       status: milestoneStatusToString(milestone.status),
       targetDate: milestone.targetDate,
       project: params.project,
@@ -165,12 +166,13 @@ export const createMilestone = (
 ): Effect.Effect<CreateMilestoneResult, CreateMilestoneError, HulyClient> =>
   Effect.gen(function*() {
     const { client, project } = yield* findProject(params.project)
+    const markupUrlConfig = client.markupUrlConfig
 
     const milestoneId: Ref<HulyMilestone> = generateId()
 
     const milestoneData: Data<HulyMilestone> = {
       label: params.label,
-      description: optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls()),
+      description: optionalMarkdownToMarkup(params.description, markupUrlConfig, ""),
       status: MilestoneStatus.Planned,
       targetDate: params.targetDate,
       comments: 0
@@ -204,6 +206,7 @@ export const updateMilestone = (
 ): Effect.Effect<UpdateMilestoneResult, UpdateMilestoneError, HulyClient> =>
   Effect.gen(function*() {
     const { client, milestone, project } = yield* findProjectAndMilestone(params)
+    const markupUrlConfig = client.markupUrlConfig
 
     const updateOps: DocumentUpdate<HulyMilestone> = {}
 
@@ -222,7 +225,7 @@ export const updateMilestone = (
           "markdown"
         )
       }
-      updateOps.description = optionalMarkdownToMarkup(params.description, "", client.getMarkupUrls())
+      updateOps.description = optionalMarkdownToMarkup(params.description, markupUrlConfig, "")
     }
 
     if (params.targetDate !== undefined) {

--- a/src/huly/operations/threads.ts
+++ b/src/huly/operations/threads.ts
@@ -29,7 +29,6 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import type { ChannelNotFoundError } from "../errors.js"
 import { MessageNotFoundError, ThreadReplyNotFoundError } from "../errors.js"
 import { buildSocialIdToPersonNameMap, findChannel } from "./channels.js"
-import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { toRef } from "./shared.js"
 
 import { chunter } from "../huly-plugins.js"
@@ -151,7 +150,7 @@ export const listThreadReplies = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: ThreadReplyId.make(msg._id),
-        body: markupToMarkdownString(msg.message),
+        body: client.toMarkdown(msg.message),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -170,7 +169,7 @@ export const addThreadReply = (
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
 
     const replyId: Ref<HulyThreadMessage> = generateId()
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const replyData: AttachedData<HulyThreadMessage> = {
       message: markup,
@@ -203,7 +202,7 @@ export const updateThreadReply = (
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
     const reply = yield* findReply(client, channel, message, params.replyId)
 
-    const markup = markdownToMarkupString(params.body)
+    const markup = client.toMarkup(params.body)
 
     const now = yield* Clock.currentTimeMillis
     const updateOps: DocumentUpdate<HulyThreadMessage> = {

--- a/src/huly/operations/threads.ts
+++ b/src/huly/operations/threads.ts
@@ -29,6 +29,7 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import type { ChannelNotFoundError } from "../errors.js"
 import { MessageNotFoundError, ThreadReplyNotFoundError } from "../errors.js"
 import { buildSocialIdToPersonNameMap, findChannel } from "./channels.js"
+import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { toRef } from "./shared.js"
 
 import { chunter } from "../huly-plugins.js"
@@ -118,6 +119,7 @@ export const listThreadReplies = (
 ): Effect.Effect<ListThreadRepliesResult, ListThreadRepliesError, HulyClient> =>
   Effect.gen(function*() {
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const markupUrlConfig = client.markupUrlConfig
 
     const limit = Math.min(params.limit ?? 50, 200)
 
@@ -150,7 +152,7 @@ export const listThreadReplies = (
       const senderName = socialIdToName.get(msg.modifiedBy)
       return {
         id: ThreadReplyId.make(msg._id),
-        body: client.toMarkdown(msg.message),
+        body: markupToMarkdownString(msg.message, markupUrlConfig),
         sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
         senderId: msg.modifiedBy,
         createdOn: msg.createdOn,
@@ -167,9 +169,10 @@ export const addThreadReply = (
 ): Effect.Effect<AddThreadReplyResult, AddThreadReplyError, HulyClient> =>
   Effect.gen(function*() {
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const markupUrlConfig = client.markupUrlConfig
 
     const replyId: Ref<HulyThreadMessage> = generateId()
-    const markup = client.toMarkup(params.body)
+    const markup = markdownToMarkupString(params.body, markupUrlConfig)
 
     const replyData: AttachedData<HulyThreadMessage> = {
       message: markup,
@@ -201,8 +204,9 @@ export const updateThreadReply = (
   Effect.gen(function*() {
     const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
     const reply = yield* findReply(client, channel, message, params.replyId)
+    const markupUrlConfig = client.markupUrlConfig
 
-    const markup = client.toMarkup(params.body)
+    const markup = markdownToMarkupString(params.body, markupUrlConfig)
 
     const now = yield* Clock.currentTimeMillis
     const updateOps: DocumentUpdate<HulyThreadMessage> = {

--- a/test/huly/operations/comments.test.ts
+++ b/test/huly/operations/comments.test.ts
@@ -16,7 +16,7 @@ import { addComment, deleteComment, listComments, updateComment } from "../../..
 import { commentBrandId, issueIdentifier, projectIdentifier } from "../../helpers/brands.js"
 
 import { chunter, tracker } from "../../../src/huly/huly-plugins.js"
-import { markdownToMarkupString } from "../../../src/huly/operations/markup.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 
 // --- Mock Data Builders ---
 
@@ -204,7 +204,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
 
 describe("listComments", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("returns comments for an issue", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
@@ -246,7 +245,6 @@ describe("listComments", () => {
         expect(result[1].body).toBe("Second comment")
       }))
 
-    // test-revizorro: approved
     it.effect("returns empty array when issue has no comments", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -266,7 +264,6 @@ describe("listComments", () => {
         expect(result).toHaveLength(0)
       }))
 
-    // test-revizorro: approved
     it.effect("transforms message to comment format", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -304,7 +301,6 @@ describe("listComments", () => {
   })
 
   describe("identifier parsing", () => {
-    // test-revizorro: approved
     it.effect("finds issue by full identifier HULY-123", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-huly" as Ref<HulyProject>, identifier: "HULY" })
@@ -335,7 +331,6 @@ describe("listComments", () => {
         expect(result).toHaveLength(1)
       }))
 
-    // test-revizorro: approved
     it.effect("finds issue by numeric identifier 42", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-test" as Ref<HulyProject>, identifier: "TEST" })
@@ -369,7 +364,6 @@ describe("listComments", () => {
         expect(result[0].body).toBe("Found by number")
       }))
 
-    // test-revizorro: approved
     it.effect("handles lowercase identifier test-5", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-test" as Ref<HulyProject>, identifier: "TEST" })
@@ -402,7 +396,6 @@ describe("listComments", () => {
   })
 
   describe("limit handling", () => {
-    // test-revizorro: approved
     it.effect("uses default limit of 50", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -425,7 +418,6 @@ describe("listComments", () => {
         expect(captureQuery.options?.limit).toBe(50)
       }))
 
-    // test-revizorro: approved
     it.effect("enforces max limit of 200", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -449,7 +441,6 @@ describe("listComments", () => {
         expect(captureQuery.options?.limit).toBe(200)
       }))
 
-    // test-revizorro: approved
     it.effect("uses provided limit when under max", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -475,7 +466,6 @@ describe("listComments", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -495,7 +485,6 @@ describe("listComments", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -522,7 +511,6 @@ describe("listComments", () => {
 
 describe("addComment", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("adds a comment to an issue", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
@@ -549,10 +537,11 @@ describe("addComment", () => {
 
         expect(result.commentId).toBeDefined()
         expect(result.issueIdentifier).toBe("TEST-1")
-        expect(captureAddCollection.attributes?.message).toBe(markdownToMarkupString("This is my new comment"))
+        expect(captureAddCollection.attributes?.message).toBe(
+          markdownToMarkupString("This is my new comment", testMarkupUrlConfig)
+        )
       }))
 
-    // test-revizorro: approved
     it.effect("supports markdown in comment body", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -574,10 +563,9 @@ describe("addComment", () => {
 
         const markdownBody = "# Heading\n\n- Item 1\n- Item 2\n\n```js\nconsole.log('test');\n```"
         const stored = captureAddCollection.attributes?.message as string
-        expect(stored).toBe(markdownToMarkupString(markdownBody))
+        expect(stored).toBe(markdownToMarkupString(markdownBody, testMarkupUrlConfig))
       }))
 
-    // test-revizorro: approved
     it.effect("returns comment ID and issue identifier", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "HULY" })
@@ -605,7 +593,6 @@ describe("addComment", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -625,7 +612,6 @@ describe("addComment", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -652,7 +638,6 @@ describe("addComment", () => {
 
 describe("updateComment", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("updates an existing comment", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
@@ -693,13 +678,14 @@ describe("updateComment", () => {
         expect(result.commentId).toBe("comment-abc")
         expect(result.issueIdentifier).toBe("TEST-1")
         expect(result.updated).toBe(true)
-        expect(captureUpdateDoc.operations?.message).toBe(markdownToMarkupString("Updated comment body"))
+        expect(captureUpdateDoc.operations?.message).toBe(
+          markdownToMarkupString("Updated comment body", testMarkupUrlConfig)
+        )
         const editedOn = captureUpdateDoc.operations?.editedOn as number
         expect(editedOn).toBeGreaterThanOrEqual(before)
         expect(editedOn).toBeLessThanOrEqual(after)
       }))
 
-    // test-revizorro: approved
     it.effect("sets editedOn timestamp", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -737,7 +723,6 @@ describe("updateComment", () => {
         expect(editedOn).toBeLessThanOrEqual(after)
       }))
 
-    // test-revizorro: approved
     it.effect("supports markdown in updated body", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -766,10 +751,11 @@ describe("updateComment", () => {
           body: "**Bold** and *italic*"
         }).pipe(Effect.provide(testLayer))
 
-        expect(captureUpdateDoc.operations?.message).toBe(markdownToMarkupString("**Bold** and *italic*"))
+        expect(captureUpdateDoc.operations?.message).toBe(
+          markdownToMarkupString("**Bold** and *italic*", testMarkupUrlConfig)
+        )
       }))
 
-    // test-revizorro: approved
     it.effect("returns updated: false when body is unchanged", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
@@ -782,7 +768,7 @@ describe("updateComment", () => {
         const messages = [
           makeChatMessage({
             _id: "comment-abc" as Ref<ChatMessage>,
-            message: markdownToMarkupString("Same content"),
+            message: markdownToMarkupString("Same content", testMarkupUrlConfig),
             attachedTo: "issue-1" as Ref<Doc>
           })
         ]
@@ -811,7 +797,6 @@ describe("updateComment", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -833,7 +818,6 @@ describe("updateComment", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -857,7 +841,6 @@ describe("updateComment", () => {
         expect((error as IssueNotFoundError).identifier).toBe("TEST-999")
       }))
 
-    // test-revizorro: approved
     it.effect("returns CommentNotFoundError when comment doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -884,7 +867,6 @@ describe("updateComment", () => {
         expect((error as CommentNotFoundError).project).toBe("TEST")
       }))
 
-    // test-revizorro: approved
     it.effect("CommentNotFoundError has helpful message", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "HULY" })
@@ -914,7 +896,6 @@ describe("updateComment", () => {
 
 describe("deleteComment", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("deletes an existing comment", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
@@ -953,7 +934,6 @@ describe("deleteComment", () => {
         expect(captureRemoveDoc.id).toBe("comment-to-delete")
       }))
 
-    // test-revizorro: approved
     it.effect("finds issue by numeric identifier", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "HULY" })
@@ -992,7 +972,6 @@ describe("deleteComment", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -1013,7 +992,6 @@ describe("deleteComment", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -1036,7 +1014,6 @@ describe("deleteComment", () => {
         expect((error as IssueNotFoundError).identifier).toBe("TEST-999")
       }))
 
-    // test-revizorro: approved
     it.effect("returns CommentNotFoundError when comment doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -1060,7 +1037,6 @@ describe("deleteComment", () => {
         expect((error as CommentNotFoundError).commentId).toBe("nonexistent-comment")
       }))
 
-    // test-revizorro: approved
     it.effect("only deletes comment attached to correct issue", () =>
       Effect.gen(function*() {
         const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })

--- a/test/huly/operations/components.test.ts
+++ b/test/huly/operations/components.test.ts
@@ -28,7 +28,7 @@ import {
   setIssueComponent,
   updateComponent
 } from "../../../src/huly/operations/components.js"
-import { markdownToMarkupString } from "../../../src/huly/operations/markup.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import { componentIdentifier, email, issueIdentifier, projectIdentifier } from "../../helpers/brands.js"
 
 // --- Mock Data Builders ---
@@ -287,7 +287,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
 // --- Tests ---
 
 describe("findComponentByIdOrLabel", () => {
-  // test-revizorro: approved
   it.effect("finds component by ID", () =>
     Effect.gen(function*() {
       const client = yield* HulyClient
@@ -300,7 +299,6 @@ describe("findComponentByIdOrLabel", () => {
       components: [makeComponent({ _id: "comp-abc" as Ref<HulyComponent>, label: "Frontend" })]
     }))))
 
-  // test-revizorro: approved
   it.effect("finds component by label when ID lookup fails", () =>
     Effect.gen(function*() {
       const client = yield* HulyClient
@@ -313,7 +311,6 @@ describe("findComponentByIdOrLabel", () => {
       components: [makeComponent({ _id: "comp-xyz" as Ref<HulyComponent>, label: "Frontend" })]
     }))))
 
-  // test-revizorro: approved
   it.effect("returns undefined when component not found by ID or label", () =>
     Effect.gen(function*() {
       const client = yield* HulyClient
@@ -327,7 +324,6 @@ describe("findComponentByIdOrLabel", () => {
 })
 
 describe("listComponents", () => {
-  // test-revizorro: approved
   it.effect("returns components for a project", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -361,7 +357,6 @@ describe("listComponents", () => {
       expect(result[1].lead).toBe("Bob")
     }))
 
-  // test-revizorro: approved
   it.effect("returns components with no lead", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -381,7 +376,6 @@ describe("listComponents", () => {
       expect(result[0].lead).toBeUndefined()
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })
@@ -394,7 +388,6 @@ describe("listComponents", () => {
       expect((error as ProjectNotFoundError).identifier).toBe("NONEXIST")
     }))
 
-  // test-revizorro: approved
   it.effect("clamps limit to 200", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -409,7 +402,6 @@ describe("listComponents", () => {
       expect(captureComponentQuery.options?.limit).toBe(200)
     }))
 
-  // test-revizorro: approved
   it.effect("returns empty array when no components exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -423,7 +415,6 @@ describe("listComponents", () => {
 })
 
 describe("getComponent", () => {
-  // test-revizorro: approved
   it.effect("returns full component details", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -458,7 +449,6 @@ describe("getComponent", () => {
       expect(result.createdOn).toBe(500)
     }))
 
-  // test-revizorro: approved
   it.effect("returns component with no lead", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -483,7 +473,6 @@ describe("getComponent", () => {
       expect(result.lead).toBeUndefined()
     }))
 
-  // test-revizorro: approved
   it.effect("returns ComponentNotFoundError when component doesn't exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -501,7 +490,6 @@ describe("getComponent", () => {
       expect((error as ComponentNotFoundError).project).toBe("PROJ")
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })
@@ -517,7 +505,6 @@ describe("getComponent", () => {
 })
 
 describe("createComponent", () => {
-  // test-revizorro: approved
   it.effect("creates component with minimal params", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -541,7 +528,6 @@ describe("createComponent", () => {
       expect(captureCreateDoc.attributes?.comments).toBe(0)
     }))
 
-  // test-revizorro: approved
   it.effect("creates component with description and lead", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -567,11 +553,12 @@ describe("createComponent", () => {
       }).pipe(Effect.provide(testLayer))
 
       expect(result.label).toBe("Frontend")
-      expect(captureCreateDoc.attributes?.description).toBe(markdownToMarkupString("UI component"))
+      expect(captureCreateDoc.attributes?.description).toBe(
+        markdownToMarkupString("UI component", testMarkupUrlConfig)
+      )
       expect(captureCreateDoc.attributes?.lead).toBe("person-1")
     }))
 
-  // test-revizorro: approved
   it.effect("returns PersonNotFoundError when lead not found", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -590,7 +577,6 @@ describe("createComponent", () => {
       expect((error as PersonNotFoundError).identifier).toBe("nobody@example.com")
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })
@@ -607,7 +593,6 @@ describe("createComponent", () => {
 })
 
 describe("updateComponent", () => {
-  // test-revizorro: approved
   it.effect("updates component label", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -635,7 +620,6 @@ describe("updateComponent", () => {
       expect(captureUpdateDoc.operations?.label).toBe("Backend V2")
     }))
 
-  // test-revizorro: approved
   it.effect("updates component description", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -659,10 +643,11 @@ describe("updateComponent", () => {
       }).pipe(Effect.provide(testLayer))
 
       expect(result.updated).toBe(true)
-      expect(captureUpdateDoc.operations?.description).toBe(markdownToMarkupString("Updated description"))
+      expect(captureUpdateDoc.operations?.description).toBe(
+        markdownToMarkupString("Updated description", testMarkupUrlConfig)
+      )
     }))
 
-  // test-revizorro: approved
   it.effect("updates component lead", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -696,7 +681,6 @@ describe("updateComponent", () => {
       expect(captureUpdateDoc.operations?.lead).toBe("person-2")
     }))
 
-  // test-revizorro: approved
   it.effect("clears lead when set to null", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -724,7 +708,6 @@ describe("updateComponent", () => {
       expect(captureUpdateDoc.operations?.lead).toBeNull()
     }))
 
-  // test-revizorro: approved
   it.effect("returns updated=false when no changes provided", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -748,7 +731,6 @@ describe("updateComponent", () => {
       expect(result.updated).toBe(false)
     }))
 
-  // test-revizorro: approved
   it.effect("returns ComponentNotFoundError when component doesn't exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -767,7 +749,6 @@ describe("updateComponent", () => {
       expect((error as ComponentNotFoundError).identifier).toBe("Ghost")
     }))
 
-  // test-revizorro: approved
   it.effect("returns PersonNotFoundError when new lead not found", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -794,7 +775,6 @@ describe("updateComponent", () => {
       expect((error as PersonNotFoundError).identifier).toBe("nobody@example.com")
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })
@@ -812,7 +792,6 @@ describe("updateComponent", () => {
 })
 
 describe("setIssueComponent", () => {
-  // test-revizorro: approved
   it.effect("sets component on an issue", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -847,7 +826,6 @@ describe("setIssueComponent", () => {
       expect(captureUpdateDoc.operations?.component).toBe("comp-1")
     }))
 
-  // test-revizorro: approved
   it.effect("clears component when set to null", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -877,7 +855,6 @@ describe("setIssueComponent", () => {
       expect(captureUpdateDoc.operations?.component).toBeNull()
     }))
 
-  // test-revizorro: approved
   it.effect("returns ComponentNotFoundError when component doesn't exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -906,7 +883,6 @@ describe("setIssueComponent", () => {
       expect((error as ComponentNotFoundError).identifier).toBe("Ghost")
     }))
 
-  // test-revizorro: approved
   it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -928,7 +904,6 @@ describe("setIssueComponent", () => {
       expect((error as IssueNotFoundError).identifier).toBe("PROJ-999")
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })
@@ -946,7 +921,6 @@ describe("setIssueComponent", () => {
 })
 
 describe("deleteComponent", () => {
-  // test-revizorro: approved
   it.effect("deletes component", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -973,7 +947,6 @@ describe("deleteComponent", () => {
       expect(captureRemoveDoc.id).toBe("comp-1")
     }))
 
-  // test-revizorro: approved
   it.effect("finds component by ID for deletion", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -999,7 +972,6 @@ describe("deleteComponent", () => {
       expect(result.deleted).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("returns ComponentNotFoundError when component doesn't exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "PROJ" })
@@ -1018,7 +990,6 @@ describe("deleteComponent", () => {
       expect((error as ComponentNotFoundError).project).toBe("PROJ")
     }))
 
-  // test-revizorro: approved
   it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({ projects: [] })

--- a/test/huly/operations/issue-templates.test.ts
+++ b/test/huly/operations/issue-templates.test.ts
@@ -31,7 +31,7 @@ import {
   removeTemplateChild,
   updateIssueTemplate
 } from "../../../src/huly/operations/issue-templates.js"
-import { markdownToMarkupString } from "../../../src/huly/operations/markup.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import {
   componentIdentifier,
   email,
@@ -405,7 +405,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
 // --- Tests ---
 
 describe("listIssueTemplates", () => {
-  // test-revizorro: approved
   it.effect("returns templates for a project", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -423,7 +422,6 @@ describe("listIssueTemplates", () => {
       expect(result[1].title).toBe("Template B")
     }))
 
-  // test-revizorro: approved
   it.effect("returns empty array when no templates exist", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -434,7 +432,6 @@ describe("listIssueTemplates", () => {
       expect(result).toHaveLength(0)
     }))
 
-  // test-revizorro: approved
   it.effect("maps priority correctly", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -461,7 +458,6 @@ describe("listIssueTemplates", () => {
       expect(result[4].priority).toBe("no-priority")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -476,7 +472,6 @@ describe("listIssueTemplates", () => {
 })
 
 describe("getIssueTemplate", () => {
-  // test-revizorro: approved
   it.effect("returns full template details by title", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -507,7 +502,6 @@ describe("getIssueTemplate", () => {
       expect(result.createdOn).toBe(1000)
     }))
 
-  // test-revizorro: approved
   it.effect("returns template by ID", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -529,7 +523,6 @@ describe("getIssueTemplate", () => {
       expect(result.id).toBe("template-abc")
     }))
 
-  // test-revizorro: approved
   it.effect("resolves assignee name when present", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -554,7 +547,6 @@ describe("getIssueTemplate", () => {
       expect(result.assignee).toBe("Jane Doe")
     }))
 
-  // test-revizorro: approved
   it.effect("returns undefined assignee when template has no assignee", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -572,7 +564,6 @@ describe("getIssueTemplate", () => {
       expect(result.assignee).toBeUndefined()
     }))
 
-  // test-revizorro: approved
   it.effect("resolves component label when present", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -597,7 +588,6 @@ describe("getIssueTemplate", () => {
       expect(result.component).toBe("Backend")
     }))
 
-  // test-revizorro: approved
   it.effect("returns undefined component when template has no component", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -615,7 +605,6 @@ describe("getIssueTemplate", () => {
       expect(result.component).toBeUndefined()
     }))
 
-  // test-revizorro: approved
   it.effect("returns undefined estimation when zero", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -633,7 +622,6 @@ describe("getIssueTemplate", () => {
       expect(result.estimation).toBeUndefined()
     }))
 
-  // test-revizorro: approved
   it.effect("fails with IssueTemplateNotFoundError for unknown template", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -650,7 +638,6 @@ describe("getIssueTemplate", () => {
       expect((result as IssueTemplateNotFoundError)._tag).toBe("IssueTemplateNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -668,7 +655,6 @@ describe("getIssueTemplate", () => {
 })
 
 describe("createIssueTemplate", () => {
-  // test-revizorro: approved
   it.effect("creates template with minimal params", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -698,7 +684,6 @@ describe("createIssueTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("creates template with all optional fields", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -728,7 +713,7 @@ describe("createIssueTemplate", () => {
       expect(result.title).toBe("Full Template")
       expect(capture.attributes).toMatchObject({
         title: "Full Template",
-        description: markdownToMarkupString("Detailed description"),
+        description: markdownToMarkupString("Detailed description", testMarkupUrlConfig),
         priority: IssuePriority.High,
         assignee: "person-1",
         component: "component-1",
@@ -736,7 +721,6 @@ describe("createIssueTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("fails with PersonNotFoundError for unknown assignee", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -751,7 +735,6 @@ describe("createIssueTemplate", () => {
       expect((result as PersonNotFoundError)._tag).toBe("PersonNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ComponentNotFoundError for unknown component", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -766,7 +749,6 @@ describe("createIssueTemplate", () => {
       expect((result as ComponentNotFoundError)._tag).toBe("ComponentNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -800,7 +782,6 @@ describe("createIssueFromTemplate", () => {
     })
   }
 
-  // test-revizorro: approved
   it.effect("creates issue using template defaults", () =>
     Effect.gen(function*() {
       const capture: MockConfig["captureAddCollection"] = {}
@@ -818,7 +799,6 @@ describe("createIssueFromTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("overrides template values with provided params", () =>
     Effect.gen(function*() {
       const capture: MockConfig["captureAddCollection"] = {}
@@ -841,7 +821,6 @@ describe("createIssueFromTemplate", () => {
       expect(captureUploadMarkup.markup).toBe("Custom description")
     }))
 
-  // test-revizorro: approved
   it.effect("resolves template assignee from person email", () =>
     Effect.gen(function*() {
       const person = makePerson({ _id: "person-1" as Ref<Person>, name: "Jane Doe" })
@@ -875,7 +854,6 @@ describe("createIssueFromTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("falls back to person name as assignee lookup when no email channel", () =>
     Effect.gen(function*() {
       // When template has assignee but person has no email channel,
@@ -908,7 +886,6 @@ describe("createIssueFromTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("overrides template assignee when param provided", () =>
     Effect.gen(function*() {
       const person1 = makePerson({ _id: "person-1" as Ref<Person>, name: "Jane Doe" })
@@ -945,7 +922,6 @@ describe("createIssueFromTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("applies template component to created issue via updateDoc", () =>
     Effect.gen(function*() {
       const component = makeComponent({ _id: "comp-1" as Ref<HulyComponent>, label: "Backend" })
@@ -973,7 +949,6 @@ describe("createIssueFromTemplate", () => {
       })
     }))
 
-  // test-revizorro: approved
   it.effect("fails with IssueTemplateNotFoundError for unknown template", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({
@@ -989,7 +964,6 @@ describe("createIssueFromTemplate", () => {
       expect((result as IssueTemplateNotFoundError)._tag).toBe("IssueTemplateNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -1004,7 +978,6 @@ describe("createIssueFromTemplate", () => {
 })
 
 describe("updateIssueTemplate", () => {
-  // test-revizorro: approved
   it.effect("updates template title", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1027,7 +1000,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ title: "New Title" })
     }))
 
-  // test-revizorro: approved
   it.effect("updates template description", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1047,10 +1019,11 @@ describe("updateIssueTemplate", () => {
       }).pipe(Effect.provide(testLayer))
 
       expect(result.updated).toBe(true)
-      expect(captureUpdate.operations).toMatchObject({ description: markdownToMarkupString("Updated description") })
+      expect(captureUpdate.operations).toMatchObject({
+        description: markdownToMarkupString("Updated description", testMarkupUrlConfig)
+      })
     }))
 
-  // test-revizorro: approved
   it.effect("updates template priority", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1073,7 +1046,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ priority: IssuePriority.Urgent })
     }))
 
-  // test-revizorro: approved
   it.effect("updates template assignee", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1100,7 +1072,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ assignee: "person-1" })
     }))
 
-  // test-revizorro: approved
   it.effect("clears assignee when set to null", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1123,7 +1094,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ assignee: null })
     }))
 
-  // test-revizorro: approved
   it.effect("updates template component", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1148,7 +1118,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ component: "component-1" })
     }))
 
-  // test-revizorro: approved
   it.effect("clears component when set to null", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1171,7 +1140,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ component: null })
     }))
 
-  // test-revizorro: approved
   it.effect("updates template estimation", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1194,7 +1162,6 @@ describe("updateIssueTemplate", () => {
       expect(captureUpdate.operations).toMatchObject({ estimation: 90 })
     }))
 
-  // test-revizorro: approved
   it.effect("returns updated=false when no changes provided", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1214,7 +1181,6 @@ describe("updateIssueTemplate", () => {
       expect(result.id).toBe("template-1")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with PersonNotFoundError for unknown assignee", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1234,7 +1200,6 @@ describe("updateIssueTemplate", () => {
       expect((result as PersonNotFoundError)._tag).toBe("PersonNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ComponentNotFoundError for unknown component", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1254,7 +1219,6 @@ describe("updateIssueTemplate", () => {
       expect((result as ComponentNotFoundError)._tag).toBe("ComponentNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with IssueTemplateNotFoundError for unknown template", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1269,7 +1233,6 @@ describe("updateIssueTemplate", () => {
       expect((result as IssueTemplateNotFoundError)._tag).toBe("IssueTemplateNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -1285,7 +1248,6 @@ describe("updateIssueTemplate", () => {
 })
 
 describe("deleteIssueTemplate", () => {
-  // test-revizorro: approved
   it.effect("deletes template by title", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1308,7 +1270,6 @@ describe("deleteIssueTemplate", () => {
       expect(captureRemove.called).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("deletes template by ID", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1335,7 +1296,6 @@ describe("deleteIssueTemplate", () => {
       expect(captureRemove.id).toBe("template-xyz")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with IssueTemplateNotFoundError for unknown template", () =>
     Effect.gen(function*() {
       const project = makeProject({ identifier: "TEST" })
@@ -1349,7 +1309,6 @@ describe("deleteIssueTemplate", () => {
       expect((result as IssueTemplateNotFoundError)._tag).toBe("IssueTemplateNotFoundError")
     }))
 
-  // test-revizorro: approved
   it.effect("fails with ProjectNotFoundError for unknown project", () =>
     Effect.gen(function*() {
       const testLayer = createTestLayerWithMocks({})
@@ -1493,7 +1452,7 @@ describe("createIssueTemplate with children", () => {
       expect(children[0].title).toBe("Child A")
       expect(children[0].priority).toBe(IssuePriority.High)
       expect(children[1].title).toBe("Child B")
-      expect(children[1].description).toBe(markdownToMarkupString("desc B"))
+      expect(children[1].description).toBe(markdownToMarkupString("desc B", testMarkupUrlConfig))
     }))
 
   it.effect("creates template with empty children when none provided", () =>

--- a/test/huly/operations/milestones.test.ts
+++ b/test/huly/operations/milestones.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../src/huly/operations/milestones.js"
 
 import { tracker } from "../../../src/huly/huly-plugins.js"
-import { markdownToMarkupString } from "../../../src/huly/operations/markup.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import { issueIdentifier, milestoneIdentifier, projectIdentifier } from "../../helpers/brands.js"
 
 const makeProject = (overrides?: Partial<HulyProject>): HulyProject => {
@@ -217,7 +217,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
 
 describe("listMilestones", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("returns milestones for a project", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -238,7 +237,6 @@ describe("listMilestones", () => {
         expect(result[1].label).toBe("Sprint 2")
       }))
 
-    // test-revizorro: approved
     it.effect("transforms status correctly", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -262,7 +260,6 @@ describe("listMilestones", () => {
         expect(result[3].status).toBe("canceled")
       }))
 
-    // test-revizorro: approved
     it.effect("returns empty array when no milestones", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -279,7 +276,6 @@ describe("listMilestones", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -297,7 +293,6 @@ describe("listMilestones", () => {
   })
 
   describe("limit handling", () => {
-    // test-revizorro: approved
     it.effect("uses default limit of 50", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -314,7 +309,6 @@ describe("listMilestones", () => {
         expect(captureQuery.options?.limit).toBe(50)
       }))
 
-    // test-revizorro: approved
     it.effect("enforces max limit of 200", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -331,7 +325,6 @@ describe("listMilestones", () => {
         expect(captureQuery.options?.limit).toBe(200)
       }))
 
-    // test-revizorro: approved
     it.effect("uses provided limit when under max", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -350,7 +343,6 @@ describe("listMilestones", () => {
   })
 
   describe("sorting", () => {
-    // test-revizorro: approved
     it.effect("sorts by modifiedOn descending", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -371,13 +363,12 @@ describe("listMilestones", () => {
 
 describe("getMilestone", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("returns milestone by label", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
         const milestone = makeMilestone({
           label: "Sprint 1",
-          description: markdownToMarkupString("First sprint"),
+          description: markdownToMarkupString("First sprint", testMarkupUrlConfig),
           status: MilestoneStatus.InProgress,
           targetDate: 1706500000000,
           modifiedOn: 1706400000000,
@@ -401,7 +392,6 @@ describe("getMilestone", () => {
         expect(result.project).toBe("TEST")
       }))
 
-    // test-revizorro: approved
     it.effect("returns milestone by ID", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -429,7 +419,6 @@ describe("getMilestone", () => {
         expect(result.status).toBe("in-progress")
       }))
 
-    // test-revizorro: approved
     it.effect("returns empty description when not set", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -452,7 +441,6 @@ describe("getMilestone", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -470,7 +458,6 @@ describe("getMilestone", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns MilestoneNotFoundError when milestone doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -490,7 +477,6 @@ describe("getMilestone", () => {
         expect((error as MilestoneNotFoundError).project).toBe("TEST")
       }))
 
-    // test-revizorro: approved
     it.effect("MilestoneNotFoundError has helpful message", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -514,7 +500,6 @@ describe("getMilestone", () => {
 
 describe("createMilestone", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("creates milestone with required fields", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -538,7 +523,6 @@ describe("createMilestone", () => {
         expect(captureCreateDoc.attributes?.status).toBe(MilestoneStatus.Planned)
       }))
 
-    // test-revizorro: approved
     it.effect("creates milestone with description and uploads collab doc", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -559,13 +543,14 @@ describe("createMilestone", () => {
           targetDate: 1706500000000
         }).pipe(Effect.provide(testLayer))
 
-        expect(captureCreateDoc.attributes?.description).toBe(markdownToMarkupString("First sprint of Q1"))
+        expect(captureCreateDoc.attributes?.description).toBe(
+          markdownToMarkupString("First sprint of Q1", testMarkupUrlConfig)
+        )
         expect(captureUploadMarkup.objectAttr).toBe("description")
         expect(captureUploadMarkup.markup).toBe("First sprint of Q1")
         expect(captureUploadMarkup.format).toBe("markdown")
       }))
 
-    // test-revizorro: approved
     it.effect("sets initial status to Planned", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -586,7 +571,6 @@ describe("createMilestone", () => {
         expect(captureCreateDoc.attributes?.status).toBe(MilestoneStatus.Planned)
       }))
 
-    // test-revizorro: approved
     it.effect("initializes comments to 0", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -607,7 +591,6 @@ describe("createMilestone", () => {
         expect(captureCreateDoc.attributes?.comments).toBe(0)
       }))
 
-    // test-revizorro: approved
     it.effect("returns created milestone with id and label", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -631,7 +614,6 @@ describe("createMilestone", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -655,7 +637,6 @@ describe("createMilestone", () => {
 
 describe("updateMilestone", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("updates milestone label", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -678,7 +659,6 @@ describe("updateMilestone", () => {
         expect(captureUpdateDoc.operations?.label).toBe("Sprint 1 - Updated")
       }))
 
-    // test-revizorro: approved
     it.effect("updates milestone description via uploadMarkup and updateDoc", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -703,10 +683,11 @@ describe("updateMilestone", () => {
         expect(captureUploadMarkup.objectAttr).toBe("description")
         expect(captureUploadMarkup.markup).toBe("Updated description")
         expect(captureUploadMarkup.format).toBe("markdown")
-        expect(captureUpdateDoc.operations?.description).toBe(markdownToMarkupString("Updated description"))
+        expect(captureUpdateDoc.operations?.description).toBe(
+          markdownToMarkupString("Updated description", testMarkupUrlConfig)
+        )
       }))
 
-    // test-revizorro: approved
     it.effect("updates milestone targetDate", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -728,7 +709,6 @@ describe("updateMilestone", () => {
         expect(captureUpdateDoc.operations?.targetDate).toBe(1706600000000)
       }))
 
-    // test-revizorro: approved
     it.effect("updates milestone status", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -750,7 +730,6 @@ describe("updateMilestone", () => {
         expect(captureUpdateDoc.operations?.status).toBe(MilestoneStatus.Completed)
       }))
 
-    // test-revizorro: approved
     it.effect("updates multiple fields at once", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -775,14 +754,13 @@ describe("updateMilestone", () => {
         }).pipe(Effect.provide(testLayer))
 
         expect(captureUpdateDoc.operations?.label).toBe("Sprint 1 Final")
-        expect(captureUpdateDoc.operations?.description).toBe(markdownToMarkupString("Completed"))
+        expect(captureUpdateDoc.operations?.description).toBe(markdownToMarkupString("Completed", testMarkupUrlConfig))
         expect(captureUpdateDoc.operations?.status).toBe(MilestoneStatus.Completed)
         expect(captureUpdateDoc.operations?.targetDate).toBe(1706700000000)
         expect(captureUploadMarkup.objectAttr).toBe("description")
         expect(captureUploadMarkup.markup).toBe("Completed")
       }))
 
-    // test-revizorro: approved
     it.effect("returns updated=false when no fields provided", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -801,7 +779,6 @@ describe("updateMilestone", () => {
         expect(result.updated).toBe(false)
       }))
 
-    // test-revizorro: approved
     it.effect("status string to enum conversion works for all statuses", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -836,7 +813,6 @@ describe("updateMilestone", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -855,7 +831,6 @@ describe("updateMilestone", () => {
         expect(error._tag).toBe("ProjectNotFoundError")
       }))
 
-    // test-revizorro: approved
     it.effect("returns MilestoneNotFoundError when milestone doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -881,7 +856,6 @@ describe("updateMilestone", () => {
 
 describe("setIssueMilestone", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("sets milestone on issue by label", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -907,7 +881,6 @@ describe("setIssueMilestone", () => {
         expect(captureUpdateDoc.operations?.milestone).toBe("m-1")
       }))
 
-    // test-revizorro: approved
     it.effect("sets milestone on issue by milestone ID", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -932,7 +905,6 @@ describe("setIssueMilestone", () => {
         expect(captureUpdateDoc.operations?.milestone).toBe("milestone-abc")
       }))
 
-    // test-revizorro: approved
     it.effect("clears milestone when null", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -956,7 +928,6 @@ describe("setIssueMilestone", () => {
         expect(captureUpdateDoc.operations?.milestone).toBeNull()
       }))
 
-    // test-revizorro: approved
     it.effect("finds issue by number", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -984,7 +955,6 @@ describe("setIssueMilestone", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -1004,7 +974,6 @@ describe("setIssueMilestone", () => {
         expect(error._tag).toBe("ProjectNotFoundError")
       }))
 
-    // test-revizorro: approved
     it.effect("returns IssueNotFoundError when issue doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -1029,7 +998,6 @@ describe("setIssueMilestone", () => {
         expect((error as IssueNotFoundError).project).toBe("TEST")
       }))
 
-    // test-revizorro: approved
     it.effect("returns MilestoneNotFoundError when milestone doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject()
@@ -1057,7 +1025,6 @@ describe("setIssueMilestone", () => {
 
 describe("deleteMilestone", () => {
   describe("basic functionality", () => {
-    // test-revizorro: approved
     it.effect("deletes milestone by label", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -1080,7 +1047,6 @@ describe("deleteMilestone", () => {
         expect(captureRemoveDoc.called).toBe(true)
       }))
 
-    // test-revizorro: approved
     it.effect("deletes milestone by ID", () =>
       Effect.gen(function*() {
         const project = makeProject({ identifier: "TEST" })
@@ -1105,7 +1071,6 @@ describe("deleteMilestone", () => {
   })
 
   describe("error handling", () => {
-    // test-revizorro: approved
     it.effect("returns ProjectNotFoundError when project doesn't exist", () =>
       Effect.gen(function*() {
         const testLayer = createTestLayerWithMocks({
@@ -1124,7 +1089,6 @@ describe("deleteMilestone", () => {
         expect((error as ProjectNotFoundError).identifier).toBe("NONEXISTENT")
       }))
 
-    // test-revizorro: approved
     it.effect("returns MilestoneNotFoundError when milestone doesn't exist", () =>
       Effect.gen(function*() {
         const project = makeProject()

--- a/test/mcp/registry.test.ts
+++ b/test/mcp/registry.test.ts
@@ -8,6 +8,7 @@ import { IssueIdentifier } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { HulyClient } from "../../src/huly/client.js"
 import { HulyError } from "../../src/huly/errors.js"
+import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
 import type { WorkspaceClientOperations } from "../../src/huly/workspace-client.js"
@@ -29,6 +30,7 @@ const parse = (input: unknown) => Schema.decodeUnknown(Params)(input)
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
+  markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),
@@ -63,7 +65,6 @@ const noopWorkspaceClient: WorkspaceClientOperations = {
 }
 
 describe("createToolHandler", () => {
-  // test-revizorro: approved
   it.effect("returns success response on valid input", () =>
     Effect.gen(function*() {
       const handler = createToolHandler(
@@ -81,7 +82,6 @@ describe("createToolHandler", () => {
       expect(result.content[0].text).toContain("hello world")
     }))
 
-  // test-revizorro: approved
   it.effect("returns parse error on invalid input", () =>
     Effect.gen(function*() {
       const handler = createToolHandler(
@@ -100,7 +100,6 @@ describe("createToolHandler", () => {
       expect(result.content[0].text).toContain("Invalid parameters")
     }))
 
-  // test-revizorro: approved
   it.effect("returns domain error on operation failure", () =>
     Effect.gen(function*() {
       const handler = createToolHandler(
@@ -164,7 +163,6 @@ describe("createEncodedToolHandler", () => {
 })
 
 describe("createStorageToolHandler", () => {
-  // test-revizorro: approved
   it.effect("returns success response via storage client", () =>
     Effect.gen(function*() {
       const handler = createStorageToolHandler(
@@ -182,7 +180,6 @@ describe("createStorageToolHandler", () => {
       expect(result.content[0].text).toContain("file://doc.pdf")
     }))
 
-  // test-revizorro: approved
   it.effect("returns parse error on invalid input", () =>
     Effect.gen(function*() {
       const handler = createStorageToolHandler(
@@ -202,7 +199,6 @@ describe("createStorageToolHandler", () => {
 })
 
 describe("createCombinedToolHandler", () => {
-  // test-revizorro: approved
   it.effect("returns success response via both clients", () =>
     Effect.gen(function*() {
       const handler = createCombinedToolHandler(
@@ -224,7 +220,6 @@ describe("createCombinedToolHandler", () => {
 })
 
 describe("createWorkspaceToolHandler", () => {
-  // test-revizorro: approved
   it.effect("returns success response when workspace client available", () =>
     Effect.gen(function*() {
       const handler = createWorkspaceToolHandler(
@@ -244,7 +239,6 @@ describe("createWorkspaceToolHandler", () => {
       expect(result.content[0].text).toContain("myws")
     }))
 
-  // test-revizorro: approved
   it.effect("returns error when workspace client is undefined", () =>
     Effect.gen(function*() {
       const handler = createWorkspaceToolHandler(
@@ -265,7 +259,6 @@ describe("createWorkspaceToolHandler", () => {
       expect(result.content[0].text).toContain("WorkspaceClient not available")
     }))
 
-  // test-revizorro: approved
   it.effect("returns parse error on invalid input", () =>
     Effect.gen(function*() {
       const handler = createWorkspaceToolHandler(
@@ -287,7 +280,6 @@ describe("createWorkspaceToolHandler", () => {
 })
 
 describe("createNoParamsWorkspaceToolHandler", () => {
-  // test-revizorro: approved
   it.effect("returns success response with no params", () =>
     Effect.gen(function*() {
       const handler = createNoParamsWorkspaceToolHandler(
@@ -303,7 +295,6 @@ describe("createNoParamsWorkspaceToolHandler", () => {
       expect(result.content[0].text).toContain("5")
     }))
 
-  // test-revizorro: approved
   it.effect("returns error when workspace client is undefined", () =>
     Effect.gen(function*() {
       const handler = createNoParamsWorkspaceToolHandler(
@@ -320,7 +311,6 @@ describe("createNoParamsWorkspaceToolHandler", () => {
       expect(result.content[0].text).toContain("WorkspaceClient not available")
     }))
 
-  // test-revizorro: approved
   it.effect("returns domain error on operation failure", () =>
     Effect.gen(function*() {
       const handler = createNoParamsWorkspaceToolHandler(

--- a/test/mcp/tools-index-branches.test.ts
+++ b/test/mcp/tools-index-branches.test.ts
@@ -5,11 +5,13 @@ import { Effect } from "effect"
 import { expect } from "vitest"
 
 import type { HulyClientOperations } from "../../src/huly/client.js"
+import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
+  markupUrlConfig: testMarkupUrlConfig,
   findAll: (() => Effect.succeed(toFindResult([]))) as HulyClientOperations["findAll"],
   findOne: (() => Effect.succeed(undefined)) as HulyClientOperations["findOne"],
   createDoc: () => Effect.die(new Error("not implemented")),
@@ -29,7 +31,6 @@ const noopStorageClient: HulyStorageOperations = {
 }
 
 describe("handleToolCall - known tool execution (line 71)", () => {
-  // test-revizorro: approved
   it.effect("returns a response when tool is found in registry", () =>
     Effect.gen(function*() {
       // Pick a tool that we know exists - list_projects is simple and just needs findAll

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -5,11 +5,13 @@ import { Effect } from "effect"
 import { expect } from "vitest"
 
 import type { HulyClientOperations } from "../../src/huly/client.js"
+import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { CATEGORY_NAMES, createFilteredRegistry, TOOL_DEFINITIONS, toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
+  markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),
@@ -29,7 +31,6 @@ const noopStorageClient: HulyStorageOperations = {
 }
 
 describe("CATEGORY_NAMES", () => {
-  // test-revizorro: approved
   it.effect("contains expected categories", () =>
     Effect.gen(function*() {
       expect(CATEGORY_NAMES.has("projects")).toBe(true)
@@ -41,7 +42,6 @@ describe("CATEGORY_NAMES", () => {
 })
 
 describe("toolRegistry", () => {
-  // test-revizorro: approved
   it.effect("has tools", () =>
     Effect.gen(function*() {
       expect(toolRegistry.tools.size).toBeGreaterThan(0)
@@ -49,7 +49,6 @@ describe("toolRegistry", () => {
       expect(toolRegistry.tools.size).toBe(toolRegistry.definitions.length)
     }))
 
-  // test-revizorro: approved
   it.effect("all tool names are unique", () =>
     Effect.gen(function*() {
       const names = toolRegistry.definitions.map((t) => t.name)
@@ -59,7 +58,6 @@ describe("toolRegistry", () => {
 })
 
 describe("createFilteredRegistry", () => {
-  // test-revizorro: approved
   it.effect("filters to only requested categories", () =>
     Effect.gen(function*() {
       const filtered = createFilteredRegistry(new Set(["issues"]))
@@ -72,7 +70,6 @@ describe("createFilteredRegistry", () => {
       }
     }))
 
-  // test-revizorro: approved
   it.effect("returns empty registry for unknown category", () =>
     Effect.gen(function*() {
       const filtered = createFilteredRegistry(new Set(["nonexistent_category"]))
@@ -80,7 +77,6 @@ describe("createFilteredRegistry", () => {
       expect(filtered.tools.size).toBe(0)
     }))
 
-  // test-revizorro: approved
   it.effect("combines multiple categories", () =>
     Effect.gen(function*() {
       const filtered = createFilteredRegistry(new Set(["issues", "projects"]))
@@ -95,7 +91,6 @@ describe("createFilteredRegistry", () => {
 })
 
 describe("handleToolCall", () => {
-  // test-revizorro: approved
   it.effect("returns null for unknown tool", () =>
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
@@ -112,7 +107,6 @@ describe("handleToolCall", () => {
 })
 
 describe("TOOL_DEFINITIONS", () => {
-  // test-revizorro: approved
   it.effect("is populated", () =>
     Effect.gen(function*() {
       const keys = Object.keys(TOOL_DEFINITIONS)
@@ -120,7 +114,6 @@ describe("TOOL_DEFINITIONS", () => {
       expect(keys.length).toBe(toolRegistry.tools.size)
     }))
 
-  // test-revizorro: approved
   it.effect("entries match toolRegistry", () =>
     Effect.gen(function*() {
       for (const [name, tool] of Object.entries(TOOL_DEFINITIONS)) {

--- a/test/mcp/tools/notifications.test.ts
+++ b/test/mcp/tools/notifications.test.ts
@@ -5,11 +5,13 @@ import { Effect } from "effect"
 import { expect } from "vitest"
 
 import type { HulyClientOperations } from "../../../src/huly/client.js"
+import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../../src/huly/storage.js"
 import { notificationTools } from "../../../src/mcp/tools/notifications.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
+  markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),
@@ -35,7 +37,6 @@ const findTool = (name: string) => {
 }
 
 describe("notificationTools", () => {
-  // test-revizorro: approved
   it.effect("exports all expected notification tools", () =>
     Effect.gen(function*() {
       const expectedTools = [
@@ -61,7 +62,6 @@ describe("notificationTools", () => {
       expect(notificationTools.length).toBe(expectedTools.length)
     }))
 
-  // test-revizorro: approved
   it.effect("all tools have category 'notifications'", () =>
     Effect.gen(function*() {
       for (const tool of notificationTools) {
@@ -69,7 +69,6 @@ describe("notificationTools", () => {
       }
     }))
 
-  // test-revizorro: approved
   it.effect("all tools have non-empty description and inputSchema", () =>
     Effect.gen(function*() {
       for (const tool of notificationTools) {
@@ -80,7 +79,6 @@ describe("notificationTools", () => {
 })
 
 describe("notification tool handlers", () => {
-  // test-revizorro: approved
   it.effect("mark_all_notifications_read handler returns success for empty list", () =>
     Effect.gen(function*() {
       const tool = findTool("mark_all_notifications_read")
@@ -91,7 +89,6 @@ describe("notification tool handlers", () => {
       expect(parsed.count).toBe(0)
     }))
 
-  // test-revizorro: approved
   it.effect("archive_all_notifications handler returns success for empty list", () =>
     Effect.gen(function*() {
       const tool = findTool("archive_all_notifications")
@@ -102,7 +99,6 @@ describe("notification tool handlers", () => {
       expect(parsed.count).toBe(0)
     }))
 
-  // test-revizorro: approved
   it.effect("get_unread_notification_count handler returns count", () =>
     Effect.gen(function*() {
       const tool = findTool("get_unread_notification_count")
@@ -113,7 +109,6 @@ describe("notification tool handlers", () => {
       expect(parsed.count).toBe(0)
     }))
 
-  // test-revizorro: approved
   it.effect("list_notifications handler returns empty list", () =>
     Effect.gen(function*() {
       const tool = findTool("list_notifications")
@@ -124,7 +119,6 @@ describe("notification tool handlers", () => {
       expect(parsed).toEqual([])
     }))
 
-  // test-revizorro: approved
   it.effect("get_notification handler returns error for missing notification", () =>
     Effect.gen(function*() {
       const tool = findTool("get_notification")
@@ -135,7 +129,6 @@ describe("notification tool handlers", () => {
       expect(result.isError).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("mark_notification_read handler returns error for missing notification", () =>
     Effect.gen(function*() {
       const tool = findTool("mark_notification_read")
@@ -146,7 +139,6 @@ describe("notification tool handlers", () => {
       expect(result.isError).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("archive_notification handler returns error for missing notification", () =>
     Effect.gen(function*() {
       const tool = findTool("archive_notification")
@@ -157,7 +149,6 @@ describe("notification tool handlers", () => {
       expect(result.isError).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("delete_notification handler returns error for missing notification", () =>
     Effect.gen(function*() {
       const tool = findTool("delete_notification")
@@ -168,7 +159,6 @@ describe("notification tool handlers", () => {
       expect(result.isError).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("get_notification_context handler returns null for missing context", () =>
     Effect.gen(function*() {
       const tool = findTool("get_notification_context")
@@ -185,7 +175,6 @@ describe("notification tool handlers", () => {
       expect(parsed).toBeNull()
     }))
 
-  // test-revizorro: approved
   it.effect("list_notification_contexts handler returns empty list", () =>
     Effect.gen(function*() {
       const tool = findTool("list_notification_contexts")
@@ -196,7 +185,6 @@ describe("notification tool handlers", () => {
       expect(parsed).toEqual([])
     }))
 
-  // test-revizorro: approved
   it.effect("pin_notification_context handler returns error for missing context", () =>
     Effect.gen(function*() {
       const tool = findTool("pin_notification_context")
@@ -211,7 +199,6 @@ describe("notification tool handlers", () => {
       expect(result.isError).toBe(true)
     }))
 
-  // test-revizorro: approved
   it.effect("list_notification_settings handler returns empty list", () =>
     Effect.gen(function*() {
       const tool = findTool("list_notification_settings")
@@ -222,7 +209,6 @@ describe("notification tool handlers", () => {
       expect(parsed).toEqual([])
     }))
 
-  // test-revizorro: approved
   it.effect("update_notification_provider_setting handler returns updated=false when setting not found", () =>
     Effect.gen(function*() {
       const tool = findTool("update_notification_provider_setting")
@@ -241,7 +227,6 @@ describe("notification tool handlers", () => {
       expect(parsed.updated).toBe(false)
     }))
 
-  // test-revizorro: approved
   it.effect("handler returns parse error for invalid params", () =>
     Effect.gen(function*() {
       const tool = findTool("get_notification")


### PR DESCRIPTION
Supersedes #23.

Keeps markup conversion pure while passing connection-derived workspace URL config through all remaining call sites.

Verified with `pnpm check-all` and local Huly integration tests.