### PR TITLE
refactor: rename DocumentUrlConfig to WorkbenchUrlConfig

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -47,7 +47,7 @@ import { concatLink } from "../utils/url.js"
 import { HulyAuthError, HulyConnectionError } from "./errors.js"
 import { type MarkupUrlConfig, testMarkupUrlConfig } from "./operations/markup.js"
 import { HulySdk, type HulySdkDependencies } from "./sdk-deps.js"
-import type { DocumentUrlConfig } from "./url-builders.js"
+import { testWorkbenchUrlConfig, type WorkbenchUrlConfig } from "./url-builders.js"
 
 // --- Connection helpers ---
 
@@ -180,7 +180,7 @@ export type HulyClientError = ConnectionError
 
 interface HulyClientContext {
   readonly markupUrlConfig: MarkupUrlConfig
-  readonly documentUrlConfig: DocumentUrlConfig
+  readonly workbenchUrlConfig: WorkbenchUrlConfig
 }
 
 export interface HulyClientOperations extends HulyClientContext {
@@ -308,7 +308,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
         refUrl: UrlString.make(refUrl),
         imageUrl: UrlString.make(imageUrl)
       }
-      const documentUrlConfig: DocumentUrlConfig = {
+      const workbenchUrlConfig: WorkbenchUrlConfig = {
         baseUrl: UrlString.make(config.url),
         workspaceUrlSlug
       }
@@ -329,7 +329,7 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       const operations: HulyClientOperations = {
         getAccountUuid: () => accountUuid,
         getPrimarySocialId: () => primarySocialId,
-        documentUrlConfig,
+        workbenchUrlConfig,
         markupUrlConfig,
 
         findAll: <T extends Doc>(
@@ -504,11 +504,8 @@ export class HulyClient extends Context.Tag("@hulymcp/HulyClient")<
       // PersonId is a branded string type with no public constructor
       // eslint-disable-next-line no-restricted-syntax -- see above
       getPrimarySocialId: () => "test-primary-social-id" as PersonId,
-      documentUrlConfig: {
-        baseUrl: UrlString.make("https://test.huly.local"),
-        workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
-      },
       markupUrlConfig: testMarkupUrlConfig,
+      workbenchUrlConfig: testWorkbenchUrlConfig,
       findAll: noopFindAll,
       findOne: noopFindOne,
       createDoc: notImplemented("createDoc"),

--- a/src/huly/operations/documents-edit.ts
+++ b/src/huly/operations/documents-edit.ts
@@ -117,7 +117,7 @@ export const editDocument = (
     }
 
     const finalTitle = updateOps.title ?? doc.title
-    const url = buildDocumentUrlFromConfig(client.documentUrlConfig, finalTitle, DocumentId.make(doc._id))
+    const url = buildDocumentUrlFromConfig(client.workbenchUrlConfig, finalTitle, DocumentId.make(doc._id))
 
     if (Object.keys(updateOps).length === 0 && !contentUpdatedInPlace) {
       return { id: DocumentId.make(doc._id), updated: false, url }

--- a/src/huly/operations/documents.ts
+++ b/src/huly/operations/documents.ts
@@ -368,7 +368,7 @@ export const listDocuments = (
       id: DocumentId.make(doc._id),
       title: doc.title,
       teamspace: teamspace.name,
-      url: buildDocumentUrlFromConfig(client.documentUrlConfig, doc.title, DocumentId.make(doc._id)),
+      url: buildDocumentUrlFromConfig(client.workbenchUrlConfig, doc.title, DocumentId.make(doc._id)),
       modifiedOn: doc.modifiedOn
     }))
 
@@ -410,7 +410,7 @@ export const getDocument = (
       title: doc.title,
       content,
       teamspace: teamspace.name,
-      url: buildDocumentUrlFromConfig(client.documentUrlConfig, doc.title, DocumentId.make(doc._id)),
+      url: buildDocumentUrlFromConfig(client.workbenchUrlConfig, doc.title, DocumentId.make(doc._id)),
       modifiedOn: doc.modifiedOn,
       createdOn: doc.createdOn
     }
@@ -493,7 +493,7 @@ export const createDocument = (
     return {
       id: DocumentId.make(documentId),
       title: params.title,
-      url: buildDocumentUrlFromConfig(client.documentUrlConfig, params.title, DocumentId.make(documentId))
+      url: buildDocumentUrlFromConfig(client.workbenchUrlConfig, params.title, DocumentId.make(documentId))
     }
   })
 

--- a/src/huly/operations/organizations.ts
+++ b/src/huly/operations/organizations.ts
@@ -160,7 +160,7 @@ export const listOrganizations = (
         name: org.name,
         city: org.city,
         members: org.members,
-        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+        url: buildContactUrlFromConfig(client.workbenchUrlConfig, id),
         modifiedOn: org.modifiedOn
       }
     })
