### PR TITLE
feat: direct-message read/send/edit/delete with name resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 | `update_channel_message` | Update a channel message. Only the body can be modified. |
 | `delete_channel_message` | Permanently delete a channel message. This action cannot be undone. |
 | `list_direct_messages` | List direct message conversations in Huly. Returns conversations sorted by date (newest first). |
+| `list_dm_messages` | List messages in a direct-message conversation, newest first. The `dm` argument accepts either the DM `_id` or a participant display name (e.g. `Kerr,Shannon`); a name resolves to the DM whose members include that person's account. |
+| `send_dm_message` | Send a message to a direct-message conversation. The `dm` argument accepts either the DM `_id` or a participant display name. Message body supports markdown formatting. |
+| `update_dm_message` | Update a direct-message message. Only the body can be modified. |
+| `delete_dm_message` | Permanently delete a direct-message message. This action cannot be undone. |
 | `list_thread_replies` | List replies in a message thread. Returns replies sorted by date (oldest first). |
 | `add_thread_reply` | Add a reply to a message thread. Reply body supports markdown formatting. |
 | `update_thread_reply` | Update a thread reply. Only the body can be modified. |

--- a/src/domain/schemas/direct-messages.ts
+++ b/src/domain/schemas/direct-messages.ts
@@ -1,0 +1,115 @@
+/**
+ * Direct-message conversation schemas. Sibling to channels.ts but kept
+ * separate to honour the per-file size limit and group all DM-specific
+ * params, JSON schemas, parsers, and result types in one place.
+ */
+import { JSONSchema, Schema } from "effect"
+
+import type { MessageSummary } from "./channels.js"
+import type { ChannelId } from "./shared.js"
+import { DirectMessageIdentifier, LimitParam, MessageId, NonEmptyString } from "./shared.js"
+
+// --- List DM Messages Params ---
+
+export const ListDmMessagesParamsSchema = Schema.Struct({
+  dm: DirectMessageIdentifier.annotations({
+    description: "Direct-message conversation: either the DM `_id` or a participant display name (e.g. `Kerr,Shannon`)"
+  }),
+  limit: Schema.optional(
+    LimitParam.annotations({
+      description: "Maximum number of messages to return (default: 50)"
+    })
+  )
+}).annotations({
+  title: "ListDmMessagesParams",
+  description: "Parameters for listing messages in a direct-message conversation"
+})
+
+export type ListDmMessagesParams = Schema.Schema.Type<typeof ListDmMessagesParamsSchema>
+
+// --- Send DM Message Params ---
+
+export const SendDmMessageParamsSchema = Schema.Struct({
+  dm: DirectMessageIdentifier.annotations({
+    description: "Direct-message conversation: either the DM `_id` or a participant display name (e.g. `Kerr,Shannon`)"
+  }),
+  body: NonEmptyString.annotations({
+    description: "Message body (markdown supported)"
+  })
+}).annotations({
+  title: "SendDmMessageParams",
+  description: "Parameters for sending a message to a direct-message conversation"
+})
+
+export type SendDmMessageParams = Schema.Schema.Type<typeof SendDmMessageParamsSchema>
+
+// --- Update DM Message Params ---
+
+export const UpdateDmMessageParamsSchema = Schema.Struct({
+  dm: DirectMessageIdentifier.annotations({
+    description: "Direct-message conversation: either the DM `_id` or a participant display name"
+  }),
+  messageId: MessageId.annotations({
+    description: "Message ID to update"
+  }),
+  body: NonEmptyString.annotations({
+    description: "New message body (markdown supported)"
+  })
+}).annotations({
+  title: "UpdateDmMessageParams",
+  description: "Parameters for updating a direct-message message"
+})
+
+export type UpdateDmMessageParams = Schema.Schema.Type<typeof UpdateDmMessageParamsSchema>
+
+// --- Delete DM Message Params ---
+
+export const DeleteDmMessageParamsSchema = Schema.Struct({
+  dm: DirectMessageIdentifier.annotations({
+    description: "Direct-message conversation: either the DM `_id` or a participant display name"
+  }),
+  messageId: MessageId.annotations({
+    description: "Message ID to delete"
+  })
+}).annotations({
+  title: "DeleteDmMessageParams",
+  description: "Parameters for deleting a direct-message message"
+})
+
+export type DeleteDmMessageParams = Schema.Schema.Type<typeof DeleteDmMessageParamsSchema>
+
+// --- JSON Schemas for MCP ---
+
+export const listDmMessagesParamsJsonSchema = JSONSchema.make(ListDmMessagesParamsSchema)
+export const sendDmMessageParamsJsonSchema = JSONSchema.make(SendDmMessageParamsSchema)
+export const updateDmMessageParamsJsonSchema = JSONSchema.make(UpdateDmMessageParamsSchema)
+export const deleteDmMessageParamsJsonSchema = JSONSchema.make(DeleteDmMessageParamsSchema)
+
+// --- Parsers ---
+
+export const parseListDmMessagesParams = Schema.decodeUnknown(ListDmMessagesParamsSchema)
+export const parseSendDmMessageParams = Schema.decodeUnknown(SendDmMessageParamsSchema)
+export const parseUpdateDmMessageParams = Schema.decodeUnknown(UpdateDmMessageParamsSchema)
+export const parseDeleteDmMessageParams = Schema.decodeUnknown(DeleteDmMessageParamsSchema)
+
+// --- Result Types ---
+
+export interface ListDmMessagesResult {
+  readonly messages: ReadonlyArray<MessageSummary>
+  readonly total: number
+}
+
+export interface SendDmMessageResult {
+  readonly id: MessageId
+  readonly dmId: ChannelId
+}
+
+export interface UpdateDmMessageResult {
+  readonly id: MessageId
+  readonly updated: boolean
+}
+
+export interface DeleteDmMessageResult {
+  readonly id: MessageId
+  readonly deleted: boolean
+}

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -671,6 +671,29 @@ export {
 } from "./channels.js"
 
 export {
+  type DeleteDmMessageParams,
+  deleteDmMessageParamsJsonSchema,
+  DeleteDmMessageParamsSchema,
+  type DeleteDmMessageResult,
+  type ListDmMessagesParams,
+  listDmMessagesParamsJsonSchema,
+  ListDmMessagesParamsSchema,
+  type ListDmMessagesResult,
+  parseDeleteDmMessageParams,
+  parseListDmMessagesParams,
+  parseSendDmMessageParams,
+  parseUpdateDmMessageParams,
+  type SendDmMessageParams,
+  sendDmMessageParamsJsonSchema,
+  SendDmMessageParamsSchema,
+  type SendDmMessageResult,
+  type UpdateDmMessageParams,
+  updateDmMessageParamsJsonSchema,
+  UpdateDmMessageParamsSchema,
+  type UpdateDmMessageResult
+} from "./direct-messages.js"
+
+export {
   type CreateEventParams,
   createEventParamsJsonSchema,
   CreateEventParamsSchema,

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -281,6 +281,15 @@ export type TemplateIdentifier = Schema.Schema.Type<typeof TemplateIdentifier>
 export const ChannelIdentifier = NonEmptyString.pipe(Schema.brand("ChannelIdentifier"))
 export type ChannelIdentifier = Schema.Schema.Type<typeof ChannelIdentifier>
 
+/**
+ * Identifier for a direct-message conversation. Accepts either:
+ * - the DM `_id` (e.g. `69fe02a3671a9bf783dc94fb`), or
+ * - a participant display name (e.g. `Kerr,Shannon`) — resolves to the DM
+ *   that has both the authenticated account and the named participant.
+ */
+export const DirectMessageIdentifier = NonEmptyString.pipe(Schema.brand("DirectMessageIdentifier"))
+export type DirectMessageIdentifier = Schema.Schema.Type<typeof DirectMessageIdentifier>
+
 export const TeamspaceIdentifier = NonEmptyString.pipe(Schema.brand("TeamspaceIdentifier"))
 export type TeamspaceIdentifier = Schema.Schema.Type<typeof TeamspaceIdentifier>
 

--- a/src/huly/errors-messaging.ts
+++ b/src/huly/errors-messaging.ts
@@ -20,6 +20,23 @@ export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundErro
 }
 
 /**
+ * Direct-message conversation not found in the workspace.
+ *
+ * Raised when a `dm` identifier (DM `_id` or participant display name) does
+ * not resolve to an existing DM the authenticated account is a member of.
+ */
+export class DirectMessageNotFoundError extends Schema.TaggedError<DirectMessageNotFoundError>()(
+  "DirectMessageNotFoundError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Direct message '${this.identifier}' not found`
+  }
+}
+
+/**
  * Message not found in the channel.
  */
 export class MessageNotFoundError extends Schema.TaggedError<MessageNotFoundError>()(

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -51,6 +51,7 @@ import { FunnelNotFoundError, LeadNotFoundError } from "./errors-leads.js"
 import {
   ActivityMessageNotFoundError,
   ChannelNotFoundError,
+  DirectMessageNotFoundError,
   MessageNotFoundError,
   ReactionNotFoundError,
   SavedMessageNotFoundError,
@@ -89,6 +90,7 @@ export {
   ComponentNotFoundError,
   CustomFieldNotFoundError,
   CustomFieldObjectNotFoundError,
+  DirectMessageNotFoundError,
   DocumentEmptyContentError,
   DocumentNotFoundError,
   DocumentTextMultipleMatchesError,
@@ -162,6 +164,7 @@ export type HulyDomainError =
   | CommentNotFoundError
   | MilestoneNotFoundError
   | ChannelNotFoundError
+  | DirectMessageNotFoundError
   | MessageNotFoundError
   | ThreadReplyNotFoundError
   | CalendarNotAccessibleError
@@ -223,6 +226,7 @@ export const HulyDomainError: Schema.Union<
     typeof CommentNotFoundError,
     typeof MilestoneNotFoundError,
     typeof ChannelNotFoundError,
+    typeof DirectMessageNotFoundError,
     typeof MessageNotFoundError,
     typeof ThreadReplyNotFoundError,
     typeof CalendarNotAccessibleError,
@@ -280,6 +284,7 @@ export const HulyDomainError: Schema.Union<
   CommentNotFoundError,
   MilestoneNotFoundError,
   ChannelNotFoundError,
+  DirectMessageNotFoundError,
   MessageNotFoundError,
   ThreadReplyNotFoundError,
   CalendarNotAccessibleError,

--- a/src/huly/operations/channels.ts
+++ b/src/huly/operations/channels.ts
@@ -157,7 +157,7 @@ export const buildSocialIdToPersonNameMap = (
  * Build a map from AccountUuid to Person name by querying Employee.
  * Employee has personUuid field that matches AccountUuid.
  */
-const buildAccountUuidToNameMap = (
+export const buildAccountUuidToNameMap = (
   client: HulyClient["Type"],
   accountUuids: Array<HulyAccountUuid>
 ): Effect.Effect<Map<string, string>, HulyClientError> =>

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -1,0 +1,265 @@
+/**
+ * Direct-message conversation operations: list / send / update / delete
+ * messages in a Huly DM conversation.
+ *
+ * A DM `dm` identifier accepts either:
+ * - the DM `_id` (an opaque chunter Space ref), or
+ * - a participant display name (e.g. `Kerr,Shannon`) — resolved to a DM whose
+ *   `members` includes the AccountUuid of the named person.
+ *
+ * @module
+ */
+import type { ChatMessage, DirectMessage as HulyDirectMessage } from "@hcengineering/chunter"
+import type { Employee as HulyEmployee } from "@hcengineering/contact"
+import {
+  type AccountUuid as HulyAccountUuid,
+  type AttachedData,
+  type DocumentUpdate,
+  generateId,
+  type Ref,
+  SortingOrder
+} from "@hcengineering/core"
+import { Clock, Effect } from "effect"
+
+import type { MessageSummary } from "../../domain/schemas/channels.js"
+import type {
+  DeleteDmMessageParams,
+  DeleteDmMessageResult,
+  ListDmMessagesParams,
+  ListDmMessagesResult,
+  SendDmMessageParams,
+  SendDmMessageResult,
+  UpdateDmMessageParams,
+  UpdateDmMessageResult
+} from "../../domain/schemas/direct-messages.js"
+import { ChannelId, MessageId, PersonName } from "../../domain/schemas/shared.js"
+import { HulyClient, type HulyClientError } from "../client.js"
+import { DirectMessageNotFoundError, MessageNotFoundError } from "../errors.js"
+import { buildAccountUuidToNameMap } from "./channels.js"
+import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
+import { clampLimit } from "./query-helpers.js"
+import { toRef } from "./sdk-boundary.js"
+
+import { chunter, contact } from "../huly-plugins.js"
+
+// --- Error Types ---
+
+type FindDirectMessageError =
+  | HulyClientError
+  | DirectMessageNotFoundError
+
+type ListDmMessagesError = FindDirectMessageError
+
+type SendDmMessageError = FindDirectMessageError
+
+type UpdateDmMessageError =
+  | FindDirectMessageError
+  | MessageNotFoundError
+
+type DeleteDmMessageError = UpdateDmMessageError
+
+// --- Helpers ---
+
+/**
+ * Resolve a `dm` identifier to a Huly DirectMessage document.
+ *
+ * Resolution order:
+ * 1. Treat the identifier as a DM `_id`. If a DM with that ref exists, return it.
+ * 2. Treat the identifier as a participant display name. Look up Employees with
+ *    that exact name to obtain candidate AccountUuids, then find a DM whose
+ *    `members` array contains any of those AccountUuids.
+ *
+ * If neither lookup yields a hit, fail with `DirectMessageNotFoundError`.
+ */
+export const findDirectMessage = (
+  identifier: string
+): Effect.Effect<
+  { client: HulyClient["Type"]; dm: HulyDirectMessage },
+  FindDirectMessageError,
+  HulyClient
+> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+
+    const byId = yield* client.findOne<HulyDirectMessage>(
+      chunter.class.DirectMessage,
+      { _id: toRef<HulyDirectMessage>(identifier) }
+    )
+
+    if (byId !== undefined) {
+      return { client, dm: byId }
+    }
+
+    const employees = yield* client.findAll<HulyEmployee>(
+      contact.mixin.Employee,
+      { name: identifier }
+    )
+
+    const accountUuids = employees
+      .map((e) => e.personUuid)
+      .filter((u): u is HulyAccountUuid => u !== undefined)
+
+    if (accountUuids.length === 0) {
+      return yield* new DirectMessageNotFoundError({ identifier })
+    }
+
+    const byMember = yield* client.findOne<HulyDirectMessage>(
+      chunter.class.DirectMessage,
+      { members: { $in: accountUuids } }
+    )
+
+    if (byMember === undefined) {
+      return yield* new DirectMessageNotFoundError({ identifier })
+    }
+
+    return { client, dm: byMember }
+  })
+
+const findDirectMessageMessage = (
+  params: { dm: string; messageId: string }
+): Effect.Effect<
+  { client: HulyClient["Type"]; dm: HulyDirectMessage; message: ChatMessage },
+  FindDirectMessageError | MessageNotFoundError,
+  HulyClient
+> =>
+  Effect.gen(function*() {
+    const { client, dm } = yield* findDirectMessage(params.dm)
+
+    const message = yield* client.findOne<ChatMessage>(
+      chunter.class.ChatMessage,
+      {
+        _id: toRef<ChatMessage>(params.messageId),
+        space: dm._id
+      }
+    )
+
+    if (message === undefined) {
+      return yield* new MessageNotFoundError({
+        messageId: params.messageId,
+        channel: params.dm
+      })
+    }
+
+    return { client, dm, message }
+  })
+
+// --- Operations ---
+
+/**
+ * List messages in a DM conversation, newest first.
+ */
+export const listDirectMessageMessages = (
+  params: ListDmMessagesParams
+): Effect.Effect<ListDmMessagesResult, ListDmMessagesError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, dm } = yield* findDirectMessage(params.dm)
+    const markupUrlConfig = client.markupUrlConfig
+
+    const limit = clampLimit(params.limit)
+
+    const messages = yield* client.findAll<ChatMessage>(
+      chunter.class.ChatMessage,
+      { space: dm._id },
+      {
+        limit,
+        sort: { createdOn: SortingOrder.Descending }
+      }
+    )
+
+    const total = messages.total
+
+    const accountUuidToName = yield* buildAccountUuidToNameMap(client, dm.members)
+
+    const summaries: Array<MessageSummary> = messages.map((msg) => {
+      const senderName = accountUuidToName.get(msg.modifiedBy)
+      return {
+        id: MessageId.make(msg._id),
+        body: markupToMarkdownString(msg.message, markupUrlConfig),
+        sender: senderName !== undefined ? PersonName.make(senderName) : undefined,
+        senderId: msg.modifiedBy,
+        createdOn: msg.createdOn,
+        modifiedOn: msg.modifiedOn,
+        editedOn: msg.editedOn,
+        replies: msg.replies
+      }
+    })
+
+    return { messages: summaries, total }
+  })
+
+/**
+ * Send a message to a DM conversation.
+ */
+export const sendDirectMessage = (
+  params: SendDmMessageParams
+): Effect.Effect<SendDmMessageResult, SendDmMessageError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, dm } = yield* findDirectMessage(params.dm)
+    const markupUrlConfig = client.markupUrlConfig
+
+    const messageId: Ref<ChatMessage> = generateId()
+    const markup = markdownToMarkupString(params.body, markupUrlConfig)
+
+    const messageData: AttachedData<ChatMessage> = {
+      message: markup,
+      attachments: 0
+    }
+
+    yield* client.addCollection(
+      chunter.class.ChatMessage,
+      dm._id,
+      dm._id,
+      chunter.class.DirectMessage,
+      "messages",
+      messageData,
+      messageId
+    )
+
+    return { id: MessageId.make(messageId), dmId: ChannelId.make(dm._id) }
+  })
+
+/**
+ * Update an existing DM message. Only the body can be modified.
+ */
+export const updateDirectMessage = (
+  params: UpdateDmMessageParams
+): Effect.Effect<UpdateDmMessageResult, UpdateDmMessageError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, dm, message } = yield* findDirectMessageMessage(params)
+    const markupUrlConfig = client.markupUrlConfig
+
+    const markup = markdownToMarkupString(params.body, markupUrlConfig)
+
+    const now = yield* Clock.currentTimeMillis
+    const updateOps: DocumentUpdate<ChatMessage> = {
+      message: markup,
+      editedOn: now
+    }
+
+    yield* client.updateDoc(
+      chunter.class.ChatMessage,
+      dm._id,
+      message._id,
+      updateOps
+    )
+
+    return { id: MessageId.make(message._id), updated: true }
+  })
+
+/**
+ * Permanently delete a DM message.
+ */
+export const deleteDirectMessage = (
+  params: DeleteDmMessageParams
+): Effect.Effect<DeleteDmMessageResult, DeleteDmMessageError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, dm, message } = yield* findDirectMessageMessage(params)
+
+    yield* client.removeDoc(
+      chunter.class.ChatMessage,
+      dm._id,
+      message._id
+    )
+
+    return { id: MessageId.make(message._id), deleted: true }
+  })

