### PR TITLE
Harden direct message creation

### DIFF
--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -779,21 +779,29 @@ else
   skip_test "create_direct_message(rejects_self)" "HULY_EMAIL is not set"
 fi
 SELF_NAME=""
+EMPLOYEES_FOR_DM_TEXT=""
 if [ -n "$HULY_EMAIL" ]; then
   EMPLOYEES_FOR_DM_TEXT=$(run_capture_only \
     '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_employees","arguments":{"limit":200}},"id":2}')
   if [ $? -eq 0 ]; then
-    SELF_NAME=$(echo "$EMPLOYEES_FOR_DM_TEXT" | jq -r --arg email "$HULY_EMAIL" '.[]? | select(.email == $email) | .name // empty' 2>/dev/null | head -1)
+    SELF_NAME=$(echo "$EMPLOYEES_FOR_DM_TEXT" | jq -r --arg email "$HULY_EMAIL" '[.[]? | select(.email == $email) | .name // empty] | unique | if length == 1 then .[0] else empty end' 2>/dev/null)
+  else
+    EMPLOYEES_FOR_DM_TEXT=""
   fi
 fi
 if [ -n "$SELF_NAME" ]; then
-  EXISTING_DM_PERSON=$(echo "$DM_LIST_TEXT" | jq -r --arg self "$SELF_NAME" '.conversations[]?.participants[]? | select(. != $self)' 2>/dev/null | head -1)
-  if [ -n "$EXISTING_DM_PERSON" ]; then
-    EXISTING_DM_PERSON_JSON=$(json_string "$EXISTING_DM_PERSON")
-    CREATE_DM_TEXT=$(run_capture "create_direct_message(existing:$EXISTING_DM_PERSON)" \
-      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_direct_message\",\"arguments\":{\"person\":$EXISTING_DM_PERSON_JSON}},\"id\":2}")
-    if [ $? -eq 0 ]; then
-      assert_json_field_equals "create_direct_message existing created=false" "$CREATE_DM_TEXT" ".created" "false"
+  EXISTING_DM_PERSON_NAME=$(echo "$DM_LIST_TEXT" | jq -r --arg self "$SELF_NAME" '.conversations[]?.participants[]? | select(. != $self)' 2>/dev/null | head -1)
+  if [ -n "$EXISTING_DM_PERSON_NAME" ]; then
+    EXISTING_DM_PERSON_EMAIL=$(echo "$EMPLOYEES_FOR_DM_TEXT" | jq -r --arg name "$EXISTING_DM_PERSON_NAME" '[.[]? | select(.name == $name and (.email // "") != "") | .email] | unique | if length == 1 then .[0] else empty end' 2>/dev/null)
+    if [ -n "$EXISTING_DM_PERSON_EMAIL" ]; then
+      EXISTING_DM_PERSON_JSON=$(json_string "$EXISTING_DM_PERSON_EMAIL")
+      CREATE_DM_TEXT=$(run_capture "create_direct_message(existing:$EXISTING_DM_PERSON_NAME)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_direct_message\",\"arguments\":{\"person\":$EXISTING_DM_PERSON_JSON}},\"id\":2}")
+      if [ $? -eq 0 ]; then
+        assert_json_field_equals "create_direct_message existing created=false" "$CREATE_DM_TEXT" ".created" "false"
+      fi
+    else
+      skip_test "create_direct_message(existing)" "existing DM participant is not uniquely identifiable by email"
     fi
   else
     skip_test "create_direct_message(existing)" "no existing one-to-one DM participant found"

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -790,7 +790,7 @@ if [ -n "$HULY_EMAIL" ]; then
   fi
 fi
 if [ -n "$SELF_NAME" ]; then
