### PR TITLE
[codex] propagate strict Huly query typing

### DIFF
--- a/.changeset/strict-query-convention.md
+++ b/.changeset/strict-query-convention.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Apply the strict Huly query helper convention across high-risk issue, document, label, relation, and task-management lookups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ Search examples for real usage patterns when implementing MCP tools.
 
 **Eventual consistency**: Huly's client does not see its own writes immediately within the same session. `findOne`, `addCollection` (resolves `attachedTo` ref internally), and other read-after-write patterns will hang or return stale data if the target document was just created.
 
+**Query typing**: Huly's SDK `DocumentQuery<T>` permits arbitrary string keys. Use `hulyQuery<T>()` for new or changed direct `client.findAll` / `client.findOne` query object literals, and use `StrictDocumentQuery<T>` for mutable query builders before passing them through `hulyQuery`. This catches invented fields such as `"blockedBy._id"` locally. If a dynamic or intentionally escaped query must bypass this helper, document the Huly behavior being relied on at the call site.
+
 ## Manual Testing (stdio)
 
 ```bash

--- a/src/huly/operations/documents.ts
+++ b/src/huly/operations/documents.ts
@@ -5,7 +5,6 @@
  */
 import {
   type Data,
-  type DocumentQuery,
   type DocumentUpdate,
   generateId,
   type MarkupBlobRef,
@@ -44,7 +43,13 @@ import { DocumentId, TeamspaceId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import { DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
 import { buildDocumentUrlFromConfig } from "../url-builders.js"
-import { clampLimit, escapeLikeWildcards, findByNameOrId } from "./query-helpers.js"
+import {
+  clampLimit,
+  escapeLikeWildcards,
+  findByNameOrId,
+  hulyQuery,
+  type StrictDocumentQuery
+} from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
 import { core, documentPlugin } from "../huly-plugins.js"
@@ -104,8 +109,8 @@ const findTeamspace = (
   Effect.gen(function*() {
     const client = yield* HulyClient
 
-    const nameQuery: DocumentQuery<HulyTeamspace> = { name: identifier }
-    const idQuery: DocumentQuery<HulyTeamspace> = { _id: toRef<HulyTeamspace>(identifier) }
+    const nameQuery: StrictDocumentQuery<HulyTeamspace> = { name: identifier }
+    const idQuery: StrictDocumentQuery<HulyTeamspace> = { _id: toRef<HulyTeamspace>(identifier) }
     if (!opts?.includeArchived) {
       nameQuery.archived = false
       idQuery.archived = false
@@ -167,7 +172,7 @@ export const listTeamspaces = (
   Effect.gen(function*() {
     const client = yield* HulyClient
 
-    const query: DocumentQuery<HulyTeamspace> = {}
+    const query: StrictDocumentQuery<HulyTeamspace> = {}
     if (!params.includeArchived) {
       query.archived = false
     }
@@ -176,7 +181,7 @@ export const listTeamspaces = (
 
     const teamspaces = yield* client.findAll<HulyTeamspace>(
       documentPlugin.class.Teamspace,
-      query,
+      hulyQuery(query),
       {
         limit,
         sort: {
@@ -211,7 +216,7 @@ export const getTeamspace = (
 
     const docs = yield* client.findAll<HulyDocument>(
       documentPlugin.class.Document,
-      { space: teamspace._id },
+      hulyQuery<HulyDocument>({ space: teamspace._id }),
       { limit: 1, total: true }
     )
 
@@ -233,7 +238,7 @@ export const createTeamspace = (
 
     const existing = yield* client.findOne<HulyTeamspace>(
       documentPlugin.class.Teamspace,
-      { name: params.name, archived: false }
+      hulyQuery<HulyTeamspace>({ name: params.name, archived: false })
     )
 
     if (existing !== undefined) {
@@ -335,7 +340,7 @@ export const listDocuments = (
 
     const limit = clampLimit(params.limit)
 
-    const query: DocumentQuery<HulyDocument> = {
+    const query: StrictDocumentQuery<HulyDocument> = {
       space: teamspace._id
     }
 
@@ -353,7 +358,7 @@ export const listDocuments = (
 
     const documents = yield* client.findAll<HulyDocument>(
       documentPlugin.class.Document,
-      query,
+      hulyQuery(query),
       {
         limit,
         sort: {
@@ -461,7 +466,7 @@ export const createDocument = (
     // Fetch rank of the last document to insert after
     const lastDoc = yield* client.findOne<HulyDocument>(
       documentPlugin.class.Document,
-      { space: teamspace._id },
+      hulyQuery<HulyDocument>({ space: teamspace._id }),
       { sort: { rank: SortingOrder.Descending } }
     )
     const rank = makeRank(lastDoc?.rank, undefined)

--- a/src/huly/operations/issues-read.ts
+++ b/src/huly/operations/issues-read.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import type { Person } from "@hcengineering/contact"
-import { type DocumentQuery, type Ref, SortingOrder, type Status, type WithLookup } from "@hcengineering/core"
+import { type Ref, SortingOrder, type Status, type WithLookup } from "@hcengineering/core"
 import { type Issue as HulyIssue } from "@hcengineering/tracker"
 import { Effect, Schema } from "effect"
 
@@ -25,7 +25,7 @@ import {
   resolveStatusByName,
   type StatusInfo
 } from "./issues-shared.js"
-import { clampLimit, escapeLikeWildcards, withLookup } from "./query-helpers.js"
+import { clampLimit, escapeLikeWildcards, hulyQuery, type StrictDocumentQuery, withLookup } from "./query-helpers.js"
 
 type ListIssuesError =
   | HulyClientError
@@ -40,6 +40,10 @@ type GetIssueError =
   | HulyConnectionError
   | ProjectNotFoundError
   | IssueNotFoundError
+
+type IssueWithLookup = WithLookup<HulyIssue> & {
+  $lookup?: { assignee?: Person }
+}
 
 const resolveStatusName = (
   statuses: Array<StatusInfo>,
@@ -59,7 +63,7 @@ export const listIssues = (
   Effect.gen(function*() {
     const { client, project, statuses } = yield* findProjectWithStatuses(params.project)
 
-    const query: DocumentQuery<HulyIssue> = {
+    const query: StrictDocumentQuery<IssueWithLookup> = {
       space: project._id
     }
 
@@ -159,13 +163,9 @@ export const listIssues = (
 
     const limit = clampLimit(params.limit)
 
-    type IssueWithLookup = WithLookup<HulyIssue> & {
-      $lookup?: { assignee?: Person }
-    }
-
     const issues = yield* client.findAll<IssueWithLookup>(
       tracker.class.Issue,
-      query,
+      hulyQuery(query),
       withLookup<IssueWithLookup>(
         {
           limit,
@@ -229,11 +229,11 @@ export const getIssue = (
 
     const issue = (yield* client.findOne<HulyIssue>(
       tracker.class.Issue,
-      { space: project._id, identifier: fullIdentifier }
+      hulyQuery<HulyIssue>({ space: project._id, identifier: fullIdentifier })
     )) ?? (number !== null
       ? yield* client.findOne<HulyIssue>(
         tracker.class.Issue,
-        { space: project._id, number }
+        hulyQuery<HulyIssue>({ space: project._id, number })
       )
       : undefined)
     if (issue === undefined) {
@@ -243,7 +243,7 @@ export const getIssue = (
     const statusName = resolveStatusName(statuses, issue.status)
 
     const person = issue.assignee !== null
-      ? yield* client.findOne<Person>(contact.class.Person, { _id: issue.assignee })
+      ? yield* client.findOne<Person>(contact.class.Person, hulyQuery<Person>({ _id: issue.assignee }))
       : undefined
 
     const description = issue.description

--- a/src/huly/operations/issues-shared.ts
+++ b/src/huly/operations/issues-shared.ts
@@ -1,4 +1,4 @@
-import type { DocumentQuery, Ref, Status, WithLookup } from "@hcengineering/core"
+import type { Ref, Status, WithLookup } from "@hcengineering/core"
 import type { ProjectType } from "@hcengineering/task"
 import type { Issue as HulyIssue, Project as HulyProject } from "@hcengineering/tracker"
 import { IssuePriority } from "@hcengineering/tracker"
@@ -11,7 +11,7 @@ import { normalizeForComparison } from "../../utils/normalize.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import { InvalidStatusError, IssueNotFoundError, ProjectNotFoundError } from "../errors.js"
 import { core, task, tracker } from "../huly-plugins.js"
-import { findOneOrFail } from "./query-helpers.js"
+import { findOneOrFail, hulyQuery } from "./query-helpers.js"
 
 // Huly API uses 0 as sentinel for "not set" on numeric fields like estimation and remainingTime.
 // Confirmed: creating an issue without estimation stores 0, not null/undefined.
@@ -36,7 +36,7 @@ export const findProject = (
     const project = yield* findOneOrFail(
       client,
       tracker.class.Project,
-      { identifier: projectIdentifier } satisfies DocumentQuery<HulyProject>,
+      { identifier: projectIdentifier },
       () => new ProjectNotFoundError({ identifier: projectIdentifier })
     )
 
@@ -76,7 +76,7 @@ export const findProjectWithStatuses = (
     const project = yield* findOneOrFail<ProjectWithType, ProjectNotFoundError>(
       client,
       tracker.class.Project,
-      { identifier: projectIdentifier } satisfies DocumentQuery<ProjectWithType>,
+      { identifier: projectIdentifier },
       () => new ProjectNotFoundError({ identifier: projectIdentifier }),
       { lookup: { type: task.class.ProjectType } }
     )
@@ -96,7 +96,7 @@ export const findProjectWithStatuses = (
         const statusDocsResult = yield* Effect.either(
           client.findAll<Status>(
             core.class.Status,
-            { _id: { $in: statusRefs } }
+            hulyQuery<Status>({ _id: { $in: statusRefs } })
           )
         )
 
@@ -188,17 +188,17 @@ export const findIssueInProject = (
 
     const issue = (yield* client.findOne<HulyIssue>(
       tracker.class.Issue,
-      {
+      hulyQuery<HulyIssue>({
         space: project._id,
         identifier: fullIdentifier
-      }
+      })
     )) ?? (number !== null
       ? yield* client.findOne<HulyIssue>(
         tracker.class.Issue,
-        {
+        hulyQuery<HulyIssue>({
           space: project._id,
           number
-        }
+        })
       )
       : undefined)
     if (issue === undefined) {

--- a/src/huly/operations/issues-write.ts
+++ b/src/huly/operations/issues-write.ts
@@ -39,6 +39,7 @@ import {
   type StatusInfo,
   stringToPriority
 } from "./issues-shared.js"
+import { hulyQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
 type CreateIssueError =
@@ -140,7 +141,7 @@ const resolveTaskTypeWorkflow = (
 ): Effect.Effect<TaskTypeWorkflow, HulyClientError | HulyError> =>
   Effect.gen(function*() {
     const workflowProjectType = projectType
-      ?? (yield* client.findOne<ProjectType>(task.class.ProjectType, { _id: project.type }))
+      ?? (yield* client.findOne<ProjectType>(task.class.ProjectType, hulyQuery<ProjectType>({ _id: project.type })))
     if (workflowProjectType === undefined) {
       return yield* Effect.fail(
         new HulyError({
@@ -152,11 +153,11 @@ const resolveTaskTypeWorkflow = (
 
     const taskTypesByProjectTypeList = yield* client.findAll<TaskType>(
       task.class.TaskType,
-      { _id: { $in: [...workflowProjectType.tasks] } }
+      hulyQuery<TaskType>({ _id: { $in: [...workflowProjectType.tasks] } })
     )
     const taskTypesByParent = yield* client.findAll<TaskType>(
       task.class.TaskType,
-      { parent: workflowProjectType._id }
+      hulyQuery<TaskType>({ parent: workflowProjectType._id })
     )
     const taskTypes = mergeTaskTypes([...taskTypesByProjectTypeList], [...taskTypesByParent])
     const matches = [...taskTypes].filter((candidate) => taskTypeMatches(candidate, taskTypeRef))
@@ -309,7 +310,7 @@ export const createIssue = (
 
     const lastIssue = yield* client.findOne<HulyIssue>(
       tracker.class.Issue,
-      { space: project._id },
+      hulyQuery<HulyIssue>({ space: project._id }),
       { sort: { rank: SortingOrder.Descending } }
     )
     const rank = makeRank(lastIssue?.rank, undefined)

--- a/src/huly/operations/labels.ts
+++ b/src/huly/operations/labels.ts
@@ -1,4 +1,4 @@
-import type { Class, Data, Doc, DocumentQuery, DocumentUpdate, Ref, Space } from "@hcengineering/core"
+import type { Class, Data, Doc, DocumentUpdate, Ref, Space } from "@hcengineering/core"
 import { generateId, SortingOrder } from "@hcengineering/core"
 import type { TagCategory as HulyTagCategory, TagElement as HulyTagElement, TagReference } from "@hcengineering/tags"
 import { Effect } from "effect"
@@ -17,7 +17,7 @@ import type { IssueNotFoundError, ProjectNotFoundError } from "../errors.js"
 import { TagCategoryNotFoundError, TagNotFoundError } from "../errors.js"
 import { core, tags, tracker } from "../huly-plugins.js"
 import { findProjectAndIssue } from "./issues-shared.js"
-import { clampLimit } from "./query-helpers.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 import { findCategoryByIdOrLabel } from "./tag-categories.js"
 
@@ -36,16 +36,16 @@ const findTagByIdOrTitle = (
   Effect.gen(function*() {
     const tag = (yield* client.findOne<HulyTagElement>(
       tags.class.TagElement,
-      {
+      hulyQuery<HulyTagElement>({
         _id: toRef<HulyTagElement>(idOrTitle),
         targetClass: issueClassRef
-      }
+      })
     )) ?? (yield* client.findOne<HulyTagElement>(
       tags.class.TagElement,
-      {
+      hulyQuery<HulyTagElement>({
         title: idOrTitle,
         targetClass: issueClassRef
-      }
+      })
     ))
 
     return tag
@@ -84,7 +84,7 @@ export const listLabels = (
 
     const limit = clampLimit(params.limit)
 
-    const query: DocumentQuery<HulyTagElement> = { targetClass: issueClassRef }
+    const query: StrictDocumentQuery<HulyTagElement> = { targetClass: issueClassRef }
 
     if (params.category !== undefined) {
       const catRef = yield* resolveCategoryRef(client, params.category)
@@ -95,7 +95,7 @@ export const listLabels = (
 
     const elements = yield* client.findAll<HulyTagElement>(
       tags.class.TagElement,
-      query,
+      hulyQuery(query),
       {
         limit,
         sort: { modifiedOn: SortingOrder.Descending }
@@ -119,10 +119,10 @@ export const createLabel = (
 
     const existing = yield* client.findOne<HulyTagElement>(
       tags.class.TagElement,
-      {
+      hulyQuery<HulyTagElement>({
         title: params.title,
         targetClass: issueClassRef
-      }
+      })
     )
 
     if (existing !== undefined) {
@@ -213,10 +213,10 @@ export const removeIssueLabel = (
 
     const tagRefs = yield* client.findAll<TagReference>(
       tags.class.TagReference,
-      {
+      hulyQuery<TagReference>({
         attachedTo: issue._id,
         attachedToClass: tracker.class.Issue
-      }
+      })
     )
 
     const matchingRef = tagRefs.find(

--- a/src/huly/operations/query-helpers.ts
+++ b/src/huly/operations/query-helpers.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect"
 import { MAX_LIMIT } from "../../domain/schemas/shared.js"
 import type { HulyClientError, HulyClientOperations } from "../client.js"
 
-type StrictDocumentQuery<T extends Doc> =
+export type StrictDocumentQuery<T extends Doc> =
   & {
     [P in keyof T]?: DocumentQuery<T>[P]
   }
@@ -43,12 +43,12 @@ export const withLookup = <T extends Doc>(
 export const findOneOrFail = <T extends Doc, E>(
   client: HulyClientOperations,
   _class: Ref<Class<T>>,
-  query: DocumentQuery<T>,
+  query: StrictDocumentQuery<T>,
   onNotFound: () => E,
   options?: FindOptions<T>
 ): Effect.Effect<WithLookup<T>, E | HulyClientError> =>
   Effect.flatMap(
-    client.findOne<T>(_class, query, options),
+    client.findOne<T>(_class, hulyQuery(query), options),
     (result) =>
       result !== undefined
         ? Effect.succeed(result)
@@ -58,23 +58,23 @@ export const findOneOrFail = <T extends Doc, E>(
 export const findByNameOrId = <T extends Doc>(
   client: HulyClientOperations,
   _class: Ref<Class<T>>,
-  primaryQuery: DocumentQuery<T>,
-  fallbackQuery: DocumentQuery<T>,
+  primaryQuery: StrictDocumentQuery<T>,
+  fallbackQuery: StrictDocumentQuery<T>,
   options?: FindOptions<T>
 ): Effect.Effect<WithLookup<T> | undefined, HulyClientError> =>
   Effect.flatMap(
-    client.findOne<T>(_class, primaryQuery, options),
+    client.findOne<T>(_class, hulyQuery(primaryQuery), options),
     (result) =>
       result !== undefined
         ? Effect.succeed(result)
-        : client.findOne<T>(_class, fallbackQuery, options)
+        : client.findOne<T>(_class, hulyQuery(fallbackQuery), options)
   )
 
 export const findByNameOrIdOrFail = <T extends Doc, E>(
   client: HulyClientOperations,
   _class: Ref<Class<T>>,
-  primaryQuery: DocumentQuery<T>,
-  fallbackQuery: DocumentQuery<T>,
+  primaryQuery: StrictDocumentQuery<T>,
+  fallbackQuery: StrictDocumentQuery<T>,
   onNotFound: () => E,
   options?: FindOptions<T>
 ): Effect.Effect<WithLookup<T>, E | HulyClientError> =>

--- a/src/huly/operations/task-management.ts
+++ b/src/huly/operations/task-management.ts
@@ -37,6 +37,7 @@ import { normalizeForComparison } from "../../utils/normalize.js"
 import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
 import { HulyConnectionError, HulyError } from "../errors.js"
 import { core, task, tracker } from "../huly-plugins.js"
+import { hulyQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
 type TaskManagementError = HulyClientError | HulyConnectionError | HulyError
@@ -104,7 +105,7 @@ const getStatusDocs = (
 ): Effect.Effect<ReadonlyArray<Status>, HulyClientError> =>
   statusIds.length === 0
     ? Effect.succeed([])
-    : client.findAll<Status>(core.class.Status, { _id: { $in: [...statusIds] } }).pipe(
+    : client.findAll<Status>(core.class.Status, hulyQuery<Status>({ _id: { $in: [...statusIds] } })).pipe(
       Effect.map((result) => [...result])
     )
 
@@ -114,7 +115,7 @@ const getTaskTypes = (
 ): Effect.Effect<ReadonlyArray<TaskType>, HulyClientError> =>
   taskTypeIds.length === 0
     ? Effect.succeed([])
-    : client.findAll<TaskType>(task.class.TaskType, { _id: { $in: [...taskTypeIds] } }).pipe(
+    : client.findAll<TaskType>(task.class.TaskType, hulyQuery<TaskType>({ _id: { $in: [...taskTypeIds] } })).pipe(
       Effect.map((result) => [...result])
     )
 
@@ -122,7 +123,7 @@ const getTaskTypesByProjectType = (
   client: HulyClientOperations,
   projectTypeId: Ref<ProjectType>
 ): Effect.Effect<ReadonlyArray<TaskType>, HulyClientError> =>
-  client.findAll<TaskType>(task.class.TaskType, { parent: projectTypeId }).pipe(
+  client.findAll<TaskType>(task.class.TaskType, hulyQuery<TaskType>({ parent: projectTypeId })).pipe(
     Effect.map((result) => [...result])
   )
 
@@ -130,7 +131,7 @@ const getRecoverableStatusesByName = (
   client: HulyClientOperations,
   name: string
 ): Effect.Effect<ReadonlyArray<Status>, never> =>
-  client.findAll<Status>(core.class.Status, { ofAttribute: tracker.attribute.IssueStatus }).pipe(
+  client.findAll<Status>(core.class.Status, hulyQuery<Status>({ ofAttribute: tracker.attribute.IssueStatus })).pipe(
     Effect.map((result) =>
       [...result].filter((status) => normalizeForComparison(status.name) === normalizeForComparison(name))
     ),
@@ -204,7 +205,7 @@ const listAllProjectTypes = (
 ): Effect.Effect<ReadonlyArray<ProjectType>, HulyClientError> =>
   client.findAll<ProjectType>(
     task.class.ProjectType,
-    {},
+    hulyQuery<ProjectType>({}),
     { sort: { name: SortingOrder.Ascending } }
   ).pipe(Effect.map((result) => [...result]))
 


### PR DESCRIPTION
## Summary

Propagates the strict Huly query convention introduced in PR #50 across the high-risk query paths we identified.

## Why

The Huly SDK `DocumentQuery<T>` permits arbitrary string keys, which allowed invented fields like `"blockedBy._id"` to typecheck even though live Huly did not return rows for that query shape. The previous PR added the narrow guard; this PR turns it into a documented project convention and applies it to the modules most likely to regress.

## Changes

- Document the `hulyQuery<T>()` / `StrictDocumentQuery<T>` convention in `CLAUDE.md`.
- Export `StrictDocumentQuery<T>` and make `findOneOrFail`, `findByNameOrId`, and `findByNameOrIdOrFail` enforce it internally.
- Convert direct Huly read queries in document, issue, label, relation, and task-management operations to `hulyQuery<T>()` or `StrictDocumentQuery<T>` for mutable builders.
- Add a patch changeset.

