### PR TITLE
feat: expose workbench url on contact responses

### DIFF
--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, Schema } from "effect"
 
-import type { ContactProvider, OrganizationId, PersonName } from "./shared.js"
+import type { ContactProvider, OrganizationId, PersonName, UrlString } from "./shared.js"
 import { Email, LimitParam, MemberReference, NonEmptyString, PersonId } from "./shared.js"
 
 // No codec needed — internal type, not used for runtime validation
@@ -9,6 +9,7 @@ export interface PersonSummary {
   readonly name: PersonName
   readonly city?: string | undefined
   readonly email?: Email | undefined
+  readonly url: UrlString
   readonly modifiedOn?: number | undefined
 }
 
@@ -26,6 +27,7 @@ export interface Person {
   readonly email?: Email | undefined
   readonly channels?: ReadonlyArray<{ readonly provider: ContactProvider; readonly value: string }> | undefined
   readonly organizations?: ReadonlyArray<OrganizationMembershipSummary> | undefined
+  readonly url: UrlString
   readonly modifiedOn?: number | undefined
   readonly createdOn?: number | undefined
 }
@@ -36,6 +38,7 @@ export interface EmployeeSummary {
   readonly email?: Email | undefined
   readonly position?: string | undefined
   readonly active: boolean
+  readonly url: UrlString
   readonly modifiedOn?: number | undefined
 }
 
@@ -44,6 +47,7 @@ export interface OrganizationSummary {
   readonly name: string
   readonly city?: string | undefined
   readonly members: number
+  readonly url: UrlString
   readonly modifiedOn?: number | undefined
 }
 
@@ -389,6 +393,7 @@ export interface GetOrganizationResult {
   readonly city?: string | undefined
   readonly description?: string | undefined
   readonly members: number
+  readonly url: UrlString
   readonly modifiedOn?: number | undefined
 }
 

--- a/src/huly/operations/organizations.ts
+++ b/src/huly/operations/organizations.ts
@@ -39,6 +39,7 @@ import {
 } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { leadClassIds } from "../lead-plugin.js"
+import { buildContactUrlFromConfig } from "../url-builders.js"
 import { batchGetEmailsForPersons, findPersonByEmail, findPersonById } from "./contacts-shared.js"
 import { clampLimit } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
@@ -152,13 +153,17 @@ export const listOrganizations = (
       }
     )
 
-    return orgs.map(org => ({
-      id: OrganizationId.make(org._id),
-      name: org.name,
-      city: org.city,
-      members: org.members,
-      modifiedOn: org.modifiedOn
-    }))
+    return orgs.map(org => {
+      const id = OrganizationId.make(org._id)
+      return {
+        id,
+        name: org.name,
+        city: org.city,
+        members: org.members,
+        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+        modifiedOn: org.modifiedOn
+      }
+    })
   })
 
 export const createOrganization = (
@@ -225,12 +230,14 @@ export const getOrganization = (
       : undefined
     /* eslint-enable no-restricted-syntax */
 
+    const id = OrganizationId.make(org._id)
     return {
-      id: OrganizationId.make(org._id),
+      id,
       name: org.name,
       city: org.city || undefined,
       description: descriptionText,
       members: org.members,
+      url: buildContactUrlFromConfig(client.documentUrlConfig, id),
       modifiedOn: org.modifiedOn
     }
   })