-  EXISTING_DM_PERSON_NAME=$(echo "$DM_LIST_TEXT" | jq -r --arg self "$SELF_NAME" '.conversations[]?.participants[]? | select(. != $self)' 2>/dev/null | head -1)
+  EXISTING_DM_PERSON_NAME=$(echo "$DM_LIST_TEXT" | jq -r --arg self "$SELF_NAME" '.conversations[]? | select((.participantIds // [] | length) == 2 and (.participants // [] | length) == 2 and ((.participants // []) | index($self) != null)) | .participants[]? | select(. != $self)' 2>/dev/null | head -1)
   if [ -n "$EXISTING_DM_PERSON_NAME" ]; then
     EXISTING_DM_PERSON_EMAIL=$(echo "$EMPLOYEES_FOR_DM_TEXT" | jq -r --arg name "$EXISTING_DM_PERSON_NAME" '[.[]? | select(.name == $name and (.email // "") != "") | .email] | unique | if length == 1 then .[0] else empty end' 2>/dev/null)
     if [ -n "$EXISTING_DM_PERSON_EMAIL" ]; then

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -771,6 +771,36 @@ run_test "list_channel_messages(general)" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_channel_messages","arguments":{"channel":"general","limit":3}},"id":2}'
 DM_LIST_TEXT=$(run_capture "list_direct_messages" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_direct_messages","arguments":{"limit":3}},"id":2}')
+if [ -n "$HULY_EMAIL" ]; then
+  SELF_EMAIL_JSON=$(json_string "$HULY_EMAIL")
+  run_expect_error "create_direct_message(rejects_self)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_direct_message\",\"arguments\":{\"person\":$SELF_EMAIL_JSON}},\"id\":2}"
+else
+  skip_test "create_direct_message(rejects_self)" "HULY_EMAIL is not set"
+fi
+SELF_NAME=""
+if [ -n "$HULY_EMAIL" ]; then
+  EMPLOYEES_FOR_DM_TEXT=$(run_capture_only \
+    '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_employees","arguments":{"limit":200}},"id":2}')
+  if [ $? -eq 0 ]; then
+    SELF_NAME=$(echo "$EMPLOYEES_FOR_DM_TEXT" | jq -r --arg email "$HULY_EMAIL" '.[]? | select(.email == $email) | .name // empty' 2>/dev/null | head -1)
+  fi
+fi
+if [ -n "$SELF_NAME" ]; then
+  EXISTING_DM_PERSON=$(echo "$DM_LIST_TEXT" | jq -r --arg self "$SELF_NAME" '.conversations[]?.participants[]? | select(. != $self)' 2>/dev/null | head -1)
+  if [ -n "$EXISTING_DM_PERSON" ]; then
+    EXISTING_DM_PERSON_JSON=$(json_string "$EXISTING_DM_PERSON")
+    CREATE_DM_TEXT=$(run_capture "create_direct_message(existing:$EXISTING_DM_PERSON)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_direct_message\",\"arguments\":{\"person\":$EXISTING_DM_PERSON_JSON}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_equals "create_direct_message existing created=false" "$CREATE_DM_TEXT" ".created" "false"
+    fi
+  else
+    skip_test "create_direct_message(existing)" "no existing one-to-one DM participant found"
+  fi
+else
+  skip_test "create_direct_message(existing)" "could not determine current employee name"
+fi
 DM_ID="${HULY_TEST_DM_ID:-}"
 if [ -z "$DM_ID" ]; then
   DM_ID=$(echo "$DM_LIST_TEXT" | jq -r '.conversations[0].id // empty' 2>/dev/null)

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -182,12 +182,11 @@ export const PersonName = NonEmptyString.pipe(Schema.brand("PersonName"))
 export type PersonName = Schema.Schema.Type<typeof PersonName>
 
 /**
- * Input schema for any field that resolves through findPersonByEmailOrName —
- * accepts either an email address or a display name. Use this for assignee,
- * lead, and similar person-reference inputs. Email validation stays strict
- * for fields where only an email makes sense (account creation, social-id
- * lookups). Named `*Input` to distinguish from the existing PersonRef
- * output struct in domain/schemas/issues.ts.
+ * Input schema for any field that accepts either an email address or a display
+ * name as a person reference. Email validation stays strict for fields where
+ * only an email makes sense (account creation, social-id lookups). Named
+ * `*Input` to distinguish from the existing PersonRef output struct in
+ * domain/schemas/issues.ts.
  */
 export const PersonRefInput = Schema.Union(Email, PersonName)
 export type PersonRefInput = Schema.Schema.Type<typeof PersonRefInput>

--- a/src/huly/errors-contacts.ts
+++ b/src/huly/errors-contacts.ts
@@ -5,6 +5,8 @@
  */
 import { Schema } from "effect"
 
+const MIN_AMBIGUOUS_PERSON_MATCHES = 2
+
 /**
  * Person (assignee) not found.
  */
@@ -16,6 +18,21 @@ export class PersonNotFoundError extends Schema.TaggedError<PersonNotFoundError>
 ) {
   override get message(): string {
     return `Person '${this.identifier}' not found`
+  }
+}
+
+/**
+ * Person identifier matched multiple people.
+ */
+export class PersonIdentifierAmbiguousError extends Schema.TaggedError<PersonIdentifierAmbiguousError>()(
+  "PersonIdentifierAmbiguousError",
+  {
+    identifier: Schema.String,
+    matches: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(MIN_AMBIGUOUS_PERSON_MATCHES))
+  }
+) {
+  override get message(): string {
+    return `Person identifier '${this.identifier}' matched ${this.matches} people; use an exact email address instead`
   }
 }
 

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -4,7 +4,7 @@
  * Split into domain modules:
  * - errors-base: HulyError, HulyConnectionError, HulyAuthError
  * - errors-tracker: issue, project, status, milestone, component, template errors
- * - errors-contacts: PersonNotFoundError, OrganizationNotFoundError, InvalidContactProviderError, InvalidPersonUuidError
+ * - errors-contacts: person, organization, and contact validation errors
  * - errors-files: file upload/fetch/size errors, BYTES_PER_MB
  * - errors-documents: teamspace, document errors
  * - errors-messaging: channel, message, thread, reaction errors
@@ -26,6 +26,7 @@ import {
   InvalidPersonUuidError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonIdentifierAmbiguousError,
   PersonNotFoundError
 } from "./errors-contacts.js"
 import { CustomFieldNotFoundError, CustomFieldObjectNotFoundError } from "./errors-custom-fields.js"