--- a/src/mcp/tools/channels.ts
+++ b/src/mcp/tools/channels.ts
@@ -3,29 +3,37 @@ import {
   createChannelParamsJsonSchema,
   deleteChannelMessageParamsJsonSchema,
   deleteChannelParamsJsonSchema,
+  deleteDmMessageParamsJsonSchema,
   deleteThreadReplyParamsJsonSchema,
   getChannelParamsJsonSchema,
   listChannelMessagesParamsJsonSchema,
   listChannelsParamsJsonSchema,
   listDirectMessagesParamsJsonSchema,
+  listDmMessagesParamsJsonSchema,
   listThreadRepliesParamsJsonSchema,
   parseAddThreadReplyParams,
   parseCreateChannelParams,
   parseDeleteChannelMessageParams,
   parseDeleteChannelParams,
+  parseDeleteDmMessageParams,
   parseDeleteThreadReplyParams,
   parseGetChannelParams,
   parseListChannelMessagesParams,
   parseListChannelsParams,
   parseListDirectMessagesParams,
+  parseListDmMessagesParams,
   parseListThreadRepliesParams,
   parseSendChannelMessageParams,
+  parseSendDmMessageParams,
   parseUpdateChannelMessageParams,
   parseUpdateChannelParams,
+  parseUpdateDmMessageParams,
   parseUpdateThreadReplyParams,
   sendChannelMessageParamsJsonSchema,
+  sendDmMessageParamsJsonSchema,
   updateChannelMessageParamsJsonSchema,
   updateChannelParamsJsonSchema,
+  updateDmMessageParamsJsonSchema,
   updateThreadReplyParamsJsonSchema
 } from "../../domain/schemas.js"
 import {
@@ -40,6 +48,12 @@ import {
   updateChannel,
   updateChannelMessage
 } from "../../huly/operations/channels.js"
+import {
+  deleteDirectMessage,
+  listDirectMessageMessages,
+  sendDirectMessage,
+  updateDirectMessage
+} from "../../huly/operations/direct-messages.js"
 import {
   addThreadReply,
   deleteThreadReply,
@@ -160,6 +174,52 @@ export const channelTools: ReadonlyArray<RegisteredTool> = [
       "list_direct_messages",
       parseListDirectMessagesParams,
       listDirectMessages
+    )
+  },
+  {
+    name: "list_dm_messages",
+    description:
+      "List messages in a direct-message conversation, newest first. The `dm` argument accepts either the DM `_id` or a participant display name (e.g. `Kerr,Shannon`); a name resolves to the DM whose members include that person's account.",
+    category: CATEGORY,
+    inputSchema: listDmMessagesParamsJsonSchema,
+    handler: createToolHandler(
+      "list_dm_messages",
+      parseListDmMessagesParams,
+      listDirectMessageMessages
+    )
+  },
+  {
+    name: "send_dm_message",
+    description:
+      "Send a message to a direct-message conversation. The `dm` argument accepts either the DM `_id` or a participant display name. Message body supports markdown formatting.",
+    category: CATEGORY,
+    inputSchema: sendDmMessageParamsJsonSchema,
+    handler: createToolHandler(
+      "send_dm_message",
+      parseSendDmMessageParams,
+      sendDirectMessage
+    )
+  },
+  {
+    name: "update_dm_message",
+    description: "Update a direct-message message. Only the body can be modified.",
+    category: CATEGORY,
+    inputSchema: updateDmMessageParamsJsonSchema,
+    handler: createToolHandler(
+      "update_dm_message",
+      parseUpdateDmMessageParams,
+      updateDirectMessage
+    )
+  },
+  {
+    name: "delete_dm_message",
+    description: "Permanently delete a direct-message message. This action cannot be undone.",
+    category: CATEGORY,
+    inputSchema: deleteDmMessageParamsJsonSchema,
+    handler: createToolHandler(
+      "delete_dm_message",
+      parseDeleteDmMessageParams,
+      deleteDirectMessage
     )
   },
   {

--- a/test/helpers/brands.ts
+++ b/test/helpers/brands.ts
@@ -26,6 +26,7 @@ import type {
   ComponentIdentifier,
   ComponentLabel,
   ContactProvider,
+  DirectMessageIdentifier,
   DocumentId,
   DocumentIdentifier,
   Email,
@@ -150,6 +151,7 @@ export const componentIdentifier = (s: string) => s as ComponentIdentifier
 export const milestoneIdentifier = (s: string) => s as MilestoneIdentifier
 export const templateIdentifier = (s: string) => s as TemplateIdentifier
 export const channelIdentifier = (s: string) => s as ChannelIdentifier
+export const directMessageIdentifier = (s: string) => s as DirectMessageIdentifier
 export const teamspaceIdentifier = (s: string) => s as TeamspaceIdentifier
 export const documentIdentifier = (s: string) => s as DocumentIdentifier
 export const tagIdentifier = (s: string) => s as TagIdentifier
@@ -188,6 +190,7 @@ export type {
   ComponentIdentifier,
   ComponentLabel,
   ContactProvider,
+  DirectMessageIdentifier,
   DocumentId,
   DocumentIdentifier,
   Email,

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -11,6 +11,7 @@ import {
   ChannelNotFoundError,
   CommentNotFoundError,
   ComponentNotFoundError,
+  DirectMessageNotFoundError,
   DocumentNotFoundError,
   EventNotFoundError,
   FileFetchError,
@@ -263,6 +264,21 @@ describe("Huly Errors", () => {
       Effect.gen(function*() {
         const error = new ChannelNotFoundError({ identifier: "general" })
         expect(error.message).toBe("Channel 'general' not found")
+      }))
+  })
+
+  describe("DirectMessageNotFoundError", () => {
+    it.effect("creates with identifier", () =>
+      Effect.gen(function*() {
+        const error = new DirectMessageNotFoundError({ identifier: "Kerr,Shannon" })
+        expect(error._tag).toBe("DirectMessageNotFoundError")
+        expect(error.identifier).toBe("Kerr,Shannon")
+      }))
+
+    it.effect("generates message from fields", () =>
+      Effect.gen(function*() {
+        const error = new DirectMessageNotFoundError({ identifier: "Kerr,Shannon" })
+        expect(error.message).toBe("Direct message 'Kerr,Shannon' not found")
       }))
   })
 
@@ -639,6 +655,8 @@ describe("Huly Errors", () => {
               return `milestone:${error.identifier}`
             case "ChannelNotFoundError":
               return `channel:${error.identifier}`
+            case "DirectMessageNotFoundError":
+              return `dm:${error.identifier}`
             case "MessageNotFoundError":
               return `message:${error.messageId}`
             case "ThreadReplyNotFoundError":
@@ -737,6 +755,7 @@ describe("Huly Errors", () => {
         ).toBe("comment:c-1")
         expect(matchError(new MilestoneNotFoundError({ identifier: "m-1", project: "P" }))).toBe("milestone:m-1")
         expect(matchError(new ChannelNotFoundError({ identifier: "ch-1" }))).toBe("channel:ch-1")
+        expect(matchError(new DirectMessageNotFoundError({ identifier: "dm-1" }))).toBe("dm:dm-1")
         expect(matchError(new MessageNotFoundError({ messageId: "msg-1", channel: "ch-1" }))).toBe("message:msg-1")
         expect(matchError(new ThreadReplyNotFoundError({ replyId: "r-1", messageId: "msg-1" }))).toBe("reply:r-1")
         expect(matchError(new CalendarNotAccessibleError({ calendarId: "cal-1" }))).toBe("calendar:cal-1")

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -294,7 +294,7 @@ describe("listDirectMessageMessages", () => {
         _id: "msg-1" as Ref<ChatMessage>,
         space: "dm-1" as Ref<Space>,
         message: "hi",
-        // eslint-disable-next-line no-restricted-syntax -- AccountUuid → PersonId at the test boundary; both are branded strings, runtime safe
+        // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; AccountUuid and PersonId are both `string` here, so the cast is safe at this test boundary
         modifiedBy: accountUuid as unknown as PersonId
       })
       const employee = makeEmployee({

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -1,0 +1,462 @@
+import { describe, it } from "@effect/vitest"
+import type { ChatMessage, DirectMessage as HulyDirectMessage } from "@hcengineering/chunter"
+import type { Employee as HulyEmployee } from "@hcengineering/contact"
+import {
+  type AccountUuid as HulyAccountUuid,
+  type Doc,
+  type PersonId,
+  type Ref,
+  type Space,
+  toFindResult
+} from "@hcengineering/core"
+import { Effect, Exit } from "effect"
+import { expect } from "vitest"
+
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import type { DirectMessageNotFoundError, MessageNotFoundError } from "../../../src/huly/errors.js"
+import {
+  deleteDirectMessage,
+  findDirectMessage,
+  listDirectMessageMessages,
+  sendDirectMessage,
+  updateDirectMessage
+} from "../../../src/huly/operations/direct-messages.js"
+import { directMessageIdentifier, messageBrandId } from "../../helpers/brands.js"
+
+import { chunter, contact } from "../../../src/huly/huly-plugins.js"
+
+// --- Factory helpers (mirror the channels.test.ts pattern, no module mocks) ---
+
+const asEmployee = (v: unknown) => v as HulyEmployee
+
+const makeDirectMessage = (overrides?: Partial<HulyDirectMessage>): HulyDirectMessage => {
+  const result: HulyDirectMessage = {
+    _id: "dm-1" as Ref<HulyDirectMessage>,
+    _class: chunter.class.DirectMessage,
+    space: "space-1" as Ref<Space>,
+    name: "",
+    description: "",
+    private: true,
+    archived: false,
+    members: [],
+    messages: 0,
+    modifiedBy: "user-1" as PersonId,
+    modifiedOn: 0,
+    createdBy: "user-1" as PersonId,
+    createdOn: 0,
+    ...overrides
+  }
+  return result
+}
+
+const makeMessage = (overrides?: Partial<ChatMessage>): ChatMessage => {
+  const result: ChatMessage = {
+    _id: "msg-1" as Ref<ChatMessage>,
+    _class: chunter.class.ChatMessage,
+    space: "dm-1" as Ref<Space>,
+    attachedTo: "dm-1" as Ref<HulyDirectMessage>,
+    attachedToClass: chunter.class.DirectMessage,
+    collection: "messages",
+    message: "hello",
+    attachments: 0,
+    modifiedBy: "user-1" as PersonId,
+    modifiedOn: 0,
+    createdBy: "user-1" as PersonId,
+    createdOn: 0,
+    ...overrides
+  }
+  return result
+}
+
+const makeEmployee = (overrides?: Partial<HulyEmployee>): HulyEmployee =>
+  asEmployee({
+    _id: "employee-1" as Ref<HulyEmployee>,
+    _class: contact.mixin.Employee,
+    space: "space-1" as Ref<Space>,
+    name: "Kerr,Shannon",
+    active: true,
+    modifiedBy: "user-1" as PersonId,
+    modifiedOn: 0,
+    createdBy: "user-1" as PersonId,
+    createdOn: 0,
+    ...overrides
+  })
+
+interface MockConfig {
+  directMessages?: Array<HulyDirectMessage>
+  messages?: Array<ChatMessage>
+  employees?: Array<HulyEmployee>
+  captureAddCollection?: { attributes?: Record<string, unknown>; id?: string }
+  captureUpdateDoc?: { operations?: Record<string, unknown> }
+  captureRemoveDoc?: { called?: boolean }
+}
+
+const createTestLayer = (config: MockConfig) => {
+  const directMessages = config.directMessages ?? []
+  const messages = config.messages ?? []
+  const employees = config.employees ?? []
+
+  const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown) => {
+    if (_class === chunter.class.DirectMessage) {
+      const q = query as { members?: { $in?: Array<HulyAccountUuid> } }
+      let result = [...directMessages]
+      if (q.members?.$in) {
+        const wanted = q.members.$in
+        result = result.filter((dm) => dm.members.some((m) => wanted.includes(m)))
+      }
+      return Effect.succeed(toFindResult(result))
+    }
+    if (_class === chunter.class.ChatMessage) {
+      const q = query as { space?: Ref<Space> }
+      const filtered = q.space ? messages.filter((m) => m.space === q.space) : messages
+      return Effect.succeed(toFindResult(filtered))
+    }
+    if (_class === contact.mixin.Employee) {
+      const q = query as { name?: string; personUuid?: { $in?: Array<HulyAccountUuid> } }
+      let result = [...employees]
+      if (q.name !== undefined) {
+        result = result.filter((e) => e.name === q.name)
+      }
+      if (q.personUuid?.$in !== undefined) {
+        const wanted = q.personUuid.$in
+        result = result.filter((e) => e.personUuid !== undefined && wanted.includes(e.personUuid))
+      }
+      return Effect.succeed(toFindResult(result))
+    }
+    return Effect.succeed(toFindResult([]))
+  }) as HulyClientOperations["findAll"]
+
+  const findOneImpl: HulyClientOperations["findOne"] = ((_class: unknown, query: unknown) => {
+    if (_class === chunter.class.DirectMessage) {
+      const q = query as { _id?: Ref<HulyDirectMessage>; members?: { $in?: Array<HulyAccountUuid> } }
+      const found = directMessages.find((dm) => {
+        if (q._id !== undefined) return dm._id === q._id
+        if (q.members?.$in !== undefined) {
+          const wanted = q.members.$in
+          return dm.members.some((m) => wanted.includes(m))
+        }
+        return false
+      })
+      return Effect.succeed(found)
+    }
+    if (_class === chunter.class.ChatMessage) {
+      const q = query as { _id?: Ref<ChatMessage>; space?: Ref<Space> }
+      const found = messages.find((m) => (!q._id || m._id === q._id) && (!q.space || m.space === q.space))
+      return Effect.succeed(found)
+    }
+    return Effect.succeed(undefined)
+  }) as HulyClientOperations["findOne"]
+
+  const addCollectionImpl: HulyClientOperations["addCollection"] = ((
+    _class: unknown,
+    _space: unknown,
+    _attachedTo: unknown,
+    _attachedToClass: unknown,
+    _collection: unknown,
+    attributes: unknown,
+    id?: unknown
+  ) => {
+    if (config.captureAddCollection) {
+      config.captureAddCollection.attributes = attributes as Record<string, unknown>
+      config.captureAddCollection.id = id as string
+    }
+    return Effect.succeed((id ?? "new-msg-id") as Ref<Doc>)
+  }) as HulyClientOperations["addCollection"]
+
+  const updateDocImpl: HulyClientOperations["updateDoc"] = ((
+    _class: unknown,
+    _space: unknown,
+    _objectId: unknown,
+    operations: unknown
+  ) => {
+    if (config.captureUpdateDoc) {
+      config.captureUpdateDoc.operations = operations as Record<string, unknown>
+    }
+    return Effect.succeed({})
+  }) as HulyClientOperations["updateDoc"]
+
+  const removeDocImpl: HulyClientOperations["removeDoc"] = ((
+    _class: unknown,
+    _space: unknown,
+    _objectId: unknown
+  ) => {
+    if (config.captureRemoveDoc) {
+      config.captureRemoveDoc.called = true
+    }
+    return Effect.succeed({})
+  }) as HulyClientOperations["removeDoc"]
+
+  const createDocImpl: HulyClientOperations["createDoc"] = ((
+    _class: unknown,
+    _space: unknown,
+    _attributes: unknown,
+    id?: unknown
+  ) => Effect.succeed((id ?? "new-id") as Ref<Doc>)) as HulyClientOperations["createDoc"]
+
+  return HulyClient.testLayer({
+    findAll: findAllImpl,
+    findOne: findOneImpl,
+    addCollection: addCollectionImpl,
+    updateDoc: updateDocImpl,
+    removeDoc: removeDocImpl,
+    createDoc: createDocImpl
+  })
+}
+
+// --- Tests ---
+
+describe("findDirectMessage", () => {
+  it.effect("resolves by DM _id", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-42" as Ref<HulyDirectMessage> })
+      const layer = createTestLayer({ directMessages: [dm] })
+
+      const result = yield* findDirectMessage("dm-42").pipe(Effect.provide(layer))
+
+      expect(result.dm._id).toBe("dm-42")
+    }))
+
+  it.effect("resolves by participant display name via Employee.personUuid", () =>
+    Effect.gen(function*() {
+      const accountUuid = "account-shannon" as HulyAccountUuid
+      const dm = makeDirectMessage({
+        _id: "dm-named" as Ref<HulyDirectMessage>,
+        members: [accountUuid]
+      })
+      const employee = makeEmployee({
+        name: "Kerr,Shannon",
+        personUuid: accountUuid
+      })
+      const layer = createTestLayer({ directMessages: [dm], employees: [employee] })
+
+      const result = yield* findDirectMessage("Kerr,Shannon").pipe(Effect.provide(layer))
+
+      expect(result.dm._id).toBe("dm-named")
+    }))
+
+  it.effect("fails with DirectMessageNotFoundError when name resolves to no Employee", () =>
+    Effect.gen(function*() {
+      const layer = createTestLayer({ directMessages: [], employees: [] })
+
+      const exit = yield* Effect.exit(findDirectMessage("Nobody,Here").pipe(Effect.provide(layer)))
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause.toString()
+        expect(error).toContain("DirectMessageNotFoundError")
+        expect(error).toContain("Nobody,Here")
+      }
+    }))
+
+  it.effect("fails when Employee exists but no DM has that member", () =>
+    Effect.gen(function*() {
+      const employee = makeEmployee({
+        name: "Solo,Stranger",
+        personUuid: "account-stranger" as HulyAccountUuid
+      })
+      const layer = createTestLayer({ directMessages: [], employees: [employee] })
+
+      const exit = yield* Effect.exit(findDirectMessage("Solo,Stranger").pipe(Effect.provide(layer)))
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }))
+
+  it.effect("ignores Employees with no personUuid during name resolution", () =>
+    Effect.gen(function*() {
+      const employeeNoUuid = asEmployee({
+        _id: "employee-no-uuid" as Ref<HulyEmployee>,
+        _class: contact.mixin.Employee,
+        space: "space-1" as Ref<Space>,
+        name: "Ghost,User",
+        active: true,
+        modifiedBy: "user-1" as PersonId,
+        modifiedOn: 0,
+        createdBy: "user-1" as PersonId,
+        createdOn: 0
+      })
+      const layer = createTestLayer({ directMessages: [], employees: [employeeNoUuid] })
+
+      const exit = yield* Effect.exit(findDirectMessage("Ghost,User").pipe(Effect.provide(layer)))
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }))
+})
+
+describe("listDirectMessageMessages", () => {
+  it.effect("returns messages with sender names resolved from DM members", () =>
+    Effect.gen(function*() {
+      const accountUuid = "account-shannon" as HulyAccountUuid
+      const dm = makeDirectMessage({
+        _id: "dm-1" as Ref<HulyDirectMessage>,
+        members: [accountUuid]
+      })
+      const message = makeMessage({
+        _id: "msg-1" as Ref<ChatMessage>,
+        space: "dm-1" as Ref<Space>,
+        message: "hi",
+        // eslint-disable-next-line no-restricted-syntax -- AccountUuid → PersonId at the test boundary; both are branded strings, runtime safe
+        modifiedBy: accountUuid as unknown as PersonId
+      })
+      const employee = makeEmployee({
+        name: "Kerr,Shannon",
+        personUuid: accountUuid
+      })
+      const layer = createTestLayer({
+        directMessages: [dm],
+        messages: [message],
+        employees: [employee]
+      })
+
+      const result = yield* listDirectMessageMessages({
+        dm: directMessageIdentifier("dm-1")
+      }).pipe(Effect.provide(layer))
+
+      expect(result.messages).toHaveLength(1)
+      expect(result.messages[0].body).toBe("hi")
+      expect(result.messages[0].sender).toBe("Kerr,Shannon")
+    }))
+
+  it.effect("omits sender when DM members do not cover the message author", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage>, members: [] })
+      const message = makeMessage({ space: "dm-1" as Ref<Space>, message: "anon" })
+      const layer = createTestLayer({ directMessages: [dm], messages: [message] })
+
+      const result = yield* listDirectMessageMessages({
+        dm: directMessageIdentifier("dm-1")
+      }).pipe(Effect.provide(layer))
+
+      expect(result.messages[0].sender).toBeUndefined()
+    }))
+
+  it.effect("propagates DirectMessageNotFoundError for unknown identifier", () =>
+    Effect.gen(function*() {
+      const layer = createTestLayer({})
+
+      const exit = yield* Effect.exit(
+        listDirectMessageMessages({ dm: directMessageIdentifier("nope") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }))
+})
+
+describe("sendDirectMessage", () => {
+  it.effect("addCollection is called with the DM as space and the message body as markup", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage> })
+      const capture: MockConfig["captureAddCollection"] = {}
+      const layer = createTestLayer({ directMessages: [dm], captureAddCollection: capture })
+
+      const result = yield* sendDirectMessage({
+        dm: directMessageIdentifier("dm-1"),
+        body: "hello world"
+      }).pipe(Effect.provide(layer))
+
+      expect(result.dmId).toBe("dm-1")
+      expect(typeof result.id).toBe("string")
+      expect(capture.attributes?.message).toBeDefined()
+    }))
+
+  it.effect("fails when DM cannot be resolved", () =>
+    Effect.gen(function*() {
+      const layer = createTestLayer({})
+
+      const exit = yield* Effect.exit(
+        sendDirectMessage({
+          dm: directMessageIdentifier("dm-missing"),
+          body: "hi"
+        }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }))
+})
+
+describe("updateDirectMessage", () => {
+  it.effect("updates an existing DM message body and stamps editedOn", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage> })
+      const message = makeMessage({
+        _id: "msg-1" as Ref<ChatMessage>,
+        space: "dm-1" as Ref<Space>
+      })
+      const capture: MockConfig["captureUpdateDoc"] = {}
+      const layer = createTestLayer({
+        directMessages: [dm],
+        messages: [message],
+        captureUpdateDoc: capture
+      })
+
+      const result = yield* updateDirectMessage({
+        dm: directMessageIdentifier("dm-1"),
+        messageId: messageBrandId("msg-1"),
+        body: "edited"
+      }).pipe(Effect.provide(layer))
+
+      expect(result.id).toBe("msg-1")
+      expect(result.updated).toBe(true)
+      expect(capture.operations).toBeDefined()
+      expect(capture.operations?.message).toBeDefined()
+      expect(capture.operations?.editedOn).toBeTypeOf("number")
+    }))
+
+  it.effect("fails with MessageNotFoundError when message id is unknown", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage> })
+      const layer = createTestLayer({ directMessages: [dm], messages: [] })
+
+      const exit: Exit.Exit<unknown, DirectMessageNotFoundError | MessageNotFoundError | unknown> = yield* Effect.exit(
+        updateDirectMessage({
+          dm: directMessageIdentifier("dm-1"),
+          messageId: messageBrandId("missing"),
+          body: "x"
+        }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("MessageNotFoundError")
+      }
+    }))
+})
+
+describe("deleteDirectMessage", () => {
+  it.effect("removeDoc is called for the resolved message", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage> })
+      const message = makeMessage({
+        _id: "msg-1" as Ref<ChatMessage>,
+        space: "dm-1" as Ref<Space>
+      })
+      const capture: MockConfig["captureRemoveDoc"] = {}
+      const layer = createTestLayer({
+        directMessages: [dm],
+        messages: [message],
+        captureRemoveDoc: capture
+      })
+
+      const result = yield* deleteDirectMessage({
+        dm: directMessageIdentifier("dm-1"),
+        messageId: messageBrandId("msg-1")
+      }).pipe(Effect.provide(layer))
+
+      expect(result.deleted).toBe(true)
+      expect(capture.called).toBe(true)
+    }))
+
+  it.effect("fails with MessageNotFoundError when message id is unknown", () =>
+    Effect.gen(function*() {
+      const dm = makeDirectMessage({ _id: "dm-1" as Ref<HulyDirectMessage> })
+      const layer = createTestLayer({ directMessages: [dm], messages: [] })
+
+      const exit = yield* Effect.exit(
+        deleteDirectMessage({
+          dm: directMessageIdentifier("dm-1"),
+          messageId: messageBrandId("missing")
+        }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }))
+})


