### PR TITLE
[codex] fix relation blocks query

### DIFF
--- a/.changeset/issue-relations-blocks-fallback.md
+++ b/.changeset/issue-relations-blocks-fallback.md
@@ -1,5 +1,0 @@
----
-"@firfi/huly-mcp": patch
----
-
-Fix `list_issue_relations` so the `blocks` result is populated when Huly does not match nested `blockedBy._id` queries.

--- a/.changeset/issue-relations-blocks-query.md
+++ b/.changeset/issue-relations-blocks-query.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Fix `list_issue_relations` so the `blocks` result queries Huly by the stored `blockedBy` related-document shape.

--- a/src/huly/operations/issues-shared.ts
+++ b/src/huly/operations/issues-shared.ts
@@ -87,8 +87,12 @@ export const findProjectWithStatuses = (
     if (projectType?.statuses) {
       const statusRefs = projectType.statuses.map(s => s._id)
       if (statusRefs.length > 0) {
-        // Try to query Status documents for names
-        // On some workspaces this fails with deserialization errors
+        // Try to query Status documents for names. Historical manual-test proof
+        // is in `git show 31ccf83e^:PROBLEMS.md`: on workspace
+        // `internalai @ huly.app.monadical.io`, querying Status docs failed with
+        // `Cannot read properties of null (reading '#<Object>')`, breaking issue
+        // read/list/update flows. The branch below preserves operation behavior
+        // by using the status refs already present on ProjectType.
         const statusDocsResult = yield* Effect.either(
           client.findAll<Status>(
             core.class.Status,

--- a/src/huly/operations/relations.ts
+++ b/src/huly/operations/relations.ts
@@ -270,18 +270,15 @@ export const listIssueRelations = (
       _class: toObjectClassName(String(i._class))
     })
 
-    const directBlockingIssueCandidates = yield* client.findAll<HulyIssue>(
+    // Huly stores "source blocks target" on the target issue as a RelatedDocument
+    // in `blockedBy`. Live local-Huly verification for PR #48 showed that querying
+    // `{ "blockedBy._id": issue._id }` returns no rows, so the implementation uses
+    // the stored shape directly and keeps the exact-id filter below as a guard.
+    const blockingIssueCandidates = yield* client.findAll<HulyIssue>(
       tracker.class.Issue,
-      { "blockedBy._id": toRef<Doc>(issue._id) },
+      { blockedBy: makeRelatedDoc(issue) },
       blockingIssueFindOptions
     )
-    const blockingIssueCandidates = directBlockingIssueCandidates.length > 0
-      ? directBlockingIssueCandidates
-      : yield* client.findAll<HulyIssue>(
-        tracker.class.Issue,
-        { blockedBy: makeRelatedDoc(issue) },
-        blockingIssueFindOptions
-      )
     const blocks = blockingIssueCandidates
       .filter(candidate => candidate._id !== issue._id && hasRelationById(candidate.blockedBy, issue._id))
       .map(toIssueEntry)

--- a/test/huly/operations/relations.test.ts
+++ b/test/huly/operations/relations.test.ts
@@ -36,6 +36,8 @@ const hasBlockedByRelatedDocQuery = (query: unknown, id: string): boolean => {
     && recordValue(blockedBy, "_class") === tracker.class.Issue
 }
 
+const hasBlockedByDotQuery = (query: unknown, id: string): boolean => recordValue(query, "blockedBy._id") === id
+
 const hasBlockingIssueProjection = (options: unknown): boolean => {
   const projection = recordValue(options, "projection")
   return recordValue(projection, "_id") === 1
@@ -112,7 +114,6 @@ interface MockConfig {
     objectId: unknown
     operations: unknown
   }>
-  supportsBlockedByDotQuery?: boolean
 }
 
 const createTestLayerWithMocks = (config: MockConfig) => {
@@ -128,14 +129,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
       const inValues = inQueryValues(recordValue(query, "_id"))
       if (inValues !== undefined) {
         const filtered = issues.filter(i => inValues.includes(i._id))
-        return Effect.succeed(toFindResult(filtered))
-      }
-      const blockedById = stringRecordValue(query, "blockedBy._id")
-      if (blockedById !== undefined) {
-        if (config.supportsBlockedByDotQuery === false) {
-          return Effect.succeed(toFindResult([]))
-        }
-        const filtered = issues.filter(i => i.blockedBy?.some(ref => ref._id === blockedById))
         return Effect.succeed(toFindResult(filtered))
       }
       const blockedByRelatedId = stringRecordValue(recordValue(query, "blockedBy"), "_id")
@@ -664,51 +657,8 @@ describe("listIssueRelations", () => {
       expect(result.blocks[0]._id).toBe("issue-4")
       expect(result.relations).toHaveLength(0)
       expect(result.documents).toHaveLength(0)
-      expect(
-        capturedFindAllQueries.some(({ query }) => stringRecordValue(query, "blockedBy._id") === "issue-1")
-      ).toBe(true)
-    }))
-
-  it.effect("falls back when the nested blockedBy query returns no matches", () =>
-    Effect.gen(function*() {
-      const project = makeProject({ _id: "proj-1" as Ref<HulyProject>, identifier: "TEST" })
-      const issue = makeIssue({
-        _id: "issue-1" as Ref<HulyIssue>,
-        space: "proj-1" as Ref<HulyProject>,
-        identifier: "TEST-1",
-        number: 1
-      })
-      const blocked = makeIssue({
-        _id: "issue-4" as Ref<HulyIssue>,
-        space: "proj-1" as Ref<HulyProject>,
-        identifier: "TEST-4",
-        number: 4,
-        blockedBy: [{ _id: "issue-1" as Ref<Doc>, _class: tracker.class.Issue }]
-      })
-      const otherBlocked = makeIssue({
-        _id: "issue-5" as Ref<HulyIssue>,
-        space: "proj-1" as Ref<HulyProject>,
-        identifier: "TEST-5",
-        number: 5,
-        blockedBy: [{ _id: "issue-2" as Ref<Doc>, _class: tracker.class.Issue }]
-      })
-      const capturedFindAllQueries: Array<{ _class: unknown; query: unknown; options: unknown }> = []
-      const testLayer = createTestLayerWithMocks({
-        projects: [project],
-        issues: [issue, blocked, otherBlocked],
-        capturedFindAllQueries,
-        supportsBlockedByDotQuery: false
-      })
-
-      const result = yield* listIssueRelations({
-        project: projectIdentifier("TEST"),
-        issueIdentifier: issueIdentifier("TEST-1")
-      }).pipe(Effect.provide(testLayer))
-
-      expect(result.blocks).toHaveLength(1)
-      expect(result.blocks[0].identifier).toBe("TEST-4")
-      expect(result.blocks[0]._id).toBe("issue-4")
       expect(capturedFindAllQueries.some(({ query }) => hasBlockedByRelatedDocQuery(query, "issue-1"))).toBe(true)
+      expect(capturedFindAllQueries.some(({ query }) => hasBlockedByDotQuery(query, "issue-1"))).toBe(false)
       expect(
         capturedFindAllQueries.some(({ options, query }) =>
           hasBlockedByRelatedDocQuery(query, "issue-1") && hasBlockingIssueProjection(options)


### PR DESCRIPTION
## Summary

- remove the unproven `blockedBy._id` relation query path
- query `blocks` using Huly's stored `blockedBy` related-document shape
- add provenance for the existing status-query recovery branch

## Validation

- `pnpm check-all`
- `scripts/integration_test_full.sh`