@@ -124,6 +125,7 @@ export {
   NotificationNotFoundError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonIdentifierAmbiguousError,
   PersonNotAnEmployeeError,
   PersonNotFoundError,
   ProjectNotFoundError,
@@ -154,6 +156,7 @@ export type HulyDomainError =
   | IssueNotFoundError
   | ProjectNotFoundError
   | InvalidStatusError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
   | OrganizationNotFoundError
   | OrganizationIdentifierAmbiguousError
@@ -219,6 +222,7 @@ export const HulyDomainError: Schema.Union<
     typeof IssueNotFoundError,
     typeof ProjectNotFoundError,
     typeof InvalidStatusError,
+    typeof PersonIdentifierAmbiguousError,
     typeof PersonNotFoundError,
     typeof OrganizationNotFoundError,
     typeof OrganizationIdentifierAmbiguousError,
@@ -280,6 +284,7 @@ export const HulyDomainError: Schema.Union<
   IssueNotFoundError,
   ProjectNotFoundError,
   InvalidStatusError,
+  PersonIdentifierAmbiguousError,
   PersonNotFoundError,
   OrganizationNotFoundError,
   OrganizationIdentifierAmbiguousError,

--- a/src/huly/operations/contacts-shared.ts
+++ b/src/huly/operations/contacts-shared.ts
@@ -1,12 +1,16 @@
 import type { Channel, Person as HulyPerson, SocialIdentity } from "@hcengineering/contact"
 import type { Doc, Ref } from "@hcengineering/core"
 import { SocialIdType } from "@hcengineering/core"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 
+import { Email, type PersonName, type PersonRefInput } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
+import { PersonIdentifierAmbiguousError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { escapeLikeWildcards } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
+
+const isEmailIdentifier = Schema.is(Email)
 
 export const findPersonById = (
   client: HulyClient["Type"],
@@ -85,6 +89,82 @@ const findPersonBySocialIdentityEmail = (
       { _id: identity.attachedTo }
     )
   })
+
+const findPersonByExactEmail = (
+  client: HulyClient["Type"],
+  email: Email
+): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  Effect.gen(function*() {
+    const socialIdentities = yield* client.findAll<SocialIdentity>(
+      contact.class.SocialIdentity,
+      {
+        type: SocialIdType.EMAIL,
+        value: email
+      }
+    )
+
+    const channels = yield* client.findAll<Channel>(
+      contact.class.Channel,
+      {
+        value: email,
+        provider: contact.channelProvider.Email
+      }
+    )
+
+    const personIds = [
+      ...new Set([
+        ...socialIdentities.map((identity) => identity.attachedTo),
+        ...channels.map((channel) => channel.attachedTo)
+      ])
+    ]
+    if (personIds.length === 0) {
+      return undefined
+    }
+
+    const persons = yield* client.findAll<HulyPerson>(
+      contact.class.Person,
+      { _id: { $in: personIds.map(toRef<HulyPerson>) } }
+    )
+
+    if (persons.length === 0) {
+      return undefined
+    }
+
+    if (persons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: email, matches: persons.length })
+    }
+
+    return persons[0]
+  })
+
+const findPersonByExactName = (
+  client: HulyClient["Type"],
+  name: PersonName
+): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  Effect.gen(function*() {
+    const persons = yield* client.findAll<HulyPerson>(
+      contact.class.Person,
+      { name }
+    )
+
+    if (persons.length === 0) {
+      return undefined
+    }
+
+    if (persons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: persons.length })
+    }
+
+    return persons[0]
+  })
+
+export const findPersonByExactEmailOrName = (
+  client: HulyClient["Type"],
+  identifier: PersonRefInput
+): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  isEmailIdentifier(identifier)
+    ? findPersonByExactEmail(client, identifier)
+    : findPersonByExactName(client, identifier)
 
 export const findPersonByEmailOrName = (
   client: HulyClient["Type"],

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -332,31 +332,18 @@ export const deleteDirectMessage = (
     return { id: MessageId.make(message._id), deleted: true }
   })
 
-/**
- * Resolve a person identifier (email or display name) to the `AccountUuid`
- * carried on the `contact.mixin.Employee` mixin. DMs are addressed by account
- * UUID; non-employee Persons (external contacts, unaccepted invites) have no
- * `personUuid` and cannot be DM'd.
- */
 const findPersonByExactEmail = (
   client: HulyClient["Type"],
   email: Email
 ): Effect.Effect<Person | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
   Effect.gen(function*() {
-    const socialIdentity = yield* client.findOne<SocialIdentity>(
+    const socialIdentities = yield* client.findAll<SocialIdentity>(
       contact.class.SocialIdentity,
       {
         type: SocialIdType.EMAIL,
         value: email
       }
     )
-
-    if (socialIdentity !== undefined) {
-      return yield* client.findOne<Person>(
-        contact.class.Person,
-        { _id: socialIdentity.attachedTo }
-      )
-    }
 
     const channels = yield* client.findAll<HulyContactChannel>(
       contact.class.Channel,
@@ -366,19 +353,30 @@ const findPersonByExactEmail = (
       }
     )
 
-    const personIds = [...new Set(channels.map((channel) => channel.attachedTo))]
+    const personIds = [
+      ...new Set([
+        ...socialIdentities.map((identity) => identity.attachedTo),
+        ...channels.map((channel) => channel.attachedTo)
+      ])
+    ]
     if (personIds.length === 0) {
       return undefined
     }
 
-    if (personIds.length > 1) {
-      return yield* new PersonIdentifierAmbiguousError({ identifier: email, matches: personIds.length })
+    const persons = yield* client.findAll<Person>(
+      contact.class.Person,
+      { _id: { $in: personIds.map(toRef<Person>) } }
+    )
+
+    if (persons.length === 0) {
+      return undefined
     }
 
-    return yield* client.findOne<Person>(
-      contact.class.Person,
-      { _id: toRef<Person>(personIds[0]) }
-    )
+    if (persons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: email, matches: persons.length })
+    }
+
+    return persons[0]
   })
 
 const findPersonByExactName = (
@@ -402,6 +400,12 @@ const findPersonByExactName = (
     return persons[0]
   })
 
+/**
+ * Resolve a person identifier (email or display name) to the `AccountUuid`
+ * carried on the `contact.mixin.Employee` mixin. DMs are addressed by account
+ * UUID; non-employee Persons (external contacts, unaccepted invites) have no
+ * `personUuid` and cannot be DM'd.
+ */
 const resolveEmployeeAccount = (
   identifier: PersonRefInput
 ): Effect.Effect<

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -11,12 +11,7 @@
  * @module
  */
 import type { ChatMessage, DirectMessage as HulyDirectMessage } from "@hcengineering/chunter"