### PR DESCRIPTION
Adds four MCP tools that fill an existing gap: `list_direct_messages` already enumerates DM conversations, but there's no way to read or send messages within them. This PR adds:

- `list_dm_messages`
- `send_dm_message`
- `update_dm_message`
- `delete_dm_message`

## Identifier resolution

The `dm` parameter accepts either:

- a DM `_id` (the chunter Space ref), or
- a participant display name like `Smith,Alice` — resolved by exact-matching `Employee.name`, mapping the `personUuid` to an `AccountUuid`, then finding a `DirectMessage` whose `members` array contains that account.

Name resolution means an LLM caller can address a DM by the human-friendly name without first having to enumerate conversations to obtain a UUID — matching the LLM-first design principle in `CLAUDE.md`.

## What changes

- New `DirectMessageNotFoundError` in `errors-messaging.ts`, registered in the `HulyDomainError` union and `Schema.Union`.
- New `DirectMessageIdentifier` brand in shared schemas.
- New `domain/schemas/direct-messages.ts` for DM params/results/JSON schemas/parsers; kept separate from `channels.ts` to honour the per-file size limit.
- New `huly/operations/direct-messages.ts` with `findDirectMessage` exposed for callers that want the resolution helper standalone, plus the four CRUD ops.
- Four tool registrations in `mcp/tools/channels.ts` (alongside `list_direct_messages` so all DM-related tools live together).
- 14 new unit tests using the existing DI-via-Layer test pattern (no module mocks, per the project's no-mocks rule). Tests cover both id and name lookup paths plus all four CRUD ops, including error branches.
- Test entry for the new error added to `errors.test.ts` (matching the channel/message error tests).

## Quality gate

`pnpm check-all` passes — build, typecheck, lint (eslint + jscpd + dprint), and the full test suite (1854 passing, including the 14 new ones).

Coverage was not run (`@vitest/coverage-v8` dev dep isn't installed in the lockfile here); happy to run + fix if you want me to add it for this PR.

## Verified end-to-end

Tested against a self-hosted Huly: read existing DMs by participant name, sent a reply, edited and deleted messages — all four tools work via the live MCP transport.