@@ -237,7 +237,7 @@ export const getOrganization = (
       city: org.city || undefined,
       description: descriptionText,
       members: org.members,
-      url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+      url: buildContactUrlFromConfig(client.workbenchUrlConfig, id),
       modifiedOn: org.modifiedOn
     }
   })

--- a/src/huly/operations/persons.ts
+++ b/src/huly/operations/persons.ts
@@ -149,7 +149,7 @@ export const listPersons = (
         name: PersonName.make(person.name),
         city: person.city,
         email: emailValue !== undefined ? Email.make(emailValue) : undefined,
-        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+        url: buildContactUrlFromConfig(client.workbenchUrlConfig, id),
         modifiedOn: person.modifiedOn
       }
     })
@@ -196,7 +196,7 @@ export const getPerson = (
         value: c.value
       })),
       organizations: organizations.length > 0 ? organizations : undefined,
-      url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+      url: buildContactUrlFromConfig(client.workbenchUrlConfig, id),
       modifiedOn: person.modifiedOn,
       createdOn: person.createdOn
     }
@@ -326,7 +326,7 @@ export const listEmployees = (
         email: emailValue !== undefined ? Email.make(emailValue) : undefined,
         position: emp.position ?? undefined,
         active: emp.active,
-        url: buildContactUrlFromConfig(client.documentUrlConfig, id),
+        url: buildContactUrlFromConfig(client.workbenchUrlConfig, id),
         modifiedOn: emp.modifiedOn
       }
     })

--- a/src/huly/url-builders.ts
+++ b/src/huly/url-builders.ts
@@ -16,12 +16,18 @@
  *
  * @module
  */