-import type {
-  Channel as HulyContactChannel,
-  Employee as HulyEmployee,
-  Person,
-  SocialIdentity
-} from "@hcengineering/contact"
+import type { Employee as HulyEmployee } from "@hcengineering/contact"
 import {
   type AccountUuid as HulyAccountUuid,
   type AttachedData,
@@ -24,11 +19,10 @@ import {
   type DocumentUpdate,
   generateId,
   type Ref,
-  SocialIdType,
   SortingOrder,
   type Space
 } from "@hcengineering/core"
-import { Clock, Effect, Schema } from "effect"
+import { Clock, Effect } from "effect"
 
 import type { MessageSummary } from "../../domain/schemas/channels.js"
 import type {
@@ -46,22 +40,22 @@ import type {
 import {
   ChannelId,
   type DirectMessageIdentifier,
-  Email,
   MessageId,
   PersonName,
   type PersonRefInput
 } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
+import type { PersonIdentifierAmbiguousError } from "../errors.js"
 import {
   CannotDirectMessageSelfError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
   MessageNotFoundError,
-  PersonIdentifierAmbiguousError,
   PersonNotAnEmployeeError,
   PersonNotFoundError
 } from "../errors.js"
 import { buildSocialIdToPersonNameMap } from "./channels.js"
+import { findPersonByExactEmailOrName } from "./contacts-shared.js"
 import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { clampLimit } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
@@ -93,8 +87,6 @@ type CreateDirectMessageError =
   | CannotDirectMessageSelfError
 
 // --- Helpers ---
-
-const isEmailIdentifier = Schema.is(Email)
 
 const sortedMemberPair = (first: HulyAccountUuid, second: HulyAccountUuid): Array<HulyAccountUuid> =>
   [first, second].sort()
@@ -328,74 +320,6 @@ export const deleteDirectMessage = (
     return { id: MessageId.make(message._id), deleted: true }
   })
 
-const findPersonByExactEmail = (
-  client: HulyClient["Type"],
-  email: Email
-): Effect.Effect<Person | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
-  Effect.gen(function*() {
-    const socialIdentities = yield* client.findAll<SocialIdentity>(
-      contact.class.SocialIdentity,
-      {
-        type: SocialIdType.EMAIL,
-        value: email
-      }
-    )
-
-    const channels = yield* client.findAll<HulyContactChannel>(
-      contact.class.Channel,
-      {
-        value: email,
-        provider: contact.channelProvider.Email
-      }
-    )
-
-    const personIds = [
-      ...new Set([
-        ...socialIdentities.map((identity) => identity.attachedTo),
-        ...channels.map((channel) => channel.attachedTo)
-      ])
-    ]
-    if (personIds.length === 0) {
-      return undefined
-    }
-
-    const persons = yield* client.findAll<Person>(
-      contact.class.Person,
-      { _id: { $in: personIds.map(toRef<Person>) } }
-    )
-
-    if (persons.length === 0) {
-      return undefined
-    }
-
-    if (persons.length > 1) {
-      return yield* new PersonIdentifierAmbiguousError({ identifier: email, matches: persons.length })
-    }
-
-    return persons[0]
-  })
-
-const findPersonByExactName = (
-  client: HulyClient["Type"],
-  name: PersonName
-): Effect.Effect<Person | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
-  Effect.gen(function*() {
-    const persons = yield* client.findAll<Person>(
-      contact.class.Person,
-      { name }
-    )
-
-    if (persons.length === 0) {
-      return undefined
-    }
-
-    if (persons.length > 1) {
-      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: persons.length })
-    }
-
-    return persons[0]
-  })
-
 /**
  * Resolve a person identifier (email or display name) to the `AccountUuid`
  * carried on the `contact.mixin.Employee` mixin. DMs are addressed by account
@@ -412,9 +336,7 @@ const resolveEmployeeAccount = (
   Effect.gen(function*() {
     const client = yield* HulyClient
 
-    const person = isEmailIdentifier(identifier)
-      ? yield* findPersonByExactEmail(client, identifier)
-      : yield* findPersonByExactName(client, identifier)
+    const person = yield* findPersonByExactEmailOrName(client, identifier)
     if (person === undefined) {
       return yield* new PersonNotFoundError({ identifier })
     }

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -94,7 +94,6 @@ type CreateDirectMessageError =
 
 // --- Helpers ---
 
-const ONE_TO_ONE_DM_MEMBER_COUNT = 2
 const isEmailIdentifier = Schema.is(Email)
 
 const sortedMemberPair = (first: HulyAccountUuid, second: HulyAccountUuid): Array<HulyAccountUuid> =>
@@ -162,11 +161,8 @@ export const findDirectMessage = (
       { members: accountUuid }
     )
 
-    const matches = directMessages.filter((dm) =>
-      dm.members.length === ONE_TO_ONE_DM_MEMBER_COUNT
-      && dm.members.includes(accountUuid)
-      && accountUuids.some((candidate) => dm.members.includes(candidate))
-    )
+    const memberPairs = accountUuids.map((candidate) => sortedMemberPair(accountUuid, candidate))
+    const matches = directMessages.filter((dm) => memberPairs.some((members) => hasExactMembers(dm, members)))
 
     if (matches.length === 0) {
       return yield* new DirectMessageNotFoundError({ identifier })

--- a/src/huly/operations/direct-messages.ts
+++ b/src/huly/operations/direct-messages.ts
@@ -11,7 +11,12 @@
  * @module
  */
 import type { ChatMessage, DirectMessage as HulyDirectMessage } from "@hcengineering/chunter"
