### PR TITLE
[codex] harden relation queries

### DIFF
--- a/.changeset/strict-huly-query-helper.md
+++ b/.changeset/strict-huly-query-helper.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Add a strict Huly query helper for relation lookups so accidental dot-key query fields fail typechecking.

--- a/src/huly/operations/query-helpers.ts
+++ b/src/huly/operations/query-helpers.ts
@@ -4,6 +4,16 @@ import { Effect } from "effect"
 import { MAX_LIMIT } from "../../domain/schemas/shared.js"
 import type { HulyClientError, HulyClientOperations } from "../client.js"
 
+type StrictDocumentQuery<T extends Doc> =
+  & {
+    [P in keyof T]?: DocumentQuery<T>[P]
+  }
+  & {
+    $search?: string
+  }
+
+export const hulyQuery = <T extends Doc>(query: StrictDocumentQuery<T>): DocumentQuery<T> => query
+
 /**
  * Escape SQL LIKE wildcard characters in a string.
  * Prevents user input from being interpreted as wildcards.

--- a/src/huly/operations/relations.ts
+++ b/src/huly/operations/relations.ts
@@ -24,6 +24,7 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import type { IssueNotFoundError, ProjectNotFoundError } from "../errors.js"
 import { documentPlugin, tracker } from "../huly-plugins.js"
 import { findIssueInProject, findProject, findProjectAndIssue, parseIssueIdentifier } from "./issues-shared.js"
+import { hulyQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
 type RelationError =
@@ -251,7 +252,7 @@ export const listIssueRelations = (
       const toIssueRef = toRef<HulyIssue>
       const issues = yield* client.findAll<HulyIssue>(
         tracker.class.Issue,
-        { _id: { $in: allIssueIds.map(toIssueRef) } }
+        hulyQuery<HulyIssue>({ _id: { $in: allIssueIds.map(toIssueRef) } })
       )
       for (const i of issues) {
         idToIdentifier.set(String(i._id), i.identifier)
@@ -276,7 +277,7 @@ export const listIssueRelations = (
     // the stored shape directly and keeps the exact-id filter below as a guard.
     const blockingIssueCandidates = yield* client.findAll<HulyIssue>(
       tracker.class.Issue,
-      { blockedBy: makeRelatedDoc(issue) },
+      hulyQuery<HulyIssue>({ blockedBy: makeRelatedDoc(issue) }),
       blockingIssueFindOptions
     )
     const blocks = blockingIssueCandidates
@@ -289,7 +290,7 @@ export const listIssueRelations = (
       const toDocRef = toRef<HulyDocument>
       const docs = yield* client.findAll<HulyDocument>(
         documentPlugin.class.Document,
-        { _id: { $in: docRelationsRefs.map(r => toDocRef(r._id)) } }
+        hulyQuery<HulyDocument>({ _id: { $in: docRelationsRefs.map(r => toDocRef(r._id)) } })
       )
       const docMap = new Map(docs.map(d => [String(d._id), d]))
 
@@ -299,7 +300,7 @@ export const listIssueRelations = (
       if (spaceIds.length > 0) {
         const teamspaces = yield* client.findAll<HulyTeamspace>(
           documentPlugin.class.Teamspace,
-          { _id: { $in: spaceIds.map(toRef<HulyTeamspace>) } }
+          hulyQuery<HulyTeamspace>({ _id: { $in: spaceIds.map(toRef<HulyTeamspace>) } })
         )
         for (const ts of teamspaces) {
           tsNameMap.set(String(ts._id), ts.name)

--- a/test/huly/operations/query-helpers-types.ts
+++ b/test/huly/operations/query-helpers-types.ts
@@ -1,0 +1,8 @@
+import type { Issue as HulyIssue } from "@hcengineering/tracker"
+
+import { hulyQuery } from "../../../src/huly/operations/query-helpers.js"
+
+hulyQuery<HulyIssue>({ identifier: "TEST-1" })
+
+// @ts-expect-error nested dot-key queries bypass Huly's stored document shape.
+hulyQuery<HulyIssue>({ "blockedBy._id": "issue-1" })


### PR DESCRIPTION
## Summary

Adds a strict Huly query helper and routes the relation lookup query literals through it so accidental nested dot-key fields are caught by local typechecking.

## Why

The Huly SDK `DocumentQuery<T>` includes a permissive string index, which allowed the previous invented `{ "blockedBy._id": ... }` relation query to typecheck even though live Huly did not return rows for that shape. This change adds a narrow compile-time guard for the relation lookup path while preserving the runtime query shape already verified in PR #49.

## Changes

- Add `hulyQuery<T>()` to preserve Huly query value types for real document fields while rejecting arbitrary object-literal keys.
- Use `hulyQuery` for `listIssueRelations` issue, document, teamspace, and `blockedBy` lookups.
- Add a type-level regression proving `"blockedBy._id"` fails typechecking.
- Add a patch changeset.

## Validation

- `pnpm vitest run test/huly/operations/relations.test.ts`
- `pnpm typecheck`
- `pnpm check-all`
