### PR TITLE
fix: fall back for issue relation lookup

### DIFF
--- a/.changeset/issue-relations-blocks-fallback.md
+++ b/.changeset/issue-relations-blocks-fallback.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Fix `list_issue_relations` so the `blocks` result is populated when Huly does not match nested `blockedBy._id` queries.

--- a/src/huly/operations/relations.ts
+++ b/src/huly/operations/relations.ts
@@ -1,4 +1,4 @@
-import type { Class, Doc, DocumentUpdate, Ref, RelatedDocument } from "@hcengineering/core"
+import type { Class, Doc, DocumentUpdate, FindOptions, Ref, RelatedDocument } from "@hcengineering/core"
 import type { Document as HulyDocument, Teamspace as HulyTeamspace } from "@hcengineering/document"
 import type { Issue as HulyIssue, Project as HulyProject } from "@hcengineering/tracker"
 import { Effect } from "effect"
@@ -36,6 +36,15 @@ const toIssueId = (value: string): IssueId => IssueId.make(value)
 const toObjectClassName = (value: string): ObjectClassName => ObjectClassName.make(value)
 const toTeamspaceIdentifier = (value: string): TeamspaceIdentifier => TeamspaceIdentifier.make(value)
 const toDocumentId = (value: string): DocumentId => DocumentId.make(value)
+
+const blockingIssueFindOptions = {
+  projection: {
+    _id: 1,
+    _class: 1,
+    identifier: 1,
+    blockedBy: 1
+  }
+} satisfies FindOptions<HulyIssue>
 
 const resolveTargetIssue = (
   client: HulyClient["Type"],
@@ -261,10 +270,18 @@ export const listIssueRelations = (
       _class: toObjectClassName(String(i._class))
     })
 