-import type { Employee as HulyEmployee } from "@hcengineering/contact"
+import type {
+  Channel as HulyContactChannel,
+  Employee as HulyEmployee,
+  Person,
+  SocialIdentity
+} from "@hcengineering/contact"
 import {
   type AccountUuid as HulyAccountUuid,
   type AttachedData,
@@ -19,10 +24,11 @@ import {
   type DocumentUpdate,
   generateId,
   type Ref,
+  SocialIdType,
   SortingOrder,
   type Space
 } from "@hcengineering/core"
-import { Clock, Effect } from "effect"
+import { Clock, Effect, Schema } from "effect"
 
 import type { MessageSummary } from "../../domain/schemas/channels.js"
 import type {
@@ -37,18 +43,25 @@ import type {
   UpdateDmMessageParams,
   UpdateDmMessageResult
 } from "../../domain/schemas/direct-messages.js"
-import { ChannelId, type DirectMessageIdentifier, MessageId, PersonName } from "../../domain/schemas/shared.js"
+import {
+  ChannelId,
+  type DirectMessageIdentifier,
+  Email,
+  MessageId,
+  PersonName,
+  type PersonRefInput
+} from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import {
   CannotDirectMessageSelfError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
   MessageNotFoundError,
+  PersonIdentifierAmbiguousError,
   PersonNotAnEmployeeError,
   PersonNotFoundError
 } from "../errors.js"
 import { buildSocialIdToPersonNameMap } from "./channels.js"
-import { findPersonByEmailOrName } from "./contacts-shared.js"
 import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { clampLimit } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
@@ -74,6 +87,7 @@ type DeleteDmMessageError = UpdateDmMessageError
 
 type CreateDirectMessageError =
   | HulyClientError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
   | PersonNotAnEmployeeError
   | CannotDirectMessageSelfError
@@ -81,6 +95,16 @@ type CreateDirectMessageError =
 // --- Helpers ---
 
 const ONE_TO_ONE_DM_MEMBER_COUNT = 2
+const isEmailIdentifier = Schema.is(Email)
+
+const sortedMemberPair = (first: HulyAccountUuid, second: HulyAccountUuid): Array<HulyAccountUuid> =>
+  [first, second].sort()
+
+const hasExactMembers = (dm: HulyDirectMessage, sortedMembers: ReadonlyArray<HulyAccountUuid>): boolean => {
+  const dmMembers = [...dm.members].sort()
+  return dmMembers.length === sortedMembers.length
+    && sortedMembers.every((member, index) => dmMembers[index] === member)
+}
 
 /**
  * Resolve a `dm` identifier to a Huly DirectMessage document.
@@ -314,17 +338,83 @@ export const deleteDirectMessage = (
  * UUID; non-employee Persons (external contacts, unaccepted invites) have no
  * `personUuid` and cannot be DM'd.
  */
+const findPersonByExactEmail = (
+  client: HulyClient["Type"],
+  email: Email
+): Effect.Effect<Person | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  Effect.gen(function*() {
+    const socialIdentity = yield* client.findOne<SocialIdentity>(
+      contact.class.SocialIdentity,
+      {
+        type: SocialIdType.EMAIL,
+        value: email
+      }
+    )
+
+    if (socialIdentity !== undefined) {
+      return yield* client.findOne<Person>(
+        contact.class.Person,
+        { _id: socialIdentity.attachedTo }
+      )
+    }
+
+    const channels = yield* client.findAll<HulyContactChannel>(
+      contact.class.Channel,
+      {
+        value: email,
+        provider: contact.channelProvider.Email
+      }
+    )
+
+    const personIds = [...new Set(channels.map((channel) => channel.attachedTo))]
+    if (personIds.length === 0) {
+      return undefined
+    }
+
+    if (personIds.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: email, matches: personIds.length })
+    }
+
+    return yield* client.findOne<Person>(
+      contact.class.Person,
+      { _id: toRef<Person>(personIds[0]) }
+    )
+  })
+
+const findPersonByExactName = (
+  client: HulyClient["Type"],
+  name: PersonName
+): Effect.Effect<Person | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  Effect.gen(function*() {
+    const persons = yield* client.findAll<Person>(
+      contact.class.Person,
+      { name }
+    )
+
+    if (persons.length === 0) {
+      return undefined
+    }
+
+    if (persons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: persons.length })
+    }
+
+    return persons[0]
+  })
+
 const resolveEmployeeAccount = (
-  identifier: string
+  identifier: PersonRefInput
 ): Effect.Effect<
   HulyAccountUuid,
