### PR TITLE
feat: idempotent create_direct_message tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 | `update_channel_message` | Update a channel message. Only the body can be modified. |
 | `delete_channel_message` | Permanently delete a channel message. This action cannot be undone. |
 | `list_direct_messages` | List direct message conversations in Huly. Returns conversations sorted by date (newest first). |
+| `create_direct_message` | Open a one-to-one direct-message conversation with a workspace member. The `person` argument accepts an email or exact display name (e.g. `Smith,Bill`). Idempotent: if a DM with that participant already exists, returns it (`created: false`); otherwise creates a new DM (`created: true`). The returned `id` can be passed as `dm` to send_dm_message, list_dm_messages, etc. |
 | `list_dm_messages` | List messages in a direct-message conversation, newest first. The `dm` argument accepts either the DM `_id` or a participant display name (e.g. `Kerr,Shannon`); a name resolves only to a one-to-one DM with the authenticated account. |
 | `send_dm_message` | Send a message to a direct-message conversation. The `dm` argument accepts either the DM `_id` or a participant display name; a name resolves only to a one-to-one DM with the authenticated account. Message body supports markdown formatting. |
 | `update_dm_message` | Update a direct-message message. The `dm` argument accepts either the DM `_id` or a participant display name; a name resolves only to a one-to-one DM with the authenticated account. Only the body can be modified. |

--- a/src/domain/schemas/direct-messages.ts
+++ b/src/domain/schemas/direct-messages.ts
@@ -7,7 +7,7 @@ import { JSONSchema, Schema } from "effect"
 
 import type { MessageSummary } from "./channels.js"
 import type { ChannelId } from "./shared.js"
-import { DirectMessageIdentifier, LimitParam, MessageId, NonEmptyString } from "./shared.js"
+import { DirectMessageIdentifier, LimitParam, MessageId, NonEmptyString, PersonRefInput } from "./shared.js"
 
 // --- List DM Messages Params ---
 
