### PR TITLE
feat: accept person display name (not just email) for assignee/lead

### DIFF
--- a/src/domain/schemas/components.ts
+++ b/src/domain/schemas/components.ts
@@ -4,11 +4,11 @@ import {
   ComponentId,
   ComponentIdentifier,
   ComponentLabel,
-  Email,
   IssueIdentifier,
   LimitParam,
   NonEmptyString,
   PersonName,
+  PersonRefInput,
   ProjectIdentifier,
   Timestamp
 } from "./shared.js"
@@ -80,8 +80,8 @@ export const CreateComponentParamsSchema = Schema.Struct({
   description: Schema.optional(Schema.String.annotations({
     description: "Component description (markdown supported)"
   })),
-  lead: Schema.optional(Email.annotations({
-    description: "Lead person email address"
+  lead: Schema.optional(PersonRefInput.annotations({
+    description: "Lead person email address or display name"
   }))
 }).annotations({
   title: "CreateComponentParams",
@@ -104,8 +104,8 @@ export const UpdateComponentParamsSchema = Schema.Struct({
     description: "New component description (markdown supported)"
   })),
   lead: Schema.optional(
-    Schema.NullOr(Email).annotations({
-      description: "New lead person email (null to unassign)"
+    Schema.NullOr(PersonRefInput).annotations({
+      description: "New lead person email or display name (null to unassign)"
     })
   )
 }).annotations({

--- a/src/domain/schemas/issue-templates.ts
+++ b/src/domain/schemas/issue-templates.ts
@@ -5,12 +5,12 @@ import type { IssueId, IssueIdentifier } from "./shared.js"
 import {
   ComponentIdentifier,
   ComponentLabel,
-  Email,
   IssueTemplateChildId,
   IssueTemplateId,
   LimitParam,
   NonEmptyString,
   PersonName,
+  PersonRefInput,
   PositiveNumber,
   ProjectIdentifier,
   StatusName,
@@ -46,8 +46,8 @@ const ChildTemplateFieldsSchema = Schema.Struct({
   priority: Schema.optional(IssuePrioritySchema.annotations({
     description: "Child default priority"
   })),
-  assignee: Schema.optional(Email.annotations({
-    description: "Child default assignee email"
+  assignee: Schema.optional(PersonRefInput.annotations({
+    description: "Child default assignee email or display name"
   })),
   component: Schema.optional(ComponentIdentifier.annotations({
     description: "Child default component ID or label"
@@ -143,8 +143,8 @@ export const CreateIssueTemplateParamsSchema = Schema.Struct({
   priority: Schema.optional(IssuePrioritySchema.annotations({
     description: "Default priority for issues created from this template"
   })),
-  assignee: Schema.optional(Email.annotations({
-    description: "Default assignee email address"
+  assignee: Schema.optional(PersonRefInput.annotations({
+    description: "Default assignee email address or display name"
   })),
   component: Schema.optional(ComponentIdentifier.annotations({
     description: "Default component ID or label"
@@ -180,8 +180,8 @@ export const CreateIssueFromTemplateParamsSchema = Schema.Struct({
   priority: Schema.optional(IssuePrioritySchema.annotations({
     description: "Override priority"
   })),
-  assignee: Schema.optional(Email.annotations({
-    description: "Override assignee email"
+  assignee: Schema.optional(PersonRefInput.annotations({
+    description: "Override assignee email or display name"
   })),
   status: Schema.optional(StatusName.annotations({
     description: "Initial status (uses project default if not specified)"
@@ -213,8 +213,8 @@ export const UpdateIssueTemplateParamsSchema = Schema.Struct({
     description: "New default priority"
   })),
   assignee: Schema.optional(
-    Schema.NullOr(Email).annotations({
-      description: "New default assignee email (null to unassign)"
+    Schema.NullOr(PersonRefInput).annotations({
+      description: "New default assignee email or display name (null to unassign)"
     })
   ),
   component: Schema.optional(

--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -11,6 +11,7 @@ import {
   NonEmptyString,
   PersonId,
   PersonName,
+  PersonRefInput,
   PositiveNumber,
   ProjectIdentifier,
   StatusName,
@@ -115,8 +116,8 @@ const ListIssuesParamsBase = Schema.Struct({
   status: Schema.optional(StatusName.annotations({
     description: "Filter by status name"
   })),
-  assignee: Schema.optional(Email.annotations({
-    description: "Filter by assignee email"
+  assignee: Schema.optional(PersonRefInput.annotations({
+    description: "Filter by assignee email or display name"
   })),
   parentIssue: Schema.optional(IssueIdentifier.annotations({
     description: "Filter to children of this parent issue (e.g., 'HULY-42')"
@@ -203,8 +204,8 @@ export const CreateIssueParamsSchema = Schema.Struct({
   priority: Schema.optional(IssuePrioritySchema.annotations({
     description: "Issue priority (urgent, high, medium, low, no-priority)"
   })),
-  assignee: Schema.optional(Email.annotations({
-    description: "Assignee email address"
+  assignee: Schema.optional(PersonRefInput.annotations({
+    description: "Assignee email address or display name"
   })),
   status: Schema.optional(StatusName.annotations({
     description: "Initial status (uses project default if not specified)"
@@ -244,8 +245,8 @@ export const UpdateIssueParamsSchema = Schema.Struct({
     description: "New issue priority"
   })),
   assignee: Schema.optional(
-    Schema.NullOr(Email).annotations({
-      description: "New assignee email (null to unassign)"
+    Schema.NullOr(PersonRefInput).annotations({
+      description: "New assignee email or display name (null to unassign)"
     })
   ),
   status: Schema.optional(StatusName.annotations({

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -178,6 +178,17 @@ export type StatusName = Schema.Schema.Type<typeof StatusName>
 export const PersonName = NonEmptyString.pipe(Schema.brand("PersonName"))
 export type PersonName = Schema.Schema.Type<typeof PersonName>
 
+/**
+ * Input schema for any field that resolves through findPersonByEmailOrName —
+ * accepts either an email address or a display name. Use this for assignee,
+ * lead, and similar person-reference inputs. Email validation stays strict
+ * for fields where only an email makes sense (account creation, social-id
+ * lookups). Named `*Input` to distinguish from the existing PersonRef
+ * output struct in domain/schemas/issues.ts.
+ */
+export const PersonRefInput = Schema.Union(Email, PersonName)
+export type PersonRefInput = Schema.Schema.Type<typeof PersonRefInput>
+
 export const ComponentLabel = NonEmptyString.pipe(Schema.brand("ComponentLabel"))
 export type ComponentLabel = Schema.Schema.Type<typeof ComponentLabel>
 

--- a/test/domain/schemas.test.ts
+++ b/test/domain/schemas.test.ts
@@ -325,6 +325,15 @@ describe("Domain Schemas", () => {
         )
         expect(error._tag).toBe("ParseError")
       }))
+
+    it.effect("accepts assignee as a display name (not just an email)", () =>
+      Effect.gen(function*() {
+        const result = yield* parseListIssuesParams({
+          project: "HULY",
+          assignee: "Braeden Bihag"
+        })
+        expect(result.assignee).toBe("Braeden Bihag")
+      }))
   })
 
   describe("GetIssueParamsSchema", () => {


### PR DESCRIPTION
## Problem

`findPersonByEmailOrName` (used by every assignee/lead field) supports either an email or a display name at runtime — see `src/huly/operations/contacts-shared.ts`. But the *input schema* for those fields is constrained to `Email` with the regex `/^[^@]+@[^@]+$/`, so the schema validator rejects names *before* they reach the resolver.

Concretely, this happens at the MCP client side:

```jsonc
update_issue({
  project: "HULY_",
  identifier: "HULY_-1",
  assignee: "Braeden Bihag"
})
// → "Invalid parameters for update_issue: assignee: must contain exactly one @;
//    assignee: Expected null, actual \"Braeden Bihag\";
//    assignee: Expected undefined, actual \"Braeden Bihag\""
```

In real usage, an LLM/agent often only knows the person by display name (e.g. the name rendered in the issue list), so the natural prompt *"assign HULY-1 to Braeden"* fails. We hit this in real team usage today — the agent then went off looking for an email on the public internet and got the wrong one.

## Fix

Add `PersonRefInput = Schema.Union(Email, PersonName)` in `domain/schemas/shared.ts` and use it on every field that already runs through `findPersonByEmailOrName`:

| File | Field |
|---|---|
| `domain/schemas/issues.ts` | `list_issues.assignee` filter |
| `domain/schemas/issues.ts` | `create_issue.assignee` |
| `domain/schemas/issues.ts` | `update_issue.assignee` |
| `domain/schemas/components.ts` | `create_component.lead` |
| `domain/schemas/components.ts` | `update_component.lead` |
| `domain/schemas/issue-templates.ts` | `create_issue_template.assignee` |
| `domain/schemas/issue-templates.ts` | `create_issue_template.children[].assignee` |
| `domain/schemas/issue-templates.ts` | `create_issue_from_template.assignee` (override) |
| `domain/schemas/issue-templates.ts` | `update_issue_template.assignee` |

I deliberately **did not** widen these:

- The `email` field on the `PersonRef` *output* struct in `issues.ts:62` (it's an output annotation, not an input).
- Any future field that genuinely needs email format (e.g. social-identity/account creation paths).

The naming `PersonRefInput` (with `Input` suffix) was chosen because there's already a `PersonRef` *output* struct in `domain/schemas/issues.ts`. If you'd prefer a different name (e.g. `EmailOrName`, `AssigneeRef`), happy to rename.

## Tests

- New regression: `test/domain/schemas.test.ts` — `ListIssuesParamsSchema accepts assignee as a display name`
- `pnpm typecheck`: clean
- `pnpm test`: **1825 passed** (was 1824)
- `pnpm lint`: clean

## Manual verification

Tested end-to-end against a self-hosted Huly v0.7.353 with this branch's bundled output. Same `update_issue({ assignee: "Braeden Bihag" })` call now succeeds and resolves to the correct Person via `findPersonByEmailOrName`.

## Context

This is a follow-up to today's bug-fix loop on #34. Same self-hosted v0.7.353 deployment, same productionized owner-tenancy pattern. Thanks again for the lightning-fast turnaround on that one.