--- a/src/huly/operations/persons.ts
+++ b/src/huly/operations/persons.ts
@@ -39,6 +39,7 @@ import { ContactProvider, Email, OrganizationId, PersonId, PersonName } from "..
 import { HulyClient, type HulyClientError } from "../client.js"
 import { PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
+import { buildContactUrlFromConfig } from "../url-builders.js"
 import { batchGetEmailsForPersons, findPersonByEmail, findPersonById } from "./contacts-shared.js"
 import { clampLimit, escapeLikeWildcards } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
@@ -142,11 +143,13 @@ export const listPersons = (
 
     return persons.map(person => {
       const emailValue = emailMap.get(person._id)
+      const id = PersonId.make(person._id)
       return {
-        id: PersonId.make(person._id),
+        id,
         name: PersonName.make(person.name),
         city: person.city,
         email: emailValue !== undefined ? Email.make(emailValue) : undefined,
+        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
         modifiedOn: person.modifiedOn
       }
     })
@@ -179,9 +182,10 @@ export const getPerson = (
 
     const { firstName, lastName } = parseName(person.name)
     const emailChannel = channels.find(c => c.provider === contact.channelProvider.Email)
+    const id = PersonId.make(person._id)
 
     return {
-      id: PersonId.make(person._id),
+      id,
       name: PersonName.make(person.name),
       firstName,
       lastName,
@@ -192,6 +196,7 @@ export const getPerson = (
         value: c.value
       })),
       organizations: organizations.length > 0 ? organizations : undefined,
+      url: buildContactUrlFromConfig(client.documentUrlConfig, id),
       modifiedOn: person.modifiedOn,
       createdOn: person.createdOn
     }
@@ -314,12 +319,14 @@ export const listEmployees = (
 
     return employees.map(emp => {
       const emailValue = emailMap.get(emp._id)
+      const id = PersonId.make(emp._id)
       return {
-        id: PersonId.make(emp._id),
+        id,
         name: PersonName.make(emp.name),
         email: emailValue !== undefined ? Email.make(emailValue) : undefined,
         position: emp.position ?? undefined,
         active: emp.active,
+        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
         modifiedOn: emp.modifiedOn
       }
     })

--- a/src/huly/url-builders.ts
+++ b/src/huly/url-builders.ts
@@ -1,18 +1,18 @@
 /**
  * URL builders for Huly web-app links.
  *
- * The Huly web app routes documents as:
- *   <baseUrl>/workbench/<workspaceUrlSlug>/document/<title-slug>-<id>
- *
- * Persons and organizations both route through the contact path:
- *   <baseUrl>/workbench/<workspaceUrlSlug>/contact/<id>
+ * Routes:
+ *   document: <baseUrl>/workbench/<workspaceUrlSlug>/document/<title-slug>-<id>
+ *   contact:  <baseUrl>/workbench/<workspaceUrlSlug>/contact/<id>
  *
  * `workspaceUrlSlug` comes from `WorkspaceLoginInfo.workspaceUrl` on the
  * account-client (not the `WorkspaceUuid` — that's a different identifier and
  * loops back to the login screen when used in URLs).
  *
- * The same `DocumentUrlConfig` (baseUrl + workspaceUrlSlug) is reused for
- * contact URLs since both kinds of link share those two inputs.
+ * The contact path segment is the workbench application alias registered in
+ * upstream platform; see
+ * https://github.com/hcengineering/platform/blob/3d469f0109ae0f8efd3f1b7efd6ca7ab141c8202/models/contact/src/index.ts#L448
+ * (`alias: contactId`, where `contactId === "contact"`).
  *
  * @module
  */
@@ -66,10 +66,8 @@ export const buildDocumentUrlFromConfig = (config: DocumentUrlConfig, title: str
   buildDocumentUrl(config.baseUrl, config.workspaceUrlSlug, title, id)
 
 /**
- * Build a Huly web-app URL for a person or organization. Both share the
- * `<baseUrl>/workbench/<workspaceUrlSlug>/contact/<id>` shape; no slug step
- * is needed because the contact id is the only path-sensitive component.
- * Trailing slashes on `baseUrl` are tolerated.
+ * Build a Huly web-app URL for a person or organization. Trailing slashes on
+ * `baseUrl` are tolerated.
  */
 export const buildContactUrl = (
   baseUrl: UrlString,

--- a/src/huly/url-builders.ts
+++ b/src/huly/url-builders.ts
@@ -4,13 +4,19 @@
  * The Huly web app routes documents as:
  *   <baseUrl>/workbench/<workspaceUrlSlug>/document/<title-slug>-<id>
  *
+ * Persons and organizations both route through the contact path:
+ *   <baseUrl>/workbench/<workspaceUrlSlug>/contact/<id>
+ *
  * `workspaceUrlSlug` comes from `WorkspaceLoginInfo.workspaceUrl` on the
  * account-client (not the `WorkspaceUuid` — that's a different identifier and
  * loops back to the login screen when used in URLs).
  *
+ * The same `DocumentUrlConfig` (baseUrl + workspaceUrlSlug) is reused for
+ * contact URLs since both kinds of link share those two inputs.
+ *
  * @module
  */
-import type { DocumentId, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
+import type { DocumentId, OrganizationId, PersonId, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 import { UrlString } from "../domain/schemas/shared.js"
 
 export interface DocumentUrlConfig {
@@ -58,3 +64,23 @@ export const buildDocumentUrl = (
 
 export const buildDocumentUrlFromConfig = (config: DocumentUrlConfig, title: string, id: DocumentId): UrlString =>
   buildDocumentUrl(config.baseUrl, config.workspaceUrlSlug, title, id)
+
+/**
+ * Build a Huly web-app URL for a person or organization. Both share the
+ * `<baseUrl>/workbench/<workspaceUrlSlug>/contact/<id>` shape; no slug step
+ * is needed because the contact id is the only path-sensitive component.
+ * Trailing slashes on `baseUrl` are tolerated.
+ */
+export const buildContactUrl = (
+  baseUrl: UrlString,
+  workspaceUrlSlug: WorkspaceUrlSlug,
+  id: OrganizationId | PersonId
+): UrlString => {
+  const trimmedBase = baseUrl.replace(/\/+$/, "")
+  return UrlString.make(`${trimmedBase}/workbench/${workspaceUrlSlug}/contact/${id}`)
+}
+
+export const buildContactUrlFromConfig = (
+  config: DocumentUrlConfig,
+  id: OrganizationId | PersonId
+): UrlString => buildContactUrl(config.baseUrl, config.workspaceUrlSlug, id)

--- a/test/huly/url-builders.test.ts
+++ b/test/huly/url-builders.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { DocumentId, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
-import { buildDocumentUrl, slugifyTitle } from "../../src/huly/url-builders.js"
+import { DocumentId, OrganizationId, PersonId, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
+import { buildContactUrl, buildDocumentUrl, slugifyTitle } from "../../src/huly/url-builders.js"
 
 describe("slugifyTitle", () => {
   it("reproduces the known Huly slug for a real document title", () => {
@@ -67,5 +67,29 @@ describe("buildDocumentUrl", () => {
   it("falls back to bare id when slug is empty", () => {
     expect(buildDocumentUrl(baseUrl, workspaceUrlSlug, "!!!", id))
       .toBe(`${baseUrl}/workbench/${workspaceUrlSlug}/document/${id}`)
+  })
+})
+
+describe("buildContactUrl", () => {
+  const baseUrl = UrlString.make("https://huly.axzez.org")
+  const workspaceUrlSlug = WorkspaceUrlSlug.make("axzez-6925fc59-8ee2eba17e-eb022e")
+  const orgId = OrganizationId.make("67d1da54dc299ae8fb101924")
+  const personId = PersonId.make("69dac6c47ace7e65e7aaca9e")
+
+  it("composes a workbench contact URL for an organization", () => {
+    expect(buildContactUrl(baseUrl, workspaceUrlSlug, orgId)).toBe(
+      "https://huly.axzez.org/workbench/axzez-6925fc59-8ee2eba17e-eb022e/contact/67d1da54dc299ae8fb101924"
+    )
+  })
+
+  it("composes a workbench contact URL for a person", () => {
+    expect(buildContactUrl(baseUrl, workspaceUrlSlug, personId)).toBe(
+      "https://huly.axzez.org/workbench/axzez-6925fc59-8ee2eba17e-eb022e/contact/69dac6c47ace7e65e7aaca9e"
+    )
+  })
+
+  it("tolerates trailing slash on baseUrl", () => {
+    expect(buildContactUrl(UrlString.make(`${baseUrl}/`), workspaceUrlSlug, orgId))
+      .toBe(`${baseUrl}/workbench/${workspaceUrlSlug}/contact/${orgId}`)
   })
 })


### PR DESCRIPTION
Closes #38.

## Summary

Document responses include a `url` field pointing at the workbench (`<base>/workbench/<slug>/document/<title-slug>-<id>`), but organization and person responses do not. That asymmetry forces MCP clients posting to Huly channels to either guess the URL pattern or fall back to plain text - markdown-API `@mentions` render as literal text since real mention nodes only come from UI autocomplete, so a markdown link to the workbench URL is the reliable fallback.

This PR adds `url: UrlString` to:

- `OrganizationSummary`
- `GetOrganizationResult`
- `PersonSummary`
- `Person`
- `EmployeeSummary`

populated via a new `buildContactUrl` helper that reuses the existing `DocumentUrlConfig` (both shapes share `baseUrl` + `workspaceUrlSlug`).

## URL pattern

Persons and organizations both route through `<base>/workbench/<slug>/contact/<id>`, so a single helper covers both. The contact id is the only path-sensitive component - no slugification step is needed.

## Notes

- I left `DocumentUrlConfig` and the `documentUrlConfig` field on `HulyClientContext` named as-is. Renaming to something like `WorkbenchUrlConfig` would be conceptually cleaner now that contacts share the config, but it expands surface area to ~12 references across 8 files; happy to do that as a follow-up if you'd prefer the rename.
- `@mention` node generation from markdown is intentionally out of scope. Markdown links to the workbench URL are sufficient for clickable references.

## Verification

- `pnpm typecheck` clean
- `pnpm test` all 1867 tests pass (3 new tests in `url-builders.test.ts` cover the new helper for org id, person id, and trailing-slash normalization)
- `pnpm lint` clean (one initial dprint nit auto-fixed)
- `pnpm build` clean