@@ -82,12 +82,28 @@ export const DeleteDmMessageParamsSchema = Schema.Struct({
 
 export type DeleteDmMessageParams = Schema.Schema.Type<typeof DeleteDmMessageParamsSchema>
 
+// --- Create DM Params ---
+
+export const CreateDirectMessageParamsSchema = Schema.Struct({
+  person: PersonRefInput.annotations({
+    description:
+      "Participant to open a one-to-one DM with: email address or exact display name (e.g. `Smith,Bill`). Resolved via the Employee mixin to a Huly account."
+  })
+}).annotations({
+  title: "CreateDirectMessageParams",
+  description:
+    "Parameters for opening a one-to-one direct-message conversation with another workspace member. If a one-to-one DM with that participant already exists, it is returned unchanged."
+})
+
+export type CreateDirectMessageParams = Schema.Schema.Type<typeof CreateDirectMessageParamsSchema>
+
 // --- JSON Schemas for MCP ---
 
 export const listDmMessagesParamsJsonSchema = JSONSchema.make(ListDmMessagesParamsSchema)
 export const sendDmMessageParamsJsonSchema = JSONSchema.make(SendDmMessageParamsSchema)
 export const updateDmMessageParamsJsonSchema = JSONSchema.make(UpdateDmMessageParamsSchema)
 export const deleteDmMessageParamsJsonSchema = JSONSchema.make(DeleteDmMessageParamsSchema)
+export const createDirectMessageParamsJsonSchema = JSONSchema.make(CreateDirectMessageParamsSchema)
 
 // --- Parsers ---
 
@@ -95,6 +111,7 @@ export const parseListDmMessagesParams = Schema.decodeUnknown(ListDmMessagesPara
 export const parseSendDmMessageParams = Schema.decodeUnknown(SendDmMessageParamsSchema)
 export const parseUpdateDmMessageParams = Schema.decodeUnknown(UpdateDmMessageParamsSchema)
 export const parseDeleteDmMessageParams = Schema.decodeUnknown(DeleteDmMessageParamsSchema)
+export const parseCreateDirectMessageParams = Schema.decodeUnknown(CreateDirectMessageParamsSchema)
 
 // --- Result Types ---
 
@@ -116,4 +133,14 @@ export interface UpdateDmMessageResult {
 export interface DeleteDmMessageResult {
   readonly id: MessageId
   readonly deleted: boolean
+}
+
+/**
+ * `created` distinguishes a newly created DM from a pre-existing one that was
+ * returned because a one-to-one conversation already existed. Callers can use
+ * it to avoid sending duplicate "hello" messages on reconnects/retries.
+ */
+export interface CreateDirectMessageResult {
+  readonly id: ChannelId
+  readonly created: boolean
 }

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -671,6 +671,10 @@ export {
 } from "./channels.js"
 
 export {
+  type CreateDirectMessageParams,
+  createDirectMessageParamsJsonSchema,
+  CreateDirectMessageParamsSchema,
+  type CreateDirectMessageResult,
   type DeleteDmMessageParams,
   deleteDmMessageParamsJsonSchema,
   DeleteDmMessageParamsSchema,
@@ -679,6 +683,7 @@ export {
   listDmMessagesParamsJsonSchema,
   ListDmMessagesParamsSchema,
   type ListDmMessagesResult,
+  parseCreateDirectMessageParams,
   parseDeleteDmMessageParams,
   parseListDmMessagesParams,
   parseSendDmMessageParams,

--- a/src/huly/errors-messaging.ts
+++ b/src/huly/errors-messaging.ts
@@ -54,6 +54,46 @@ export class DirectMessageIdentifierAmbiguousError extends Schema.TaggedError<Di
 }
 
 /**
+ * Caller attempted to open a direct-message conversation with themselves.
+ *
+ * Huly models a one-to-one DM as a space whose `members` are the authenticated
+ * account and one other account; a self-DM has only one member and is rejected
+ * upfront rather than producing a malformed space.
+ */
+export class CannotDirectMessageSelfError extends Schema.TaggedError<CannotDirectMessageSelfError>()(
+  "CannotDirectMessageSelfError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Cannot start a direct-message conversation with yourself ('${this.identifier}')`
+  }
+}
+
+/**
+ * Resolved Person has no Huly workspace account.
+ *
+ * DMs are addressed by `AccountUuid`, which is populated only on the Employee
+ * mixin (`contact.mixin.Employee.personUuid`). External contacts and persons
+ * who haven't accepted a workspace invite have no account and cannot be DM'd.
+ *
+ * Upstream reference: only Employees with `personUuid` set are returned by
+ * Huly's account services, so DM membership lists are constructed from those.
+ * See `@hcengineering/chunter/src/utils.ts#getDirectChannel`.
+ */
+export class PersonNotAnEmployeeError extends Schema.TaggedError<PersonNotAnEmployeeError>()(
+  "PersonNotAnEmployeeError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Person '${this.identifier}' is not a workspace member (no Huly account) and cannot receive direct messages`
+  }
+}
+
+/**
  * Message not found in the channel.
  */
 export class MessageNotFoundError extends Schema.TaggedError<MessageNotFoundError>()(

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -50,10 +50,12 @@ import { TagCategoryNotFoundError, TagNotFoundError } from "./errors-labels.js"
 import { FunnelNotFoundError, LeadNotFoundError } from "./errors-leads.js"
 import {
   ActivityMessageNotFoundError,
+  CannotDirectMessageSelfError,
   ChannelNotFoundError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
   MessageNotFoundError,
+  PersonNotAnEmployeeError,
   ReactionNotFoundError,
   SavedMessageNotFoundError,
   ThreadReplyNotFoundError
@@ -84,6 +86,7 @@ export {
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
+  CannotDirectMessageSelfError,
   CardNotFoundError,
   CardSpaceNotFoundError,
   ChannelNotFoundError,
@@ -121,6 +124,7 @@ export {
   NotificationNotFoundError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonNotAnEmployeeError,
   PersonNotFoundError,
   ProjectNotFoundError,
   ReactionNotFoundError,
@@ -166,9 +170,11 @@ export type HulyDomainError =
   | CommentNotFoundError
   | MilestoneNotFoundError
   | ChannelNotFoundError
+  | CannotDirectMessageSelfError
   | DirectMessageIdentifierAmbiguousError
   | DirectMessageNotFoundError
   | MessageNotFoundError
+  | PersonNotAnEmployeeError
   | ThreadReplyNotFoundError
   | CalendarNotAccessibleError
   | EventNotFoundError
@@ -229,9 +235,11 @@ export const HulyDomainError: Schema.Union<
     typeof CommentNotFoundError,
     typeof MilestoneNotFoundError,
     typeof ChannelNotFoundError,
+    typeof CannotDirectMessageSelfError,
     typeof DirectMessageIdentifierAmbiguousError,
     typeof DirectMessageNotFoundError,
     typeof MessageNotFoundError,
+    typeof PersonNotAnEmployeeError,
     typeof ThreadReplyNotFoundError,
     typeof CalendarNotAccessibleError,
     typeof EventNotFoundError,
@@ -288,9 +296,11 @@ export const HulyDomainError: Schema.Union<
   CommentNotFoundError,
   MilestoneNotFoundError,
   ChannelNotFoundError,
+  CannotDirectMessageSelfError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
   MessageNotFoundError,
+  PersonNotAnEmployeeError,
   ThreadReplyNotFoundError,
   CalendarNotAccessibleError,
   EventNotFoundError,

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -15,15 +15,19 @@ import type { Employee as HulyEmployee } from "@hcengineering/contact"
 import {
   type AccountUuid as HulyAccountUuid,
   type AttachedData,
+  type Data,
   type DocumentUpdate,
   generateId,
   type Ref,
-  SortingOrder
+  SortingOrder,
+  type Space
 } from "@hcengineering/core"
 import { Clock, Effect } from "effect"
 
 import type { MessageSummary } from "../../domain/schemas/channels.js"
 import type {
+  CreateDirectMessageParams,
+  CreateDirectMessageResult,
   DeleteDmMessageParams,
   DeleteDmMessageResult,
   ListDmMessagesParams,
@@ -35,13 +39,21 @@ import type {
 } from "../../domain/schemas/direct-messages.js"
 import { ChannelId, type DirectMessageIdentifier, MessageId, PersonName } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
-import { DirectMessageIdentifierAmbiguousError, DirectMessageNotFoundError, MessageNotFoundError } from "../errors.js"
+import {
+  CannotDirectMessageSelfError,
+  DirectMessageIdentifierAmbiguousError,
+  DirectMessageNotFoundError,
+  MessageNotFoundError,
+  PersonNotAnEmployeeError,
+  PersonNotFoundError
+} from "../errors.js"
 import { buildSocialIdToPersonNameMap } from "./channels.js"
+import { findPersonByEmailOrName } from "./contacts-shared.js"
 import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { clampLimit } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
-import { chunter, contact } from "../huly-plugins.js"
+import { chunter, contact, core } from "../huly-plugins.js"
 
 // --- Error Types ---
 
@@ -59,6 +71,12 @@ type UpdateDmMessageError =
   | MessageNotFoundError
 
 type DeleteDmMessageError = UpdateDmMessageError
+
+type CreateDirectMessageError =
+  | HulyClientError
+  | PersonNotFoundError
+  | PersonNotAnEmployeeError
+  | CannotDirectMessageSelfError
 
 // --- Helpers ---
 
@@ -288,4 +306,93 @@ export const deleteDirectMessage = (
     )
 
     return { id: MessageId.make(message._id), deleted: true }
+  })
+
+/**
+ * Resolve a person identifier (email or display name) to the `AccountUuid`
+ * carried on the `contact.mixin.Employee` mixin. DMs are addressed by account
+ * UUID; non-employee Persons (external contacts, unaccepted invites) have no
+ * `personUuid` and cannot be DM'd.
+ */
+const resolveEmployeeAccount = (
+  identifier: string
+): Effect.Effect<
+  HulyAccountUuid,
+  HulyClientError | PersonNotFoundError | PersonNotAnEmployeeError,
+  HulyClient
+> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+
+    const person = yield* findPersonByEmailOrName(client, identifier)
+    if (person === undefined) {
+      return yield* new PersonNotFoundError({ identifier })
+    }
+
+    const employee = yield* client.findOne<HulyEmployee>(
+      contact.mixin.Employee,
+      { _id: toRef<HulyEmployee>(person._id) }
+    )
+
+    if (employee?.personUuid === undefined) {
+      return yield* new PersonNotAnEmployeeError({ identifier })
+    }
+
+    return employee.personUuid
+  })
+
+/**
+ * Open a one-to-one direct-message conversation with another workspace member.
+ *
+ * Idempotent: if a one-to-one DM whose members are the authenticated account
+ * and the resolved participant already exists, it is returned with
+ * `created: false` and no new space is created. Otherwise a new DM is created
+ * with `members: [me, other].sort()` to match Huly's convention.
+ *
+ * Mirrors `getDirectChannel` in upstream Huly's chunter plugin:
+ * https://github.com/hcengineering/platform/blob/main/plugins/chunter/src/utils.ts
+ */
+export const createDirectMessage = (
+  params: CreateDirectMessageParams
+): Effect.Effect<CreateDirectMessageResult, CreateDirectMessageError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const me = client.getAccountUuid()
+
+    const other = yield* resolveEmployeeAccount(params.person)
+    if (other === me) {
+      return yield* new CannotDirectMessageSelfError({ identifier: params.person })
+    }
+
+    const existingDms = yield* client.findAll<HulyDirectMessage>(
+      chunter.class.DirectMessage,
+      { members: me }
+    )
+
+    const existing = existingDms.find((dm) =>
+      dm.members.length === ONE_TO_ONE_DM_MEMBER_COUNT
+      && dm.members.includes(other)
+    )
+
+    if (existing !== undefined) {
+      return { id: ChannelId.make(existing._id), created: false }
+    }
+
+    const dmId: Ref<HulyDirectMessage> = generateId()
+    const dmData: Data<HulyDirectMessage> = {
+      name: "",
+      description: "",
+      private: true,
+      archived: false,
+      members: [me, other].sort()
+    }
+
+    yield* client.createDoc(
+      chunter.class.DirectMessage,
+      toRef<Space>(core.space.Space),
+      dmData,
+      dmId
+    )
+
+    return { id: ChannelId.make(dmId), created: true }
   })

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -84,6 +84,8 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "ChannelNotFoundError",
   "DirectMessageIdentifierAmbiguousError",
   "DirectMessageNotFoundError",
+  "CannotDirectMessageSelfError",
+  "PersonNotAnEmployeeError",
   "MessageNotFoundError",
   "ThreadReplyNotFoundError",
   "CalendarNotAccessibleError",

--- a/src/mcp/tools/channels.ts
+++ b/src/mcp/tools/channels.ts
@@ -1,6 +1,7 @@
 import {
   addThreadReplyParamsJsonSchema,
   createChannelParamsJsonSchema,
+  createDirectMessageParamsJsonSchema,
   deleteChannelMessageParamsJsonSchema,
   deleteChannelParamsJsonSchema,
   deleteDmMessageParamsJsonSchema,
@@ -13,6 +14,7 @@ import {
   listThreadRepliesParamsJsonSchema,
   parseAddThreadReplyParams,
   parseCreateChannelParams,
+  parseCreateDirectMessageParams,
   parseDeleteChannelMessageParams,
   parseDeleteChannelParams,
   parseDeleteDmMessageParams,
@@ -49,6 +51,7 @@ import {
   updateChannelMessage
 } from "../../huly/operations/channels.js"
 import {
+  createDirectMessage,
   deleteDirectMessage,
   listDirectMessageMessages,
   sendDirectMessage,
@@ -174,6 +177,18 @@ export const channelTools: ReadonlyArray<RegisteredTool> = [
       "list_direct_messages",
       parseListDirectMessagesParams,
       listDirectMessages
+    )
+  },
+  {
+    name: "create_direct_message",
+    description:
+      "Open a one-to-one direct-message conversation with a workspace member. The `person` argument accepts an email or exact display name (e.g. `Smith,Bill`). Idempotent: if a DM with that participant already exists, returns it (`created: false`); otherwise creates a new DM (`created: true`). The returned `id` can be passed as `dm` to send_dm_message, list_dm_messages, etc.",
+    category: CATEGORY,
+    inputSchema: createDirectMessageParamsJsonSchema,
+    handler: createToolHandler(
+      "create_direct_message",
+      parseCreateDirectMessageParams,
+      createDirectMessage
     )
   },
   {

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -6,6 +6,7 @@ import {
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
+  CannotDirectMessageSelfError,
   CardNotFoundError,
   CardSpaceNotFoundError,
   ChannelNotFoundError,
@@ -40,6 +41,7 @@ import {
   NotificationNotFoundError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonNotAnEmployeeError,
   PersonNotFoundError,
   ProjectNotFoundError,
   ReactionNotFoundError,
@@ -742,6 +744,10 @@ describe("Huly Errors", () => {
               return `funnel:${error.identifier}`
             case "LeadNotFoundError":
               return `lead:${error.identifier}`
+            case "CannotDirectMessageSelfError":
+              return `dm-self:${error.identifier}`
+            case "PersonNotAnEmployeeError":
+              return `not-employee:${error.identifier}`
             default: {
               const _exhaustive: never = error
               return _exhaustive
@@ -819,6 +825,8 @@ describe("Huly Errors", () => {
             new LeadNotFoundError({ identifier: leadIdentifier("LEAD-1"), funnel: funnelIdentifier("funnel-1") })
           )
         ).toBe("lead:LEAD-1")
+        expect(matchError(new CannotDirectMessageSelfError({ identifier: "Self,User" }))).toBe("dm-self:Self,User")
+        expect(matchError(new PersonNotAnEmployeeError({ identifier: "Ext,Contact" }))).toBe("not-employee:Ext,Contact")
       }))
   })
 })

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -1,8 +1,15 @@
 import { describe, it } from "@effect/vitest"
 import type { ChatMessage, DirectMessage as HulyDirectMessage } from "@hcengineering/chunter"
-import type { Employee as HulyEmployee, Person, SocialIdentity } from "@hcengineering/contact"
+import type {
+  Channel as ContactChannel,
+  Employee as HulyEmployee,
+  Person,
+  SocialIdentity
+} from "@hcengineering/contact"
 import {
   type AccountUuid as HulyAccountUuid,
+  type Class,
+  type Data,
   type Doc,
   type PersonId,
   type Ref,
@@ -20,13 +27,14 @@ import type {
   MessageNotFoundError
 } from "../../../src/huly/errors.js"
 import {
+  createDirectMessage,
   deleteDirectMessage,
   findDirectMessage,
   listDirectMessageMessages,
   sendDirectMessage,
   updateDirectMessage
 } from "../../../src/huly/operations/direct-messages.js"
-import { directMessageIdentifier, messageBrandId } from "../../helpers/brands.js"
+import { directMessageIdentifier, messageBrandId, personName } from "../../helpers/brands.js"
 
 import { chunter, contact } from "../../../src/huly/huly-plugins.js"
 
@@ -129,9 +137,16 @@ interface MockConfig {
   employees?: Array<HulyEmployee>
   persons?: Array<Person>
   socialIdentities?: Array<SocialIdentity>
+  contactChannels?: Array<ContactChannel>
   captureAddCollection?: { attributes?: Record<string, unknown>; id?: string }
   captureUpdateDoc?: { operations?: Record<string, unknown> }
   captureRemoveDoc?: { called?: boolean }
+  captureCreateDoc?: {
+    class?: Ref<Class<Doc>>
+    space?: Ref<Space>
+    attributes?: Data<Doc>
+    id?: string
+  }
 }
 
 const createTestLayer = (config: MockConfig) => {
@@ -140,6 +155,7 @@ const createTestLayer = (config: MockConfig) => {
   const employees = config.employees ?? []
   const persons = config.persons ?? []
   const socialIdentities = config.socialIdentities ?? []
+  const contactChannels = config.contactChannels ?? []
 
   const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown) => {
     if (_class === chunter.class.DirectMessage) {
@@ -209,6 +225,49 @@ const createTestLayer = (config: MockConfig) => {
       const found = messages.find((m) => (!q._id || m._id === q._id) && (!q.space || m.space === q.space))
       return Effect.succeed(found)
     }
+    if (_class === contact.mixin.Employee) {
+      const q = query as { _id?: Ref<HulyEmployee> }
+      if (q._id === undefined) return Effect.succeed(undefined)
+      return Effect.succeed(employees.find((e) => e._id === q._id))
+    }
+    if (_class === contact.class.Person) {
+      const q = query as { _id?: Ref<Person>; name?: string | { $like?: string } }
+      if (q._id !== undefined) {
+        return Effect.succeed(persons.find((p) => p._id === q._id))
+      }
+      if (typeof q.name === "string") {
+        return Effect.succeed(persons.find((p) => p.name === q.name))
+      }
+      if (q.name?.$like !== undefined) {
+        const needle = q.name.$like.replace(/^%|%$/g, "")
+        return Effect.succeed(persons.find((p) => p.name.includes(needle)))
+      }
+      return Effect.succeed(undefined)
+    }
+    if (_class === contact.class.Channel) {
+      const q = query as {
+        value?: string | { $like?: string }
+        provider?: unknown
+      }
+      const channel = contactChannels.find((ch) => {
+        if (q.provider !== undefined && ch.provider !== q.provider) return false
+        if (typeof q.value === "string") return ch.value === q.value
+        if (q.value?.$like !== undefined) {
+          const needle = q.value.$like.replace(/^%|%$/g, "")
+          return ch.value.includes(needle)
+        }
+        return false
+      })
+      return Effect.succeed(channel)
+    }
+    if (_class === contact.class.SocialIdentity) {
+      const q = query as { type?: SocialIdType; value?: string }
+      const si = socialIdentities.find((s) =>
+        (q.type === undefined || s.type === q.type)
+        && (q.value === undefined || s.value === q.value)
+      )
+      return Effect.succeed(si)
+    }
     return Effect.succeed(undefined)
   }) as HulyClientOperations["findOne"]
 
@@ -253,10 +312,20 @@ const createTestLayer = (config: MockConfig) => {
 
   const createDocImpl: HulyClientOperations["createDoc"] = ((
     _class: unknown,
-    _space: unknown,
-    _attributes: unknown,
+    space: unknown,
+    attributes: unknown,
     id?: unknown
-  ) => Effect.succeed((id ?? "new-id") as Ref<Doc>)) as HulyClientOperations["createDoc"]
+  ) => {
+    if (config.captureCreateDoc) {
+      config.captureCreateDoc.class = _class as Ref<Class<Doc>>
+      config.captureCreateDoc.space = space as Ref<Space>
+      config.captureCreateDoc.attributes = attributes as Data<Doc>
+      if (id !== undefined) {
+        config.captureCreateDoc.id = id as string
+      }
+    }
+    return Effect.succeed((id ?? "new-id") as Ref<Doc>)
+  }) as HulyClientOperations["createDoc"]
 
   return HulyClient.testLayer({
     findAll: findAllImpl,
@@ -662,5 +731,140 @@ describe("deleteDirectMessage", () => {
       )
 
       expect(Exit.isFailure(exit)).toBe(true)
+    }))
+})
+
+describe("createDirectMessage", () => {
+  it.effect("returns existing one-to-one DM with created=false", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const existingDm = makeDirectMessage({
+        _id: "dm-bill" as Ref<HulyDirectMessage>,
+        members: [currentAccountUuid, billAccount]
+      })
+      const capture: MockConfig["captureCreateDoc"] = {}
+      const layer = createTestLayer({
+        directMessages: [existingDm],
+        persons: [billPerson],
+        employees: [billEmployee],
+        captureCreateDoc: capture
+      })
+
+      const result = yield* createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+
+      expect(result.id).toBe("dm-bill")
+      expect(result.created).toBe(false)
+      expect(capture.id).toBeUndefined()
+    }))
+
+  it.effect("creates a new one-to-one DM when none exists, with sorted members", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const capture: MockConfig["captureCreateDoc"] = {}
+      const layer = createTestLayer({
+        directMessages: [],
+        persons: [billPerson],
+        employees: [billEmployee],
+        captureCreateDoc: capture
+      })
+
+      const result = yield* createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+
+      expect(result.created).toBe(true)
+      expect(typeof result.id).toBe("string")
+      expect(capture.class).toBe(chunter.class.DirectMessage)
+      const attrs = capture.attributes as Data<HulyDirectMessage> | undefined
+      expect(attrs?.private).toBe(true)
+      expect(attrs?.archived).toBe(false)
+      expect(attrs?.name).toBe("")
+      expect(attrs?.members).toEqual([billAccount, currentAccountUuid].sort())
+    }))
+
+  it.effect("ignores group DMs when looking for an existing one-to-one", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const extraAccount = "account-extra" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const groupDm = makeDirectMessage({
+        _id: "dm-group" as Ref<HulyDirectMessage>,
+        members: [currentAccountUuid, billAccount, extraAccount]
+      })
+      const layer = createTestLayer({
+        directMessages: [groupDm],
+        persons: [billPerson],
+        employees: [billEmployee]
+      })
+
+      const result = yield* createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+
+      expect(result.created).toBe(true)
+      expect(result.id).not.toBe("dm-group")
+    }))
+
+  it.effect("fails with CannotDirectMessageSelfError when identifier resolves to caller's account", () =>
+    Effect.gen(function*() {
+      const selfPerson = makePerson({ _id: "person-self" as Ref<Person>, name: "Kerr,Shannon" })
+      const selfEmployee = makeEmployee({
+        _id: "person-self" as Ref<HulyEmployee>,
+        name: "Kerr,Shannon",
+        personUuid: currentAccountUuid
+      })
+      const layer = createTestLayer({ persons: [selfPerson], employees: [selfEmployee] })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: personName("Kerr,Shannon") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("CannotDirectMessageSelfError")
+      }
+    }))
+
+  it.effect("fails with PersonNotFoundError when identifier matches no person", () =>
+    Effect.gen(function*() {
+      const layer = createTestLayer({})
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: personName("Nobody,Here") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonNotFoundError")
+      }
+    }))
+
+  it.effect("fails with PersonNotAnEmployeeError when person has no Employee mixin / personUuid", () =>
+    Effect.gen(function*() {
+      const externalPerson = makePerson({ _id: "person-ext" as Ref<Person>, name: "Outside,Contact" })
+      // No Employee mixin row for this person.
+      const layer = createTestLayer({ persons: [externalPerson], employees: [] })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: personName("Outside,Contact") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonNotAnEmployeeError")
+      }
     }))
 })