-    const blockingIssueCandidates = yield* client.findAll<HulyIssue>(
+    const directBlockingIssueCandidates = yield* client.findAll<HulyIssue>(
       tracker.class.Issue,
-      { "blockedBy._id": toRef<Doc>(issue._id) }
+      { "blockedBy._id": toRef<Doc>(issue._id) },
+      blockingIssueFindOptions
     )
+    const blockingIssueCandidates = directBlockingIssueCandidates.length > 0
+      ? directBlockingIssueCandidates
+      : yield* client.findAll<HulyIssue>(
+        tracker.class.Issue,
+        { blockedBy: makeRelatedDoc(issue) },
+        blockingIssueFindOptions
+      )
     const blocks = blockingIssueCandidates
       .filter(candidate => candidate._id !== issue._id && hasRelationById(candidate.blockedBy, issue._id))
       .map(toIssueEntry)

--- a/test/huly/operations/relations.test.ts
+++ b/test/huly/operations/relations.test.ts
@@ -30,6 +30,20 @@ const inQueryValues = (value: unknown): ReadonlyArray<string> | undefined => {
   return Array.isArray(values) && values.every(item => typeof item === "string") ? values : undefined
 }
 
+const hasBlockedByRelatedDocQuery = (query: unknown, id: string): boolean => {
+  const blockedBy = recordValue(query, "blockedBy")
+  return recordValue(blockedBy, "_id") === id
+    && recordValue(blockedBy, "_class") === tracker.class.Issue
+}
+
+const hasBlockingIssueProjection = (options: unknown): boolean => {
+  const projection = recordValue(options, "projection")
+  return recordValue(projection, "_id") === 1
+    && recordValue(projection, "_class") === 1
+    && recordValue(projection, "identifier") === 1
+    && recordValue(projection, "blockedBy") === 1
+}
+
 const makeProject = (overrides?: Partial<HulyProject>): HulyProject => {
   const base = {
     _id: "project-1" as Ref<HulyProject>,
@@ -90,6 +104,7 @@ interface MockConfig {
   capturedFindAllQueries?: Array<{
     _class: unknown
     query: unknown
+    options: unknown
   }>
   capturedUpdateDocs?: Array<{
     _class: unknown
@@ -97,6 +112,7 @@ interface MockConfig {
     objectId: unknown
     operations: unknown
   }>
+  supportsBlockedByDotQuery?: boolean
 }
 
 const createTestLayerWithMocks = (config: MockConfig) => {
@@ -106,8 +122,8 @@ const createTestLayerWithMocks = (config: MockConfig) => {
   const capturedFindAllQueries = config.capturedFindAllQueries ?? []
   const captured = config.capturedUpdateDocs ?? []
 
-  const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown) => {
-    capturedFindAllQueries.push({ _class, query })
+  const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown, options: unknown) => {
+    capturedFindAllQueries.push({ _class, query, options })
     if (_class === tracker.class.Issue) {
       const inValues = inQueryValues(recordValue(query, "_id"))
       if (inValues !== undefined) {
@@ -116,7 +132,15 @@ const createTestLayerWithMocks = (config: MockConfig) => {
       }
       const blockedById = stringRecordValue(query, "blockedBy._id")
       if (blockedById !== undefined) {
+        if (config.supportsBlockedByDotQuery === false) {
+          return Effect.succeed(toFindResult([]))
+        }
         const filtered = issues.filter(i => i.blockedBy?.some(ref => ref._id === blockedById))
+        return Effect.succeed(toFindResult(filtered))
+      }
+      const blockedByRelatedId = stringRecordValue(recordValue(query, "blockedBy"), "_id")
+      if (blockedByRelatedId !== undefined) {
+        const filtered = issues.filter(i => i.blockedBy?.some(ref => ref._id === blockedByRelatedId))
         return Effect.succeed(toFindResult(filtered))
       }
       return Effect.succeed(toFindResult(issues))
@@ -622,7 +646,7 @@ describe("listIssueRelations", () => {
         number: 4,
         blockedBy: [{ _id: "issue-1" as Ref<Doc>, _class: tracker.class.Issue }]
       })
-      const capturedFindAllQueries: Array<{ _class: unknown; query: unknown }> = []
+      const capturedFindAllQueries: Array<{ _class: unknown; query: unknown; options: unknown }> = []
       const testLayer = createTestLayerWithMocks({
         projects: [project],
         issues: [issue, blocked],
@@ -642,6 +666,53 @@ describe("listIssueRelations", () => {
       expect(result.documents).toHaveLength(0)
       expect(
         capturedFindAllQueries.some(({ query }) => stringRecordValue(query, "blockedBy._id") === "issue-1")
+      ).toBe(true)
+    }))
+
+  it.effect("falls back when the nested blockedBy query returns no matches", () =>
+    Effect.gen(function*() {
+      const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
+      const issue = makeIssue({
+        _id: "issue-1" as Ref<HulyIssue>,
+        space: "proj-1" as Ref<HulyProject>,
+        identifier: "TEST-1",
+        number: 1
+      })
+      const blocked = makeIssue({
+        _id: "issue-4" as Ref<HulyIssue>,
+        space: "proj-1" as Ref<HulyProject>,
+        identifier: "TEST-4",
+        number: 4,
+        blockedBy: [{ _id: "issue-1" as Ref<Doc>, _class: tracker.class.Issue }]
+      })
+      const otherBlocked = makeIssue({
+        _id: "issue-5" as Ref<HulyIssue>,
+        space: "proj-1" as Ref<HulyProject>,
+        identifier: "TEST-5",
+        number: 5,
+        blockedBy: [{ _id: "issue-2" as Ref<Doc>, _class: tracker.class.Issue }]
+      })
+      const capturedFindAllQueries: Array<{ _class: unknown; query: unknown; options: unknown }> = []
+      const testLayer = createTestLayerWithMocks({
+        projects: [project],
+        issues: [issue, blocked, otherBlocked],
+        capturedFindAllQueries,
+        supportsBlockedByDotQuery: false
+      })
+
+      const result = yield* listIssueRelations({
+        project: projectIdentifier("TEST"),
+        issueIdentifier: issueIdentifier("TEST-1")
+      }).pipe(Effect.provide(testLayer))
+
+      expect(result.blocks).toHaveLength(1)
+      expect(result.blocks[0].identifier).toBe("TEST-4")
+      expect(result.blocks[0]._id).toBe("issue-4")
+      expect(capturedFindAllQueries.some(({ query }) => hasBlockedByRelatedDocQuery(query, "issue-1"))).toBe(true)
+      expect(
+        capturedFindAllQueries.some(({ options, query }) =>
+          hasBlockedByRelatedDocQuery(query, "issue-1") && hasBlockingIssueProjection(options)
+        )
       ).toBe(true)
     }))
 


### PR DESCRIPTION
## Summary
- Add a fallback relation query when Huly does not return matches for the nested `blockedBy._id` lookup.
- Keep the final result filtered by relation id so unrelated blocked issues are not returned.
- Add a regression test for the fallback path.

## Validation
- `pnpm check-all`