-  HulyClientError | PersonNotFoundError | PersonNotAnEmployeeError,
+  HulyClientError | PersonIdentifierAmbiguousError | PersonNotFoundError | PersonNotAnEmployeeError,
   HulyClient
 > =>
   Effect.gen(function*() {
     const client = yield* HulyClient
 
-    const person = yield* findPersonByEmailOrName(client, identifier)
+    const person = isEmailIdentifier(identifier)
+      ? yield* findPersonByExactEmail(client, identifier)
+      : yield* findPersonByExactName(client, identifier)
     if (person === undefined) {
       return yield* new PersonNotFoundError({ identifier })
     }
@@ -369,10 +459,8 @@ export const createDirectMessage = (
       { members: me }
     )
 
-    const existing = existingDms.find((dm) =>
-      dm.members.length === ONE_TO_ONE_DM_MEMBER_COUNT
-      && dm.members.includes(other)
-    )
+    const members = sortedMemberPair(me, other)
+    const existing = existingDms.find((dm) => hasExactMembers(dm, members))
 
     if (existing !== undefined) {
       return { id: ChannelId.make(existing._id), created: false }
@@ -384,7 +472,7 @@ export const createDirectMessage = (
       description: "",
       private: true,
       archived: false,
-      members: [me, other].sort()
+      members
     }
 
     yield* client.createDoc(

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -68,6 +68,7 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "IssueNotFoundError",
   "ProjectNotFoundError",
   "InvalidStatusError",
+  "PersonIdentifierAmbiguousError",
   "PersonNotFoundError",
   "OrganizationNotFoundError",
   "OrganizationIdentifierAmbiguousError",

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -41,6 +41,7 @@ import {
   NotificationNotFoundError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonIdentifierAmbiguousError,
   PersonNotAnEmployeeError,
   PersonNotFoundError,
   ProjectNotFoundError,
@@ -298,6 +299,24 @@ describe("Huly Errors", () => {
       Effect.gen(function*() {
         const error = new DirectMessageIdentifierAmbiguousError({ identifier: "Kerr,Shannon", matches: 2 })
         expect(error.message).toBe("Direct message 'Kerr,Shannon' is ambiguous (2 matches); use the DM _id")
+      }))
+  })
+
+  describe("PersonIdentifierAmbiguousError", () => {
+    it.effect("creates with identifier and match count", () =>
+      Effect.gen(function*() {
+        const error = new PersonIdentifierAmbiguousError({ identifier: "Smith,Bill", matches: 2 })
+        expect(error._tag).toBe("PersonIdentifierAmbiguousError")
+        expect(error.identifier).toBe("Smith,Bill")
+        expect(error.matches).toBe(2)
+      }))
+
+    it.effect("generates message from fields", () =>
+      Effect.gen(function*() {
+        const error = new PersonIdentifierAmbiguousError({ identifier: "Smith,Bill", matches: 2 })
+        expect(error.message).toBe(
+          "Person identifier 'Smith,Bill' matched 2 people; use an exact email address instead"
+        )
       }))
   })
 
@@ -638,6 +657,8 @@ describe("Huly Errors", () => {
               return `status:${error.status}`
             case "PersonNotFoundError":
               return `person:${error.identifier}`
+            case "PersonIdentifierAmbiguousError":
+              return `person-ambiguous:${error.identifier}:${error.matches}`
             case "OrganizationNotFoundError":
               return `organization:${error.identifier}`
             case "OrganizationIdentifierAmbiguousError":
@@ -759,6 +780,9 @@ describe("Huly Errors", () => {
         expect(matchError(new ProjectNotFoundError({ identifier: "Z" }))).toBe("project:Z")
         expect(matchError(new InvalidStatusError({ status: "bad", project: "P" }))).toBe("status:bad")
         expect(matchError(new PersonNotFoundError({ identifier: "john@example.com" }))).toBe("person:john@example.com")
+        expect(matchError(new PersonIdentifierAmbiguousError({ identifier: "Smith,Bill", matches: 2 }))).toBe(
+          "person-ambiguous:Smith,Bill:2"
+        )
         expect(matchError(new OrganizationNotFoundError({ identifier: "Acme" }))).toBe("organization:Acme")
         expect(
           matchError(new OrganizationIdentifierAmbiguousError({ identifier: "Acme", matches: 2 }))

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -234,12 +234,15 @@ const createTestLayer = (config: MockConfig) => {
       return Effect.succeed(toFindResult(result))
     }
     if (_class === contact.class.SocialIdentity) {
-      const q = query as { _id?: { $in?: Array<PersonId> } }
+      const q = query as { _id?: { $in?: Array<PersonId> }; type?: SocialIdType; value?: string }
       if (q._id?.$in !== undefined) {
         const wanted = q._id.$in
         return Effect.succeed(toFindResult(socialIdentities.filter((si) => wanted.includes(si._id))))
       }
-      return Effect.succeed(toFindResult(socialIdentities))
+      return Effect.succeed(toFindResult(socialIdentities.filter((s) =>
+        (q.type === undefined || s.type === q.type)
+        && (q.value === undefined || s.value === q.value)
+      )))
     }
     return Effect.succeed(toFindResult([]))
   }) as HulyClientOperations["findAll"]
@@ -932,6 +935,36 @@ describe("createDirectMessage", () => {
       expect(result.created).toBe(true)
     }))
 
+  it.effect("falls back to an email channel when a matching social identity points to no person", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const orphanIdentity = makeSocialIdentity({
+        attachedTo: "person-orphan" as Ref<Person>,
+        type: SocialIdType.EMAIL,
+        value: "bill@example.com"
+      })
+      const billChannel = makeContactChannel({
+        attachedTo: "person-bill" as Ref<Person>,
+        value: "bill@example.com"
+      })
+      const layer = createTestLayer({
+        persons: [billPerson],
+        employees: [billEmployee],
+        socialIdentities: [orphanIdentity],
+        contactChannels: [billChannel]
+      })
+
+      const result = yield* createDirectMessage({ person: email("bill@example.com") }).pipe(Effect.provide(layer))
+
+      expect(result.created).toBe(true)
+    }))
+
   it.effect("does not resolve partial display-name matches", () =>
     Effect.gen(function*() {
       const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
@@ -960,6 +993,37 @@ describe("createDirectMessage", () => {
 
       const exit = yield* Effect.exit(
         createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonIdentifierAmbiguousError")
+      }
+    }))
+
+  it.effect("fails when exact email social identities match multiple persons", () =>
+    Effect.gen(function*() {
+      const firstPerson = makePerson({ _id: "person-first" as Ref<Person>, name: "Smith,Bill" })
+      const secondPerson = makePerson({ _id: "person-second" as Ref<Person>, name: "Jones,Ada" })
+      const firstIdentity = makeSocialIdentity({
+        _id: "social-first" as Ref<SocialIdentity> & PersonId,
+        attachedTo: "person-first" as Ref<Person>,
+        type: SocialIdType.EMAIL,
+        value: "shared@example.com"
+      })
+      const secondIdentity = makeSocialIdentity({
+        _id: "social-second" as Ref<SocialIdentity> & PersonId,
+        attachedTo: "person-second" as Ref<Person>,
+        type: SocialIdType.EMAIL,
+        value: "shared@example.com"
+      })
+      const layer = createTestLayer({
+        persons: [firstPerson, secondPerson],
+        socialIdentities: [firstIdentity, secondIdentity]
+      })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: email("shared@example.com") }).pipe(Effect.provide(layer))
       )
 
       expect(Exit.isFailure(exit)).toBe(true)

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -234,6 +234,8 @@ const createTestLayer = (config: MockConfig) => {
       return Effect.succeed(toFindResult(result))
     }
     if (_class === contact.class.SocialIdentity) {
+      // Test double boundary: findAll receives opaque SDK query objects; this branch only handles
+      // SocialIdentity query shapes issued by direct-message operations. Brands are erased at runtime.
       const q = query as { _id?: { $in?: Array<PersonId> }; type?: SocialIdType; value?: string }
       if (q._id?.$in !== undefined) {
         const wanted = q._id.$in

--- a/test/huly/operations/direct-messages.test.ts
+++ b/test/huly/operations/direct-messages.test.ts
@@ -34,7 +34,7 @@ import {
   sendDirectMessage,
   updateDirectMessage
 } from "../../../src/huly/operations/direct-messages.js"
-import { directMessageIdentifier, messageBrandId, personName } from "../../helpers/brands.js"
+import { directMessageIdentifier, email, messageBrandId, personName } from "../../helpers/brands.js"
 
 import { chunter, contact } from "../../../src/huly/huly-plugins.js"
 
@@ -42,6 +42,7 @@ import { chunter, contact } from "../../../src/huly/huly-plugins.js"
 
 const asEmployee = (v: unknown) => v as HulyEmployee
 const asPerson = (v: unknown) => v as Person
+const asContactChannel = (v: unknown) => v as ContactChannel
 
 const currentAccountUuid = "test-account-uuid" as HulyAccountUuid
 
@@ -131,6 +132,23 @@ const makeSocialIdentity = (overrides?: Partial<SocialIdentity>): SocialIdentity
   return result
 }
 
+const makeContactChannel = (overrides?: Partial<ContactChannel>): ContactChannel =>
+  asContactChannel({
+    _id: "channel-1" as Ref<ContactChannel>,
+    _class: contact.class.Channel,
+    space: "space-1" as Ref<Space>,
+    attachedTo: "person-1" as Ref<Person>,
+    attachedToClass: contact.class.Person,
+    collection: "channels",
+    provider: contact.channelProvider.Email,
+    value: "user@example.com",
+    modifiedBy: "user-1" as PersonId,
+    modifiedOn: 0,
+    createdBy: "user-1" as PersonId,
+    createdOn: 0,
+    ...overrides
+  })
+
 interface MockConfig {
   directMessages?: Array<HulyDirectMessage>
   messages?: Array<ChatMessage>
@@ -189,12 +207,31 @@ const createTestLayer = (config: MockConfig) => {
       return Effect.succeed(toFindResult(result))
     }
     if (_class === contact.class.Person) {
-      const q = query as { _id?: { $in?: Array<Ref<Person>> } }
+      const q = query as { _id?: { $in?: Array<Ref<Person>> }; name?: string }
       if (q._id?.$in !== undefined) {
         const wanted = q._id.$in
         return Effect.succeed(toFindResult(persons.filter((p) => wanted.includes(p._id))))
       }
+      if (q.name !== undefined) {
+        return Effect.succeed(toFindResult(persons.filter((p) => p.name === q.name)))
+      }
       return Effect.succeed(toFindResult(persons))
+    }
+    if (_class === contact.class.Channel) {
+      const q = query as {
+        value?: string | { $like?: string }
+        provider?: unknown
+      }
+      const result = contactChannels.filter((ch) => {
+        if (q.provider !== undefined && ch.provider !== q.provider) return false
+        if (typeof q.value === "string") return ch.value === q.value
+        if (q.value?.$like !== undefined) {
+          const needle = q.value.$like.replace(/^%|%$/g, "")
+          return ch.value.includes(needle)
+        }
+        return true
+      })
+      return Effect.succeed(toFindResult(result))
     }
     if (_class === contact.class.SocialIdentity) {
       const q = query as { _id?: { $in?: Array<PersonId> } }
@@ -763,6 +800,34 @@ describe("createDirectMessage", () => {
       expect(capture.id).toBeUndefined()
     }))
 
+  it.effect("returns an existing DM whose members are stored in the opposite order", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const existingDm = makeDirectMessage({
+        _id: "dm-bill" as Ref<HulyDirectMessage>,
+        members: [billAccount, currentAccountUuid]
+      })
+      const capture: MockConfig["captureCreateDoc"] = {}
+      const layer = createTestLayer({
+        directMessages: [existingDm],
+        persons: [billPerson],
+        employees: [billEmployee],
+        captureCreateDoc: capture
+      })
+
+      const result = yield* createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+
+      expect(result.id).toBe("dm-bill")
+      expect(result.created).toBe(false)
+      expect(capture.id).toBeUndefined()
+    }))
+
   it.effect("creates a new one-to-one DM when none exists, with sorted members", () =>
     Effect.gen(function*() {
       const billAccount = "account-bill" as HulyAccountUuid
@@ -816,6 +881,120 @@ describe("createDirectMessage", () => {
 
       expect(result.created).toBe(true)
       expect(result.id).not.toBe("dm-group")
+    }))
+
+  it.effect("resolves the participant by exact email social identity", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const billIdentity = makeSocialIdentity({
+        attachedTo: "person-bill" as Ref<Person>,
+        type: SocialIdType.EMAIL,
+        value: "bill@example.com"
+      })
+      const layer = createTestLayer({
+        persons: [billPerson],
+        employees: [billEmployee],
+        socialIdentities: [billIdentity]
+      })
+
+      const result = yield* createDirectMessage({ person: email("bill@example.com") }).pipe(Effect.provide(layer))
+
+      expect(result.created).toBe(true)
+    }))
+
+  it.effect("resolves the participant by exact email contact channel", () =>
+    Effect.gen(function*() {
+      const billAccount = "account-bill" as HulyAccountUuid
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: billAccount
+      })
+      const billChannel = makeContactChannel({
+        attachedTo: "person-bill" as Ref<Person>,
+        value: "bill@example.com"
+      })
+      const layer = createTestLayer({
+        persons: [billPerson],
+        employees: [billEmployee],
+        contactChannels: [billChannel]
+      })
+
+      const result = yield* createDirectMessage({ person: email("bill@example.com") }).pipe(Effect.provide(layer))
+
+      expect(result.created).toBe(true)
+    }))
+
+  it.effect("does not resolve partial display-name matches", () =>
+    Effect.gen(function*() {
+      const billPerson = makePerson({ _id: "person-bill" as Ref<Person>, name: "Smith,Bill" })
+      const billEmployee = makeEmployee({
+        _id: "person-bill" as Ref<HulyEmployee>,
+        name: "Smith,Bill",
+        personUuid: "account-bill" as HulyAccountUuid
+      })
+      const layer = createTestLayer({ persons: [billPerson], employees: [billEmployee] })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: personName("Smith") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonNotFoundError")
+      }
+    }))
+
+  it.effect("fails when an exact display name matches multiple persons", () =>
+    Effect.gen(function*() {
+      const firstPerson = makePerson({ _id: "person-first" as Ref<Person>, name: "Smith,Bill" })
+      const secondPerson = makePerson({ _id: "person-second" as Ref<Person>, name: "Smith,Bill" })
+      const layer = createTestLayer({ persons: [firstPerson, secondPerson] })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: personName("Smith,Bill") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonIdentifierAmbiguousError")
+      }
+    }))
+
+  it.effect("fails when an exact email channel matches multiple persons", () =>
+    Effect.gen(function*() {
+      const firstPerson = makePerson({ _id: "person-first" as Ref<Person>, name: "Smith,Bill" })
+      const secondPerson = makePerson({ _id: "person-second" as Ref<Person>, name: "Jones,Ada" })
+      const firstChannel = makeContactChannel({
+        _id: "channel-first" as Ref<ContactChannel>,
+        attachedTo: "person-first" as Ref<Person>,
+        value: "shared@example.com"
+      })
+      const secondChannel = makeContactChannel({
+        _id: "channel-second" as Ref<ContactChannel>,
+        attachedTo: "person-second" as Ref<Person>,
+        value: "shared@example.com"
+      })
+      const layer = createTestLayer({
+        persons: [firstPerson, secondPerson],
+        contactChannels: [firstChannel, secondChannel]
+      })
+
+      const exit = yield* Effect.exit(
+        createDirectMessage({ person: email("shared@example.com") }).pipe(Effect.provide(layer))
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain("PersonIdentifierAmbiguousError")
+      }
     }))
 
   it.effect("fails with CannotDirectMessageSelfError when identifier resolves to caller's account", () =>

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -20,6 +20,7 @@ import {
   LeadNotFoundError,
   OrganizationIdentifierAmbiguousError,
   OrganizationNotFoundError,
+  PersonIdentifierAmbiguousError,
   PersonNotFoundError,
   ProjectNotFoundError
 } from "../../src/huly/errors.js"
@@ -90,6 +91,21 @@ describe("Error Mapping to MCP", () => {
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
           expect(response.content[0].text).toBe(
             "Person 'john@example.com' not found"
+          )
+        }))
+
+      it.effect("maps PersonIdentifierAmbiguousError with descriptive message", () =>
+        Effect.gen(function*() {
+          const error = new PersonIdentifierAmbiguousError({
+            identifier: "Smith,Bill",
+            matches: 2
+          })
+          const response = mapDomainErrorToMcp(error)
+
+          expect(response.isError).toBe(true)
+          expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+          expect(response.content[0].text).toBe(
+            "Person identifier 'Smith,Bill' matched 2 people; use an exact email address instead"
           )
         }))
 


### PR DESCRIPTION
some logic over #41 

mainly:

Exact lookup instead of fuzzy lookup - seems more predictable / won't return wrong PMs - up to discussion

Tighten one-to-one DM matching by comparing the exact sorted member pair and reusing it for creation - to remove connascence / dependency on upstream query (assumption of which being that its elements always contain "me"). It's asserted more strictly now.