-import type { DocumentId, OrganizationId, PersonId, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
-import { UrlString } from "../domain/schemas/shared.js"
+import type { DocumentId, OrganizationId, PersonId } from "../domain/schemas/shared.js"
+import { UrlString, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 
-export interface DocumentUrlConfig {
+export interface WorkbenchUrlConfig {
   readonly baseUrl: UrlString
   readonly workspaceUrlSlug: WorkspaceUrlSlug
+}
+
+// Test-only fixture for callers that need a deterministic workbench config without a real Huly workspace.
+export const testWorkbenchUrlConfig: WorkbenchUrlConfig = {
+  baseUrl: UrlString.make("https://test.huly.local"),
+  workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
 }
 
 /**
@@ -62,7 +68,7 @@ export const buildDocumentUrl = (
   return UrlString.make(`${trimmedBase}/workbench/${workspaceUrlSlug}/document/${pathSegment}`)
 }
 
-export const buildDocumentUrlFromConfig = (config: DocumentUrlConfig, title: string, id: DocumentId): UrlString =>
+export const buildDocumentUrlFromConfig = (config: WorkbenchUrlConfig, title: string, id: DocumentId): UrlString =>
   buildDocumentUrl(config.baseUrl, config.workspaceUrlSlug, title, id)
 
 /**
@@ -79,6 +85,6 @@ export const buildContactUrl = (
 }
 
 export const buildContactUrlFromConfig = (
-  config: DocumentUrlConfig,
+  config: WorkbenchUrlConfig,
   id: OrganizationId | PersonId
 ): UrlString => buildContactUrl(config.baseUrl, config.workspaceUrlSlug, id)

--- a/test/mcp/registry.test.ts
+++ b/test/mcp/registry.test.ts
@@ -4,13 +4,14 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect, Schema } from "effect"
 import { expect } from "vitest"
 
-import { IssueIdentifier, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
+import { IssueIdentifier } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { HulyClient } from "../../src/huly/client.js"
 import { HulyError } from "../../src/huly/errors.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../src/huly/url-builders.js"
 import type { WorkspaceClientOperations } from "../../src/huly/workspace-client.js"
 import { WorkspaceClient } from "../../src/huly/workspace-client.js"
 import { McpErrorCode } from "../../src/mcp/error-mapping.js"
@@ -31,11 +32,8 @@ const parse = (input: unknown) => Schema.decodeUnknown(Params)(input)
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
   getPrimarySocialId: () => "test-primary-social-id" as PersonId,
-  documentUrlConfig: {
-    baseUrl: UrlString.make("https://test.huly.local"),
-    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
-  },
   markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),

--- a/test/mcp/tools-index-branches.test.ts
+++ b/test/mcp/tools-index-branches.test.ts
@@ -4,20 +4,17 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
-import { UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../src/huly/url-builders.js"
 import { toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
   getPrimarySocialId: () => "test-primary-social-id" as PersonId,
-  documentUrlConfig: {
-    baseUrl: UrlString.make("https://test.huly.local"),
-    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
-  },
   markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
   findAll: (() => Effect.succeed(toFindResult([]))) as HulyClientOperations["findAll"],
   findOne: (() => Effect.succeed(undefined)) as HulyClientOperations["findOne"],
   createDoc: () => Effect.die(new Error("not implemented")),

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -4,20 +4,17 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
-import { UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../src/huly/url-builders.js"
 import { CATEGORY_NAMES, createFilteredRegistry, TOOL_DEFINITIONS, toolRegistry } from "../../src/mcp/tools/index.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
   getPrimarySocialId: () => "test-primary-social-id" as PersonId,
-  documentUrlConfig: {
-    baseUrl: UrlString.make("https://test.huly.local"),
-    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
-  },
   markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),

--- a/test/mcp/tools/notifications.test.ts
+++ b/test/mcp/tools/notifications.test.ts
@@ -4,20 +4,17 @@ import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
-import { UrlString, WorkspaceUrlSlug } from "../../../src/domain/schemas/shared.js"
 import type { HulyClientOperations } from "../../../src/huly/client.js"
 import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
 import { notificationTools } from "../../../src/mcp/tools/notifications.js"
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "test-account-uuid" as AccountUuid,
   getPrimarySocialId: () => "test-primary-social-id" as PersonId,
-  documentUrlConfig: {
-    baseUrl: UrlString.make("https://test.huly.local"),
-    workspaceUrlSlug: WorkspaceUrlSlug.make("test-workspace")
-  },
   markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
   findAll: () => Effect.succeed(toFindResult([])) as Effect.Effect<FindResult<never>>,
   findOne: () => Effect.succeed(undefined),
   createDoc: () => Effect.die(new Error("not implemented")),


### PR DESCRIPTION
Follow-up to my note on PR #39:

> I left `DocumentUrlConfig` and the `documentUrlConfig` field on `HulyClientContext` named as-is. Renaming to something like `WorkbenchUrlConfig` would be conceptually cleaner now that contacts share the config, but it expands surface area to ~12 references across 8 files; happy to do that as a follow-up if you would prefer the rename.

You said you would welcome it as a PR, so here it is.

## What

Pure rename, no behavior change:

- `DocumentUrlConfig` -> `WorkbenchUrlConfig` (interface in `src/huly/url-builders.ts`)
- `documentUrlConfig` -> `workbenchUrlConfig` (field on `HulyClientContext` and call sites)

The name now reflects that both `buildDocumentUrlFromConfig` and `buildContactUrlFromConfig` consume the same `{ baseUrl, workspaceUrlSlug }` pair - it is a workbench-scope config, not document-specific.

**Function names are intentionally left alone.** `buildDocumentUrlFromConfig` and `buildContactUrlFromConfig` still build document and contact URLs respectively; only the shared config shape was renamed.

While in there, I extracted `testWorkbenchUrlConfig` alongside the renamed interface, mirroring the existing `testMarkupUrlConfig` pattern - the five callers (one in `src/`, four in `test/mcp/`) had been repeating the same inline `{ baseUrl: "https://test.huly.local", workspaceUrlSlug: "test-workspace" }` literal. Happy to revert that part to a pure-rename diff if you would prefer to keep this PR strictly mechanical.

## Verification

- `pnpm typecheck` clean
- `pnpm test` - all 1867 tests pass
- `pnpm build` clean
- Deployed locally via launchd against a real Huly workspace; verified `list_organizations` and `list_documents` both return correct `url` fields built through the renamed code path
