### PR TITLE
refactor: tighten document URL config and share message lookup

### DIFF
--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -193,6 +193,9 @@ export type WorkspaceName = Schema.Schema.Type<typeof WorkspaceName>
 export const UrlString = NonEmptyString.pipe(Schema.brand("UrlString"))
 export type UrlString = Schema.Schema.Type<typeof UrlString>
 
+export const WorkspaceUrlSlug = NonEmptyString.pipe(Schema.brand("WorkspaceUrlSlug"))
+export type WorkspaceUrlSlug = Schema.Schema.Type<typeof WorkspaceUrlSlug>
+
 export const WorkspaceVersion = NonEmptyString.pipe(Schema.brand("WorkspaceVersion"))
 export type WorkspaceVersion = Schema.Schema.Type<typeof WorkspaceVersion>
 

--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -50,12 +50,12 @@ import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown
 import { absurd, Context, Effect, Layer } from "effect"
 
 import { HulyConfigService } from "../config/config.js"
-import { UrlString } from "../domain/schemas/shared.js"
+import { UrlString, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 import { concatLink } from "../utils/url.js"
 import { authToOptions, type ConnectionConfig, type ConnectionError, connectWithRetry } from "./auth-utils.js"
 import { HulyConnectionError } from "./errors.js"
 import { type MarkupUrlConfig, testMarkupUrlConfig } from "./operations/markup.js"
-import { buildDocumentUrl } from "./url-builders.js"
+import type { DocumentUrlConfig } from "./url-builders.js"
 
 interface MarkupConvertOptions {
   readonly refUrl: string
@@ -102,12 +102,11 @@ export type HulyClientError = ConnectionError
 
 interface HulyClientContext {
   readonly markupUrlConfig: MarkupUrlConfig
+  readonly documentUrlConfig: DocumentUrlConfig
 }
 
 export interface HulyClientOperations extends HulyClientContext {
   readonly getAccountUuid: () => AccountUuid
-
-  readonly documentUrl: (title: string, id: string) => UrlString
 
   readonly findAll: <T extends Doc>(
     _class: Ref<Class<T>>,
@@ -221,9 +220,10 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
         refUrl: UrlString.make(refUrl),
         imageUrl: UrlString.make(imageUrl)
       }
-
-      const documentUrl = (title: string, id: string): UrlString =>
-        buildDocumentUrl(config.url, workspaceUrlSlug, title, id)
+      const documentUrlConfig: DocumentUrlConfig = {
+        baseUrl: UrlString.make(config.url),
+        workspaceUrlSlug
+      }
 
       const withClient = <A>(
         op: (client: TxOperations) => Promise<A>,
@@ -240,7 +240,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
 
       const operations: HulyClientOperations = {
         getAccountUuid: () => accountUuid,
-        documentUrl,
+        documentUrlConfig,
         markupUrlConfig,
 
         findAll: <T extends Doc>(
@@ -406,7 +406,10 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       // AccountUuid is a double-branded string type with no public constructor
       // eslint-disable-next-line no-restricted-syntax -- see above
       getAccountUuid: () => "test-account-uuid" as AccountUuid,
-      documentUrl: (title, id) => buildDocumentUrl("https://test.huly.local", "test-workspace", title, id),
+      documentUrlConfig: {
+        baseUrl: UrlString.make("https://test.huly.local"),
+        workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
+      },
       markupUrlConfig: testMarkupUrlConfig,
       findAll: noopFindAll,
       findOne: noopFindOne,
@@ -453,7 +456,7 @@ interface MarkupOperations {
 interface RestConnection {
   client: TxOperations
   accountUuid: AccountUuid
-  workspaceUrlSlug: string
+  workspaceUrlSlug: WorkspaceUrlSlug
   markupOps: MarkupOperations
   refUrl: string
   imageUrl: string
@@ -525,7 +528,7 @@ const connectRest = async (
   return {
     client,
     accountUuid: account.uuid,
-    workspaceUrlSlug: info.workspaceUrl,
+    workspaceUrlSlug: WorkspaceUrlSlug.make(info.workspaceUrl),
     markupOps,
     refUrl,
     imageUrl

--- a/src/huly/operations/channel-messages-shared.ts
+++ b/src/huly/operations/channel-messages-shared.ts
@@ -1,0 +1,42 @@
+import type { Channel as HulyChannel, ChatMessage } from "@hcengineering/chunter"
+import { Effect } from "effect"
+
+import type { ChannelIdentifier, MessageId } from "../../domain/schemas/shared.js"
+import type { HulyClient, HulyClientError } from "../client.js"
+import type { ChannelNotFoundError } from "../errors.js"
+import { MessageNotFoundError } from "../errors.js"
+import { findChannel } from "./channels.js"
+import { toRef } from "./shared.js"
+
+import { chunter } from "../huly-plugins.js"
+
+export const findChannelMessage = (
+  params: {
+    channel: ChannelIdentifier
+    messageId: MessageId
+  }
+): Effect.Effect<
+  { client: HulyClient["Type"]; channel: HulyChannel; message: ChatMessage },
+  ChannelNotFoundError | MessageNotFoundError | HulyClientError,
+  HulyClient
+> =>
+  Effect.gen(function*() {
+    const { channel, client } = yield* findChannel(params.channel)
+
+    const message = yield* client.findOne<ChatMessage>(
+      chunter.class.ChatMessage,
+      {
+        _id: toRef<ChatMessage>(params.messageId),
+        space: channel._id
+      }
+    )
+
+    if (message === undefined) {
+      return yield* new MessageNotFoundError({
+        messageId: params.messageId,
+        channel: params.channel
+      })
+    }
+
+    return { client, channel, message }
+  })

--- a/src/huly/operations/channels-messages.ts
+++ b/src/huly/operations/channels-messages.ts
@@ -3,7 +3,7 @@
  *
  * @module
  */
-import type { Channel as HulyChannel, ChatMessage } from "@hcengineering/chunter"
+import type { ChatMessage } from "@hcengineering/chunter"
 import type { DocumentUpdate } from "@hcengineering/core"
 import { Clock, Effect } from "effect"
 
@@ -11,11 +11,9 @@ import type { DeleteChannelMessageParams, UpdateChannelMessageParams } from "../
 import type { DeleteChannelMessageResult, UpdateChannelMessageResult } from "../../domain/schemas/channels.js"
 import { MessageId } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
-import type { ChannelNotFoundError } from "../errors.js"
-import { MessageNotFoundError } from "../errors.js"
-import { findChannel } from "./channels.js"
+import type { ChannelNotFoundError, MessageNotFoundError } from "../errors.js"
+import { findChannelMessage } from "./channel-messages-shared.js"
 import { markdownToMarkupString } from "./markup.js"
-import { toRef } from "./shared.js"
 
 import { chunter } from "../huly-plugins.js"
 
@@ -29,32 +27,6 @@ type DeleteChannelMessageError =
   | ChannelNotFoundError
   | MessageNotFoundError
 
-const findChannelMessage = (
-  channelIdentifier: string,
-  messageId: string
-): Effect.Effect<
-  { client: HulyClient["Type"]; channel: HulyChannel; message: ChatMessage },
-  ChannelNotFoundError | MessageNotFoundError | HulyClientError,
-  HulyClient
-> =>
-  Effect.gen(function*() {
-    const { channel, client } = yield* findChannel(channelIdentifier)
-
-    const message = yield* client.findOne<ChatMessage>(
-      chunter.class.ChatMessage,
-      {
-        _id: toRef<ChatMessage>(messageId),
-        space: channel._id
-      }
-    )
-
-    if (message === undefined) {
-      return yield* new MessageNotFoundError({ messageId, channel: channelIdentifier })
-    }
-
-    return { client, channel, message }
-  })
-
 /**
  * Update an existing channel message. Only the body can be modified.
  */
@@ -62,7 +34,7 @@ export const updateChannelMessage = (
   params: UpdateChannelMessageParams
 ): Effect.Effect<UpdateChannelMessageResult, UpdateChannelMessageError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findChannelMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
     const markupUrlConfig = client.markupUrlConfig
 
     const markup = markdownToMarkupString(params.body, markupUrlConfig)
@@ -90,7 +62,7 @@ export const deleteChannelMessage = (
   params: DeleteChannelMessageParams
 ): Effect.Effect<DeleteChannelMessageResult, DeleteChannelMessageError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findChannelMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
 
     yield* client.removeDoc(
       chunter.class.ChatMessage,

--- a/src/huly/operations/documents-edit.ts
+++ b/src/huly/operations/documents-edit.ts
@@ -21,6 +21,7 @@ import {
   DocumentTextNotFoundError,
   type TeamspaceNotFoundError
 } from "../errors.js"
+import { buildDocumentUrlFromConfig } from "../url-builders.js"
 import { findTeamspaceAndDocument } from "./documents.js"
 
 import { documentPlugin } from "../huly-plugins.js"
@@ -116,7 +117,7 @@ export const editDocument = (
     }
 
     const finalTitle = updateOps.title ?? doc.title
-    const url = client.documentUrl(finalTitle, doc._id)
+    const url = buildDocumentUrlFromConfig(client.documentUrlConfig, finalTitle, DocumentId.make(doc._id))
 
     if (Object.keys(updateOps).length === 0 && !contentUpdatedInPlace) {
       return { id: DocumentId.make(doc._id), updated: false, url }

--- a/src/huly/operations/documents.ts
+++ b/src/huly/operations/documents.ts
@@ -43,6 +43,7 @@ import type {
 import { DocumentId, TeamspaceId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import { DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
+import { buildDocumentUrlFromConfig } from "../url-builders.js"
 import { escapeLikeWildcards } from "./query-helpers.js"
 import { clampLimit, findByNameOrId, toRef } from "./shared.js"
 
@@ -367,7 +368,7 @@ export const listDocuments = (
       id: DocumentId.make(doc._id),
       title: doc.title,
       teamspace: teamspace.name,
-      url: client.documentUrl(doc.title, doc._id),
+      url: buildDocumentUrlFromConfig(client.documentUrlConfig, doc.title, DocumentId.make(doc._id)),
       modifiedOn: doc.modifiedOn
     }))
 
@@ -409,7 +410,7 @@ export const getDocument = (
       title: doc.title,
       content,
       teamspace: teamspace.name,
-      url: client.documentUrl(doc.title, doc._id),
+      url: buildDocumentUrlFromConfig(client.documentUrlConfig, doc.title, DocumentId.make(doc._id)),
       modifiedOn: doc.modifiedOn,
       createdOn: doc.createdOn
     }
@@ -492,7 +493,7 @@ export const createDocument = (
     return {
       id: DocumentId.make(documentId),
       title: params.title,
-      url: client.documentUrl(params.title, documentId)
+      url: buildDocumentUrlFromConfig(client.documentUrlConfig, params.title, DocumentId.make(documentId))
     }
   })
 

--- a/src/huly/operations/threads.ts
+++ b/src/huly/operations/threads.ts
@@ -26,9 +26,10 @@ import type {
 } from "../../domain/schemas/channels.js"
 import { ChannelId, MessageId, PersonName, ThreadReplyId } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
-import type { ChannelNotFoundError } from "../errors.js"
-import { MessageNotFoundError, ThreadReplyNotFoundError } from "../errors.js"
-import { buildSocialIdToPersonNameMap, findChannel } from "./channels.js"
+import type { ChannelNotFoundError, MessageNotFoundError } from "../errors.js"
+import { ThreadReplyNotFoundError } from "../errors.js"
+import { findChannelMessage } from "./channel-messages-shared.js"
+import { buildSocialIdToPersonNameMap } from "./channels.js"
 import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { toRef } from "./shared.js"
 
@@ -59,32 +60,6 @@ type DeleteThreadReplyError =
   | ThreadReplyNotFoundError
 
 // --- Helpers ---
-
-const findMessage = (
-  channelIdentifier: string,
-  messageId: string
-): Effect.Effect<
-  { client: HulyClient["Type"]; channel: HulyChannel; message: ChatMessage },
-  ChannelNotFoundError | MessageNotFoundError | HulyClientError,
-  HulyClient
-> =>
-  Effect.gen(function*() {
-    const { channel, client } = yield* findChannel(channelIdentifier)
-
-    const message = yield* client.findOne<ChatMessage>(
-      chunter.class.ChatMessage,
-      {
-        _id: toRef<ChatMessage>(messageId),
-        space: channel._id
-      }
-    )
-
-    if (message === undefined) {
-      return yield* new MessageNotFoundError({ messageId, channel: channelIdentifier })
-    }
-
-    return { client, channel, message }
-  })
 
 const findReply = (
   client: HulyClient["Type"],
@@ -118,7 +93,7 @@ export const listThreadReplies = (
   params: ListThreadRepliesParams
 ): Effect.Effect<ListThreadRepliesResult, ListThreadRepliesError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
     const markupUrlConfig = client.markupUrlConfig
 
     const limit = Math.min(params.limit ?? 50, 200)
@@ -168,7 +143,7 @@ export const addThreadReply = (
   params: AddThreadReplyParams
 ): Effect.Effect<AddThreadReplyResult, AddThreadReplyError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
     const markupUrlConfig = client.markupUrlConfig
 
     const replyId: Ref<HulyThreadMessage> = generateId()
@@ -202,7 +177,7 @@ export const updateThreadReply = (
   params: UpdateThreadReplyParams
 ): Effect.Effect<UpdateThreadReplyResult, UpdateThreadReplyError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
     const reply = yield* findReply(client, channel, message, params.replyId)
     const markupUrlConfig = client.markupUrlConfig
 
@@ -228,7 +203,7 @@ export const deleteThreadReply = (
   params: DeleteThreadReplyParams
 ): Effect.Effect<DeleteThreadReplyResult, DeleteThreadReplyError, HulyClient> =>
   Effect.gen(function*() {
-    const { channel, client, message } = yield* findMessage(params.channel, params.messageId)
+    const { channel, client, message } = yield* findChannelMessage(params)
     const reply = yield* findReply(client, channel, message, params.replyId)
 
     yield* client.removeDoc(

--- a/src/huly/url-builders.ts
+++ b/src/huly/url-builders.ts
@@ -10,7 +10,13 @@
  *
  * @module
  */
+import type { DocumentId, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 import { UrlString } from "../domain/schemas/shared.js"
+
+export interface DocumentUrlConfig {
+  readonly baseUrl: UrlString
+  readonly workspaceUrlSlug: WorkspaceUrlSlug
+}
 
 /**
  * Slugify a document title to match Huly's URL path segment.
@@ -39,13 +45,16 @@ export const slugifyTitle = (title: string): string => {
  * tolerated. See {@link slugifyTitle} for the path-segment algorithm.
  */
 export const buildDocumentUrl = (
-  baseUrl: string,
-  workspaceUrlSlug: string,
+  baseUrl: UrlString,
+  workspaceUrlSlug: WorkspaceUrlSlug,
   title: string,
-  id: string
+  id: DocumentId
 ): UrlString => {
   const trimmedBase = baseUrl.replace(/\/+$/, "")
   const slug = slugifyTitle(title)
   const pathSegment = slug === "" ? id : `${slug}-${id}`
   return UrlString.make(`${trimmedBase}/workbench/${workspaceUrlSlug}/document/${pathSegment}`)
 }
+
+export const buildDocumentUrlFromConfig = (config: DocumentUrlConfig, title: string, id: DocumentId): UrlString =>
+  buildDocumentUrl(config.baseUrl, config.workspaceUrlSlug, title, id)

--- a/test/huly/url-builders.test.ts
+++ b/test/huly/url-builders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { DocumentId, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import { buildDocumentUrl, slugifyTitle } from "../../src/huly/url-builders.js"
 
 describe("slugifyTitle", () => {
@@ -43,14 +44,14 @@ describe("slugifyTitle", () => {
 })
 
 describe("buildDocumentUrl", () => {
-  const baseUrl = "https://huly.axzez.org"
-  const workspaceUuid = "axzez-6925fc59-8ee2eba17e-eb022e"
-  const id = "69e6a5dab299f79d42314f12"
+  const baseUrl = UrlString.make("https://huly.axzez.org")
+  const workspaceUrlSlug = WorkspaceUrlSlug.make("axzez-6925fc59-8ee2eba17e-eb022e")
+  const id = DocumentId.make("69e6a5dab299f79d42314f12")
 
   it("reproduces the canonical working URL", () => {
     expect(buildDocumentUrl(
       baseUrl,
-      workspaceUuid,
+      workspaceUrlSlug,
       "v1.0a Short-Circuit Analysis - Lite/Keel Variants",
       id
     )).toBe(
@@ -59,12 +60,12 @@ describe("buildDocumentUrl", () => {
   })
 
   it("tolerates trailing slash on baseUrl", () => {
-    expect(buildDocumentUrl(`${baseUrl}/`, workspaceUuid, "Test", id))
-      .toBe(`${baseUrl}/workbench/${workspaceUuid}/document/test-${id}`)
+    expect(buildDocumentUrl(UrlString.make(`${baseUrl}/`), workspaceUrlSlug, "Test", id))
+      .toBe(`${baseUrl}/workbench/${workspaceUrlSlug}/document/test-${id}`)
   })
 
   it("falls back to bare id when slug is empty", () => {
-    expect(buildDocumentUrl(baseUrl, workspaceUuid, "!!!", id))
-      .toBe(`${baseUrl}/workbench/${workspaceUuid}/document/${id}`)
+    expect(buildDocumentUrl(baseUrl, workspaceUrlSlug, "!!!", id))
+      .toBe(`${baseUrl}/workbench/${workspaceUrlSlug}/document/${id}`)
   })
 })

--- a/test/mcp/registry.test.ts
+++ b/test/mcp/registry.test.ts
@@ -4,14 +4,13 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect, Schema } from "effect"
 import { expect } from "vitest"
 
-import { IssueIdentifier } from "../../src/domain/schemas/shared.js"
+import { IssueIdentifier, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { HulyClient } from "../../src/huly/client.js"
 import { HulyError } from "../../src/huly/errors.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
-import { buildDocumentUrl } from "../../src/huly/url-builders.js"
 import type { WorkspaceClientOperations } from "../../src/huly/workspace-client.js"
 import { WorkspaceClient } from "../../src/huly/workspace-client.js"
 import { McpErrorCode } from "../../src/mcp/error-mapping.js"
@@ -31,7 +30,10 @@ const parse = (input: unknown) => Schema.decodeUnknown(Params)(input)
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
-  documentUrl: (title, id) => buildDocumentUrl("https://test.huly.local", "test-workspace", title, id),
+  documentUrlConfig: {
+    baseUrl: UrlString.make("https://test.huly.local"),
+    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
+  },
   markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),

--- a/test/mcp/tools-index-branches.test.ts
+++ b/test/mcp/tools-index-branches.test.ts
@@ -4,15 +4,18 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
+import { UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
-import { buildDocumentUrl } from "../../src/huly/url-builders.js"
 import { toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
-  documentUrl: (title, id) => buildDocumentUrl("https://test.huly.local", "test-workspace", title, id),
+  documentUrlConfig: {
+    baseUrl: UrlString.make("https://test.huly.local"),
+    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
+  },
   markupUrlConfig: testMarkupUrlConfig,
   findAll: (() => Effect.succeed(toFindResult([]))) as HulyClientOperations["findAll"],
   findOne: (() => Effect.succeed(undefined)) as HulyClientOperations["findOne"],

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -4,15 +4,18 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
+import { UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
-import { buildDocumentUrl } from "../../src/huly/url-builders.js"
 import { CATEGORY_NAMES, createFilteredRegistry, TOOL_DEFINITIONS, toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
-  documentUrl: (title, id) => buildDocumentUrl("https://test.huly.local", "test-workspace", title, id),
+  documentUrlConfig: {
+    baseUrl: UrlString.make("https://test.huly.local"),
+    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
+  },
   markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),

--- a/test/mcp/tools/notifications.test.ts
+++ b/test/mcp/tools/notifications.test.ts
@@ -4,15 +4,18 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
+import { UrlString, WorkspaceUrlSlug } from "../../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../../src/huly/storage.js"
-import { buildDocumentUrl } from "../../../src/huly/url-builders.js"
 import { notificationTools } from "../../../src/mcp/tools/notifications.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
-  documentUrl: (title, id) => buildDocumentUrl("https://test.huly.local", "test-workspace", title, id),
+  documentUrlConfig: {
+    baseUrl: UrlString.make("https://test.huly.local"),
+    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
+  },
   markupUrlConfig: testMarkupUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),


### PR DESCRIPTION
VIBED

## Summary

Follow-up cleanup on top of #30:

- extract shared `findChannelMessage` helper used by both channel-message and thread-reply operations
- remove document-specific helper method from `HulyClientOperations`
- expose typed `documentUrlConfig` instead and keep URL construction pure in `url-builders.ts`
- add branded `WorkspaceUrlSlug` and tighten URL builder/test types

## Verification

- `pnpm typecheck`
- `pnpm check-all`