### PR DESCRIPTION
## Summary

Adds an MCP tool to **open a one-to-one direct-message conversation** with a workspace member, identified by email or exact display name. Without it, callers can list/send/edit DM messages but cannot start a conversation - they have to bootstrap one in the Huly UI first.

Mirrors upstream chunter's [`getDirectChannel`](https://github.com/hcengineering/platform/blob/main/plugins/chunter/src/utils.ts) exactly:

- Find one-to-one DM where `members == sorted([me, other])`
- If found, return existing id with `created: false`
- Else create new `chunter.class.DirectMessage` under `core.space.Space` with `name: ""`, `private: true`, `members: [me, other].sort()` and return id with `created: true`

Idempotent: safe to call on every "DM Bill" intent without producing duplicates or spurious "hello" reconnects.

## Design notes

- Input is `PersonRefInput = Email | PersonName`, matching the convention used by `assignee` / `lead` params elsewhere
- Person resolution reuses `findPersonByEmailOrName`, then promotes via `contact.mixin.Employee` to obtain the participant's `personUuid` (the `AccountUuid` DMs are addressed by)
- New domain errors in `errors-messaging.ts`:
  - `PersonNotAnEmployeeError` - resolved Person has no Employee mixin / `personUuid` (external contacts, unaccepted invites)
  - `CannotDirectMessageSelfError` - caller tried to DM their own account
- Both errors map to `-32602 InvalidParams` in the MCP error mapper

## Test plan

- [x] `pnpm tsc` clean for project files (the existing `@hcengineering/ui` upstream errors are present on master too)
- [x] `pnpm vitest run` - all 1882 tests pass, including 6 new tests covering: existing DM returned, new DM created with sorted members, group-DM ignored, self-DM rejected, person-not-found, person-not-employee
- [x] `pnpm build` - bundles cleanly
- [x] Smoke-tested against a live Huly workspace via the MCP transport:
  - Create with display name -> new DM, `created: true`
  - Repeat with name -> same id, `created: false`
  - Same DM with email lookup -> same id, `created: false`
  - Self-DM by the bot's own name -> `CannotDirectMessageSelfError`
  - Message successfully delivered via existing `send_dm_message` against the returned id
