### PR TITLE
docs : add instructions in `README.md` for integration inside opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ Add the standard config to your Windsurf MCP configuration file.
 
 </details>
 
+<details>
+<summary>OpenCode</summary>
+
+Open the global configuration file (`~/.config/opencode/opencode.json`) and add this config to the `mcp` section.
+
+```json
+"huly": {
+      "type": "local",
+      "command": ["npx", "-y", "@firfi/huly-mcp@latest"],
+      "environment": {
+        "HULY_URL": "https://huly.app",
+        "HULY_EMAIL": "your@email.com",
+        "HULY_PASSWORD": "yourpassword",
+        "HULY_WORKSPACE": "yourworkspace"
+      }
+    }
+```
+
+</details>
+
 ## Updating
 
 The `@latest` tag in the install command always fetches the newest version. Most MCP clients cache the installed package, so you need to force a re-fetch:


### PR DESCRIPTION
### Add instructions in `README.md` for integration inside opencode

I wanted to integrate this MCP into OpenCode, but it threw an error. After investigating it a bit, I found out that OpenCode uses a different syntax for the MCP connection. I added that bit to the `README.md`, so it can be useful to others who want to do the same.

Signed-off-by: **Utsav**