### PR TITLE
[codex] Add generic association tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `activity`, `notifications`, `workspace`, `cards`, `custom-fields`, `labels`, `leads`, `processes`, `tag-categories`, `task-management`, `test-management`
+**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `cards`, `custom-fields`, `labels`, `leads`, `processes`, `tag-categories`, `task-management`, `test-management`
 
 ### Projects
 
@@ -383,6 +383,15 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 | Tool | Description |
 |------|-------------|
 | `fulltext_search` | Perform a global fulltext search across all Huly content. Searches issues, documents, messages, and other indexed content. Returns matching items sorted by relevance (newest first). |
+
+### Associations
+
+| Tool | Description |
+|------|-------------|
+| `list_associations` | List Huly association definitions: class-level typed links that define which document classes may be related. Use this before create_relation to discover association IDs, source/target classes, and whether relation writes are supported. |
+| `list_relations` | List concrete Huly relation instances under an association, optionally filtered by source and target documents. Requires at least one filter to avoid broad workspace scans. |
+| `create_relation` | Idempotently create one concrete relation between two resolved documents. Only succeeds for associations where list_associations reports canCreateRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated. |
+| `delete_relation` | Idempotently delete one concrete relation by relation ID or by exact association/source/target triple. Only succeeds for associations where list_associations reports canDeleteRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated. |
 
 ### Activity
 

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1164,6 +1164,42 @@ run_test "fulltext_search" \
 echo ""
 
 ##############################
+# 13b. GENERIC ASSOCIATIONS
+##############################
+echo "=== 13b. Generic Associations ==="
+ASSOCIATIONS_TEXT=$(run_capture "list_associations" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_associations","arguments":{"limit":5}},"id":2}')
+ASSOC_ID=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
+ASSOC_SOURCE_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].sourceClass // empty' 2>/dev/null)
+ASSOC_TARGET_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].targetClass // empty' 2>/dev/null)
+
+if [ -n "$ASSOC_ID" ]; then
+  assert_json_field_nonempty "list_associations has id" "$ASSOCIATIONS_TEXT" ".associations[0].associationId"
+  run_test "list_associations(filter:$ASSOC_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_associations\",\"arguments\":{\"association\":\"$ASSOC_ID\"}},\"id\":2}"
+  if [ -n "$ASSOC_SOURCE_CLASS" ] && [ -n "$ASSOC_TARGET_CLASS" ]; then
+    run_test "list_associations(class filters)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_associations\",\"arguments\":{\"sourceClass\":\"$ASSOC_SOURCE_CLASS\",\"targetClass\":\"$ASSOC_TARGET_CLASS\",\"limit\":5}},\"id\":2}"
+  fi
+  run_test "list_relations($ASSOC_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_relations\",\"arguments\":{\"association\":\"$ASSOC_ID\",\"limit\":3}},\"id\":2}"
+else
+  skip_test "list_associations has id" "no visible associations found in workspace"
+  skip_test "list_associations(filter)" "no visible associations found in workspace"
+  skip_test "list_relations" "no visible associations found in workspace"
+fi
+
+WRITABLE_ASSOCIATIONS_TEXT=$(run_capture "list_associations(writableOnly)" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_associations","arguments":{"writableOnly":true,"limit":1}},"id":2}')
+WRITABLE_ASSOC_ID=$(echo "$WRITABLE_ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
+if [ -n "$WRITABLE_ASSOC_ID" ]; then
+  skip_test "create_relation/delete_relation" "writable association discovered but disposable endpoint fixture is not defined yet"
+else
+  skip_test "create_relation/delete_relation" "read-only slice: no validated writable generic association allowlist"
+fi
+echo ""
+
+##############################
 # 14. CARDS
 ##############################
 echo "=== 14. Cards ==="

--- a/scripts/update-readme-tools.ts
+++ b/scripts/update-readme-tools.ts
@@ -51,6 +51,7 @@ const categoryOrder = [
   "calendar",
   "time tracking",
   "search",
+  "associations",
   "activity",
   "notifications",
   "workspace"

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -1,0 +1,264 @@
+import { JSONSchema, Schema } from "effect"
+
+import {
+  AssociationId,
+  DocumentIdentifier,
+  IssueIdentifier,
+  LimitParam,
+  NonEmptyString,
+  ObjectClassName,
+  ProjectIdentifier,
+  RelationId,
+  TeamspaceIdentifier,
+  Timestamp
+} from "./shared.js"
+
+export const AssociationIdentifier = NonEmptyString.pipe(Schema.brand("AssociationIdentifier"))
+export type AssociationIdentifier = Schema.Schema.Type<typeof AssociationIdentifier>
+
+export const RelationIdentifier = NonEmptyString.pipe(Schema.brand("RelationIdentifier"))
+export type RelationIdentifier = Schema.Schema.Type<typeof RelationIdentifier>
+
+export const CardinalitySchema = Schema.Literal(
+  "one-to-one",
+  "one-to-many",
+  "many-to-one",
+  "many-to-many",
+  "unknown"
+)
+
+export const RelationDirectionSchema = Schema.Literal("source-to-target", "target-to-source", "either")
+export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
+
+export const RelationIfExistsSchema = Schema.Literal("return_existing", "fail")
+export type RelationIfExists = Schema.Schema.Type<typeof RelationIfExistsSchema>
+
+const RawObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("raw"),
+  id: NonEmptyString.annotations({
+    description: "Raw Huly document _id"
+  }),
+  class: Schema.optional(ObjectClassName.annotations({
+    description:
+      "Raw Huly document class, such as tracker:class:Issue. Required unless the association side determines the expected class."
+  }))
+})
+
+const IssueObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("issue"),
+  issue: IssueIdentifier.annotations({
+    description: "Issue identifier, such as HULY-123, or a numeric issue number when project is also provided."
+  }),
+  project: Schema.optional(ProjectIdentifier.annotations({
+    description: "Project identifier. Optional when issue already includes a project prefix like HULY-123."
+  }))
+})
+
+const DocumentObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("document"),
+  document: DocumentIdentifier.annotations({
+    description: "Document title or ID"
+  }),
+  teamspace: Schema.optional(TeamspaceIdentifier.annotations({
+    description: "Teamspace name or ID. If omitted, document title matches must be unique across the workspace."
+  }))
+})
+
+export const GenericObjectLocatorSchema = Schema.Union(
+  RawObjectLocatorSchema,
+  IssueObjectLocatorSchema,
+  DocumentObjectLocatorSchema
+).annotations({
+  title: "GenericObjectLocator",
+  description:
+    "Explicit locator for a Huly document endpoint. Use raw for known _id values, issue for tracker issues, or document for Huly documents. Card locators are intentionally not included until a robust card resolver is available."
+})
+export type GenericObjectLocator = Schema.Schema.Type<typeof GenericObjectLocatorSchema>
+
+export const ResolvedObjectSummarySchema = Schema.Struct({
+  id: NonEmptyString,
+  class: ObjectClassName,
+  display: NonEmptyString,
+  locatorKind: Schema.Literal("raw", "issue", "document"),
+  warning: Schema.optional(Schema.String)
+})
+export type ResolvedObjectSummary = Schema.Schema.Type<typeof ResolvedObjectSummarySchema>
+
+export const AssociationSummarySchema = Schema.Struct({
+  associationId: AssociationId,
+  name: Schema.optional(NonEmptyString),
+  label: Schema.optional(NonEmptyString),
+  description: Schema.optional(Schema.String),
+  sourceClass: ObjectClassName,
+  targetClass: ObjectClassName,
+  sourceRole: Schema.optional(NonEmptyString),
+  targetRole: Schema.optional(NonEmptyString),
+  relationClass: Schema.optional(ObjectClassName),
+  cardinality: Schema.optional(CardinalitySchema),
+  symmetric: Schema.Boolean,
+  system: Schema.Boolean,
+  canListRelations: Schema.Boolean,
+  canCreateRelation: Schema.Boolean,
+  canDeleteRelation: Schema.Boolean,
+  unsupportedReason: Schema.optional(Schema.String)
+})
+export type AssociationSummary = Schema.Schema.Type<typeof AssociationSummarySchema>
+
+export const RelationSummarySchema = Schema.Struct({
+  relationId: RelationId,
+  associationId: AssociationId,
+  associationName: Schema.optional(NonEmptyString),
+  source: ResolvedObjectSummarySchema,
+  target: ResolvedObjectSummarySchema,
+  createdOn: Schema.optional(Timestamp),
+  modifiedOn: Schema.optional(Timestamp)
+})
+export type RelationSummary = Schema.Schema.Type<typeof RelationSummarySchema>
+
+export const ListAssociationsParamsSchema = Schema.Struct({
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id, source/target role name, or stable association name"
+  })),
+  sourceClass: Schema.optional(ObjectClassName.annotations({
+    description: "Only return associations whose source class matches this Huly class ID"
+  })),
+  targetClass: Schema.optional(ObjectClassName.annotations({
+    description: "Only return associations whose target class matches this Huly class ID"
+  })),
+  writableOnly: Schema.optional(Schema.Boolean.annotations({
+    description: "Only return associations whose relation create/delete path has been validated and allowlisted"
+  })),
+  includeSystem: Schema.optional(Schema.Boolean.annotations({
+    description: "Include internal/system associations. Defaults to false."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: "Maximum number of associations to return (default: 50)"
+  }))
+}).annotations({
+  title: "ListAssociationsParams",
+  description: "Parameters for listing generic Huly association definitions"
+})
+export type ListAssociationsParams = Schema.Schema.Type<typeof ListAssociationsParamsSchema>
+
+export const ListAssociationsResultSchema = Schema.Struct({
+  associations: Schema.Array(AssociationSummarySchema),
+  total: Schema.Number
+})
+export type ListAssociationsResult = Schema.Schema.Type<typeof ListAssociationsResultSchema>
+
+export const ListRelationsParamsSchema = Schema.Struct({
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id or name. If omitted, relations are listed only across supported visible associations."
+  })),
+  source: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Optional source endpoint filter"
+  })),
+  target: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Optional target endpoint filter"
+  })),
+  direction: Schema.optional(RelationDirectionSchema.annotations({
+    description: "source-to-target, target-to-source, or either. Defaults to source-to-target."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: "Maximum number of relations to return (default: 50)"
+  }))
+}).pipe(
+  Schema.filter((params) =>
+    params.association === undefined && params.source === undefined && params.target === undefined
+      ? "Provide at least one of association, source, or target to avoid broad workspace scans."
+      : undefined
+  )
+).annotations({
+  title: "ListRelationsParams",
+  description: "Parameters for listing concrete Huly relation instances"
+})
+export type ListRelationsParams = Schema.Schema.Type<typeof ListRelationsParamsSchema>
+
+export const ListRelationsResultSchema = Schema.Struct({
+  relations: Schema.Array(RelationSummarySchema),
+  total: Schema.Number
+})
+export type ListRelationsResult = Schema.Schema.Type<typeof ListRelationsResultSchema>
+
+export const CreateRelationParamsSchema = Schema.Struct({
+  association: AssociationIdentifier.annotations({
+    description: "Association _id or unambiguous name returned by list_associations"
+  }),
+  source: GenericObjectLocatorSchema.annotations({
+    description: "Source endpoint document"
+  }),
+  target: GenericObjectLocatorSchema.annotations({
+    description: "Target endpoint document"
+  }),
+  ifExists: Schema.optional(RelationIfExistsSchema.annotations({
+    description: "return_existing (default) returns an existing relation; fail reports an existing relation as an error"
+  }))
+}).annotations({
+  title: "CreateRelationParams",
+  description: "Parameters for idempotently creating a concrete generic relation"
+})
+export type CreateRelationParams = Schema.Schema.Type<typeof CreateRelationParamsSchema>
+
+export const CreateRelationResultSchema = Schema.Struct({
+  relationId: RelationId,
+  associationId: AssociationId,
+  source: ResolvedObjectSummarySchema,
+  target: ResolvedObjectSummarySchema,
+  created: Schema.Boolean,
+  existing: Schema.Boolean
+})
+export type CreateRelationResult = Schema.Schema.Type<typeof CreateRelationResultSchema>
+
+export const DeleteRelationParamsSchema = Schema.Struct({
+  relation: Schema.optional(RelationIdentifier.annotations({
+    description: "Concrete relation _id to delete"
+  })),
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id or unambiguous name. Required when deleting by source/target triple."
+  })),
+  source: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Source endpoint. Required when deleting by source/target triple."
+  })),
+  target: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Target endpoint. Required when deleting by source/target triple."
+  }))
+}).pipe(
+  Schema.filter((params) => {
+    const hasRelation = params.relation !== undefined
+    const hasTriple = params.association !== undefined && params.source !== undefined && params.target !== undefined
+    const hasPartialTriple = params.association !== undefined || params.source !== undefined
+      || params.target !== undefined
+
+    if (hasRelation && hasPartialTriple) {
+      return "Provide either relation, or association + source + target, not both."
+    }
+    if (!hasRelation && !hasTriple) {
+      return "Provide relation, or the full association + source + target triple. Partial triples are not allowed."
+    }
+    return undefined
+  })
+).annotations({
+  title: "DeleteRelationParams",
+  description: "Parameters for idempotently deleting one concrete generic relation"
+})
+export type DeleteRelationParams = Schema.Schema.Type<typeof DeleteRelationParamsSchema>
+
+export const DeleteRelationResultSchema = Schema.Struct({
+  relationId: Schema.optional(RelationId),
+  associationId: Schema.optional(AssociationId),
+  deleted: Schema.Boolean,
+  reason: Schema.optional(Schema.Literal("not_found", "deleted"))
+})
+export type DeleteRelationResult = Schema.Schema.Type<typeof DeleteRelationResultSchema>
+
+export const listAssociationsParamsJsonSchema = JSONSchema.make(ListAssociationsParamsSchema)
+export const listRelationsParamsJsonSchema = JSONSchema.make(ListRelationsParamsSchema)
+export const createRelationParamsJsonSchema = JSONSchema.make(CreateRelationParamsSchema)
+export const deleteRelationParamsJsonSchema = JSONSchema.make(DeleteRelationParamsSchema)
+
+const strictParseOptions = { onExcessProperty: "error" } as const
+
+export const parseListAssociationsParams = Schema.decodeUnknown(ListAssociationsParamsSchema, strictParseOptions)
+export const parseListRelationsParams = Schema.decodeUnknown(ListRelationsParamsSchema, strictParseOptions)
+export const parseCreateRelationParams = Schema.decodeUnknown(CreateRelationParamsSchema, strictParseOptions)
+export const parseDeleteRelationParams = Schema.decodeUnknown(DeleteRelationParamsSchema, strictParseOptions)

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- barrel re-export index; no logic, only re-exports from domain modules */
 export {
+  AssociationId,
   emptyParamsJsonSchema,
   EmptyParamsSchema,
   IssueId,
@@ -15,10 +16,53 @@ export {
   PositiveNumber,
   ProjectTypeId,
   ReactionId,
+  RelationId,
   SavedMessageId,
   TaskTypeId,
   Timestamp
 } from "./shared.js"
+
+export {
+  AssociationIdentifier,
+  type AssociationSummary,
+  AssociationSummarySchema,
+  CardinalitySchema,
+  type CreateRelationParams,
+  createRelationParamsJsonSchema,
+  CreateRelationParamsSchema,
+  type CreateRelationResult,
+  CreateRelationResultSchema,
+  type DeleteRelationParams,
+  deleteRelationParamsJsonSchema,
+  DeleteRelationParamsSchema,
+  type DeleteRelationResult,
+  DeleteRelationResultSchema,
+  type GenericObjectLocator,
+  GenericObjectLocatorSchema,
+  type ListAssociationsParams,
+  listAssociationsParamsJsonSchema,
+  ListAssociationsParamsSchema,
+  type ListAssociationsResult,
+  ListAssociationsResultSchema,
+  type ListRelationsParams,
+  listRelationsParamsJsonSchema,
+  ListRelationsParamsSchema,
+  type ListRelationsResult,
+  ListRelationsResultSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams,
+  type RelationDirection,
+  RelationDirectionSchema,
+  RelationIdentifier,
+  type RelationIfExists,
+  RelationIfExistsSchema,
+  type RelationSummary,
+  RelationSummarySchema,
+  type ResolvedObjectSummary,
+  ResolvedObjectSummarySchema
+} from "./generic-associations.js"
 
 export {
   type CreateProjectParams,

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -37,6 +37,12 @@ export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>
 export const IssueId = HulyRef("IssueId")
 export type IssueId = Schema.Schema.Type<typeof IssueId>
 
+export const AssociationId = HulyRef("AssociationId")
+export type AssociationId = Schema.Schema.Type<typeof AssociationId>
+
+export const RelationId = HulyRef("RelationId")
+export type RelationId = Schema.Schema.Type<typeof RelationId>
+
 export const ComponentId = HulyRef("ComponentId")
 export type ComponentId = Schema.Schema.Type<typeof ComponentId>
 

--- a/src/huly/errors-generic-associations.ts
+++ b/src/huly/errors-generic-associations.ts
@@ -1,0 +1,142 @@
+import { Schema } from "effect"
+
+import { AssociationId, RelationId } from "../domain/schemas/shared.js"
+
+const CandidateSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.optional(Schema.String),
+  sourceClass: Schema.optional(Schema.String),
+  targetClass: Schema.optional(Schema.String)
+})
+
+type Candidate = Schema.Schema.Type<typeof CandidateSchema>
+
+const formatCandidates = (candidates: ReadonlyArray<Candidate>): string =>
+  candidates.map((candidate) => {
+    const name = candidate.name === undefined ? "" : `${candidate.name} `
+    const classes = candidate.sourceClass === undefined || candidate.targetClass === undefined
+      ? ""
+      : ` ${candidate.sourceClass} -> ${candidate.targetClass}`
+    return `${name}(${candidate.id}${classes})`
+  }).join("; ")
+
+export class AssociationNotFoundError extends Schema.TaggedError<AssociationNotFoundError>()(
+  "AssociationNotFoundError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Association '${this.identifier}' not found. Call list_associations to discover valid association IDs.`
+  }
+}
+
+export class AssociationIdentifierAmbiguousError extends Schema.TaggedError<AssociationIdentifierAmbiguousError>()(
+  "AssociationIdentifierAmbiguousError",
+  {
+    identifier: Schema.String,
+    candidates: Schema.Array(CandidateSchema)
+  }
+) {
+  override get message(): string {
+    return `Association '${this.identifier}' matched multiple definitions: ${
+      formatCandidates(this.candidates)
+    }. Call list_associations with sourceClass and targetClass to choose one.`
+  }
+}
+
+export class RelationNotFoundError extends Schema.TaggedError<RelationNotFoundError>()(
+  "RelationNotFoundError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Relation '${this.identifier}' not found.`
+  }
+}
+
+export class RelationIdentifierAmbiguousError extends Schema.TaggedError<RelationIdentifierAmbiguousError>()(
+  "RelationIdentifierAmbiguousError",
+  {
+    identifier: Schema.String,
+    relationIds: Schema.Array(RelationId)
+  }
+) {
+  override get message(): string {
+    return `Relation selector '${this.identifier}' matched multiple relations: ${
+      this.relationIds.join(", ")
+    }. Delete by relation ID instead.`
+  }
+}
+
+export class RelationMutationUnsupportedError extends Schema.TaggedError<RelationMutationUnsupportedError>()(
+  "RelationMutationUnsupportedError",
+  {
+    associationId: Schema.optional(AssociationId),
+    reason: Schema.String
+  }
+) {
+  override get message(): string {
+    const id = this.associationId === undefined ? "" : ` for association '${this.associationId}'`
+    return `Generic relation mutation${id} is not supported: ${this.reason}. Call list_associations with writableOnly=true to discover writable associations.`
+  }
+}
+
+export class RelationEndpointClassMismatchError extends Schema.TaggedError<RelationEndpointClassMismatchError>()(
+  "RelationEndpointClassMismatchError",
+  {
+    field: Schema.String,
+    expectedClass: Schema.String,
+    actualClass: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Relation endpoint '${this.field}' has class '${this.actualClass}', expected '${this.expectedClass}'.`
+  }
+}
+
+export class GenericObjectIdentifierAmbiguousError extends Schema.TaggedError<GenericObjectIdentifierAmbiguousError>()(
+  "GenericObjectIdentifierAmbiguousError",
+  {
+    field: Schema.String,
+    identifier: Schema.String,
+    candidates: Schema.Array(Schema.Struct({
+      id: Schema.String,
+      class: Schema.String,
+      display: Schema.String
+    }))
+  }
+) {
+  override get message(): string {
+    const candidates = this.candidates.map((candidate) => `${candidate.display} (${candidate.id}, ${candidate.class})`)
+      .join("; ")
+    return `Object locator '${this.field}' for '${this.identifier}' is ambiguous. Use a raw locator with one of these IDs: ${candidates}`
+  }
+}
+
+export class GenericObjectLocatorInvalidError extends Schema.TaggedError<GenericObjectLocatorInvalidError>()(
+  "GenericObjectLocatorInvalidError",
+  {
+    field: Schema.String,
+    reason: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Object locator '${this.field}' is invalid: ${this.reason}`
+  }
+}
+
+export class GenericObjectNotFoundError extends Schema.TaggedError<GenericObjectNotFoundError>()(
+  "GenericObjectNotFoundError",
+  {
+    field: Schema.String,
+    identifier: Schema.String,
+    class: Schema.optional(Schema.String)
+  }
+) {
+  override get message(): string {
+    const classHint = this.class === undefined ? "" : ` with class '${this.class}'`
+    return `Object locator '${this.field}' for '${this.identifier}'${classHint} not found.`
+  }
+}

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -47,6 +47,17 @@ import {
   InvalidContentTypeError,
   InvalidFileDataError
 } from "./errors-files.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError
+} from "./errors-generic-associations.js"
 import { TagCategoryNotFoundError, TagNotFoundError } from "./errors-labels.js"
 import { FunnelNotFoundError, LeadNotFoundError } from "./errors-leads.js"
 import {
@@ -92,6 +103,8 @@ import {
 
 export {
   ActivityMessageNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
@@ -115,6 +128,9 @@ export {
   FileTooLargeError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   HulyError,
@@ -145,6 +161,10 @@ export {
   ProjectNotFoundError,
   ReactionNotFoundError,
   RecurringEventNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError,
   SavedMessageNotFoundError,
   TagCategoryNotFoundError,
   TagNotFoundError,
@@ -230,6 +250,15 @@ export type HulyDomainError =
   | ProcessMasterTagNotFoundError
   | ProcessCardIdentifierAmbiguousError
   | ProcessCardNotFoundError
+  | AssociationNotFoundError
+  | AssociationIdentifierAmbiguousError
+  | RelationNotFoundError
+  | RelationIdentifierAmbiguousError
+  | RelationMutationUnsupportedError
+  | RelationEndpointClassMismatchError
+  | GenericObjectIdentifierAmbiguousError
+  | GenericObjectLocatorInvalidError
+  | GenericObjectNotFoundError
 
 /**
  * Schema for all Huly domain errors (for serialization).
@@ -301,7 +330,16 @@ export const HulyDomainError: Schema.Union<
     typeof ProcessMasterTagAmbiguousError,
     typeof ProcessMasterTagNotFoundError,
     typeof ProcessCardIdentifierAmbiguousError,
-    typeof ProcessCardNotFoundError
+    typeof ProcessCardNotFoundError,
+    typeof AssociationNotFoundError,
+    typeof AssociationIdentifierAmbiguousError,
+    typeof RelationNotFoundError,
+    typeof RelationIdentifierAmbiguousError,
+    typeof RelationMutationUnsupportedError,
+    typeof RelationEndpointClassMismatchError,
+    typeof GenericObjectIdentifierAmbiguousError,
+    typeof GenericObjectLocatorInvalidError,
+    typeof GenericObjectNotFoundError
   ]
 > = Schema.Union(
   HulyError,
@@ -369,5 +407,14 @@ export const HulyDomainError: Schema.Union<
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
   ProcessCardIdentifierAmbiguousError,
-  ProcessCardNotFoundError
+  ProcessCardNotFoundError,
+  AssociationNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  RelationNotFoundError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationEndpointClassMismatchError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError
 )

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -1,0 +1,691 @@
+/* eslint-disable max-lines -- generic association discovery, relation lookup, and guarded mutation entrypoints are kept together to preserve one feature boundary */
+import type { Association as HulyAssociation, Doc, Relation as HulyRelation } from "@hcengineering/core"
+import { SortingOrder } from "@hcengineering/core"
+import type { Document as HulyDocument } from "@hcengineering/document"
+import { Effect } from "effect"
+
+import type {
+  AssociationSummary,
+  CreateRelationParams,
+  CreateRelationResult,
+  DeleteRelationParams,
+  DeleteRelationResult,
+  GenericObjectLocator,
+  ListAssociationsParams,
+  ListAssociationsResult,
+  ListRelationsParams,
+  ListRelationsResult,
+  RelationDirection,
+  RelationSummary,
+  ResolvedObjectSummary
+} from "../../domain/schemas/generic-associations.js"
+import { AssociationId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
+import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
+import type {
+  DocumentNotFoundError,
+  IssueNotFoundError,
+  ProjectNotFoundError,
+  TeamspaceNotFoundError
+} from "../errors.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationMutationUnsupportedError
+} from "../errors.js"
+import { core, documentPlugin } from "../huly-plugins.js"
+import { findTeamspaceAndDocument } from "./documents.js"
+import { findIssueInProject, findProject, findProjectAndIssue } from "./issues-shared.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { toClassRef, toRef } from "./sdk-boundary.js"
+
+type GenericAssociationsError =
+  | HulyClientError
+  | AssociationNotFoundError
+  | AssociationIdentifierAmbiguousError
+  | ProjectNotFoundError
+  | TeamspaceNotFoundError
+  | DocumentNotFoundError
+  | RelationMutationUnsupportedError
+  | RelationEndpointClassMismatchError
+  | GenericObjectIdentifierAmbiguousError
+  | GenericObjectLocatorInvalidError
+  | GenericObjectNotFoundError
+  | IssueNotFoundError
+
+type AssociationCandidate = {
+  readonly id: string
+  readonly name?: string | undefined
+  readonly sourceClass?: string | undefined
+  readonly targetClass?: string | undefined
+}
+
+const WRITE_UNSUPPORTED_REASON = "no generic association relation write path has been live-validated for this workspace"
+const ASSOCIATION_DISCOVERY_LIMIT = 200
+const ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT = 2
+
+const associationName = (association: HulyAssociation): string | undefined =>
+  association.nameA === association.nameB
+    ? association.nameA
+    : `${association.nameA} -> ${association.nameB}`
+
+const optionalNonEmpty = (value: string | undefined): NonEmptyString | undefined =>
+  value === undefined ? undefined : NonEmptyString.make(value)
+
+const isSystemAssociation = (association: HulyAssociation): boolean =>
+  String(association.classA).startsWith("core:class:") || String(association.classB).startsWith("core:class:")
+
+const isSymmetric = (association: HulyAssociation): boolean =>
+  association.classA === association.classB && association.nameA === association.nameB
+
+const cardinality = (type: HulyAssociation["type"]): AssociationSummary["cardinality"] => {
+  switch (type) {
+    case "1:1":
+      return "one-to-one"
+    case "1:N":
+      return "one-to-many"
+    case "N:N":
+      return "many-to-many"
+  }
+}
+
+const toAssociationSummary = (association: HulyAssociation): AssociationSummary => ({
+  associationId: AssociationId.make(association._id),
+  name: optionalNonEmpty(associationName(association)),
+  sourceClass: ObjectClassName.make(association.classA),
+  targetClass: ObjectClassName.make(association.classB),
+  sourceRole: NonEmptyString.make(association.nameA),
+  targetRole: NonEmptyString.make(association.nameB),
+  relationClass: ObjectClassName.make(core.class.Relation),
+  cardinality: cardinality(association.type),
+  symmetric: isSymmetric(association),
+  system: isSystemAssociation(association),
+  canListRelations: true,
+  canCreateRelation: false,
+  canDeleteRelation: false,
+  unsupportedReason: WRITE_UNSUPPORTED_REASON
+})
+
+const toCandidate = (association: HulyAssociation): AssociationCandidate => ({
+  id: association._id,
+  name: associationName(association),
+  sourceClass: association.classA,
+  targetClass: association.classB
+})
+
+const matchesAssociationIdentifier = (association: HulyAssociation, identifier: string): boolean => {
+  const normalized = identifier.trim().toLowerCase()
+  return association._id.toLowerCase() === normalized
+    || association.nameA.toLowerCase() === normalized
+    || association.nameB.toLowerCase() === normalized
+    || associationName(association)?.toLowerCase() === normalized
+}
+
+const associationMatchesFilters = (
+  association: HulyAssociation,
+  params?: Pick<ListAssociationsParams, "sourceClass" | "targetClass" | "includeSystem">
+): boolean =>
+  (params?.includeSystem === true || !isSystemAssociation(association))
+  && (params?.sourceClass === undefined || association.classA === String(params.sourceClass))
+  && (params?.targetClass === undefined || association.classB === String(params.targetClass))
+
+const filterVisible = (
+  associations: ReadonlyArray<HulyAssociation>,
+  params: ListAssociationsParams
+): Array<HulyAssociation> =>
+  associations.filter((association) =>
+    (params.includeSystem === true || !isSystemAssociation(association))
+    && (params.sourceClass === undefined || association.classA === String(params.sourceClass))
+    && (params.targetClass === undefined || association.classB === String(params.targetClass))
+    && (params.writableOnly !== true)
+  )
+
+const listAssociationDocs = (
+  client: HulyClientOperations,
+  params: ListAssociationsParams
+): Effect.Effect<Array<HulyAssociation>, HulyClientError> => {
+  const query: StrictDocumentQuery<HulyAssociation> = {}
+
+  if (params.sourceClass !== undefined) {
+    query.classA = toClassRef(params.sourceClass)
+  }
+  if (params.targetClass !== undefined) {
+    query.classB = toClassRef(params.targetClass)
+  }
+
+  return Effect.map(
+    client.findAll<HulyAssociation>(
+      core.class.Association,
+      hulyQuery(query),
+      {
+        limit: clampLimit(params.limit),
+        sort: { modifiedOn: SortingOrder.Descending }
+      }
+    ),
+    (result) => [...result]
+  )
+}
+
+const associationClassFilterQuery = (
+  params?: Pick<ListAssociationsParams, "sourceClass" | "targetClass">
+): StrictDocumentQuery<HulyAssociation> => {
+  const query: StrictDocumentQuery<HulyAssociation> = {}
+
+  if (params?.sourceClass !== undefined) {
+    query.classA = toClassRef(params.sourceClass)
+  }
+  if (params?.targetClass !== undefined) {
+    query.classB = toClassRef(params.targetClass)
+  }
+
+  return query
+}
+
+const resolveAssociation = (
+  client: HulyClientOperations,
+  identifier: string,
+  params?: Pick<ListAssociationsParams, "sourceClass" | "targetClass" | "includeSystem">
+): Effect.Effect<HulyAssociation, GenericAssociationsError> =>
+  Effect.gen(function*() {
+    const exactId = yield* client.findOne<HulyAssociation>(
+      core.class.Association,
+      hulyQuery<HulyAssociation>({ _id: toRef<HulyAssociation>(identifier) })
+    )
+    if (exactId !== undefined) {
+      if (!associationMatchesFilters(exactId, params)) {
+        return yield* new AssociationNotFoundError({ identifier })
+      }
+      return exactId
+    }
+
+    const nameCandidates = new Map<string, HulyAssociation>()
+    const addCandidates = (associations: ReadonlyArray<HulyAssociation>): void => {
+      for (const association of associations) {
+        if (matchesAssociationIdentifier(association, identifier) && associationMatchesFilters(association, params)) {
+          nameCandidates.set(association._id, association)
+        }
+      }
+    }
+
+    addCandidates(
+      yield* client.findAll<HulyAssociation>(
+        core.class.Association,
+        hulyQuery<HulyAssociation>({
+          ...associationClassFilterQuery(params),
+          nameA: identifier
+        }),
+        { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+      )
+    )
+    addCandidates(
+      yield* client.findAll<HulyAssociation>(
+        core.class.Association,
+        hulyQuery<HulyAssociation>({
+          ...associationClassFilterQuery(params),
+          nameB: identifier
+        }),
+        { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+      )
+    )
+
+    const rolePair = identifier.split(" -> ")
+    if (rolePair.length === 2) {
+      addCandidates(
+        yield* client.findAll<HulyAssociation>(
+          core.class.Association,
+          hulyQuery<HulyAssociation>({
+            ...associationClassFilterQuery(params),
+            nameA: rolePair[0],
+            nameB: rolePair[1]
+          }),
+          { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+        )
+      )
+    }
+
+    const candidates = [...nameCandidates.values()]
+
+    if (candidates.length === 0) {
+      return yield* new AssociationNotFoundError({ identifier })
+    }
+    if (candidates.length > 1) {
+      return yield* new AssociationIdentifierAmbiguousError({
+        identifier,
+        candidates: candidates.map(toCandidate)
+      })
+    }
+    return candidates[0]
+  })
+
+export const listAssociations = (
+  params: ListAssociationsParams
+): Effect.Effect<ListAssociationsResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+
+    if (params.association !== undefined) {
+      const association = yield* resolveAssociation(client, params.association, {
+        includeSystem: params.includeSystem,
+        sourceClass: params.sourceClass,
+        targetClass: params.targetClass
+      })
+      const summary = toAssociationSummary(association)
+      return {
+        associations: params.writableOnly === true && !summary.canCreateRelation ? [] : [summary],
+        total: params.writableOnly === true && !summary.canCreateRelation ? 0 : 1
+      }
+    }
+
+    const associations = filterVisible(
+      yield* listAssociationDocs(client, { ...params, limit: ASSOCIATION_DISCOVERY_LIMIT }),
+      params
+    ).slice(0, clampLimit(params.limit))
+    const summaries = associations.map(toAssociationSummary)
+
+    return {
+      associations: summaries,
+      total: summaries.length
+    }
+  })
+
+const displayFromDoc = (doc: Doc): string => {
+  for (const field of ["identifier", "title", "name"]) {
+    const value = Reflect.get(doc, field)
+    if (typeof value === "string" && value.trim() !== "") {
+      return value
+    }
+  }
+  return doc._id
+}
+
+const resolvedSummary = (
+  doc: Doc,
+  locatorKind: ResolvedObjectSummary["locatorKind"],
+  warning?: string
+): ResolvedObjectSummary => ({
+  id: NonEmptyString.make(doc._id),
+  class: ObjectClassName.make(doc._class),
+  display: NonEmptyString.make(displayFromDoc(doc)),
+  locatorKind,
+  warning
+})
+
+const findRawDoc = (
+  client: HulyClientOperations,
+  id: string,
+  className: string
+): Effect.Effect<Doc | undefined, HulyClientError> =>
+  client.findOne<Doc>(
+    toClassRef(className),
+    hulyQuery<Doc>({ _id: toRef<Doc>(id) })
+  )
+
+const validateExpectedClass = (
+  summary: ResolvedObjectSummary,
+  expectedClass: string | undefined,
+  field: string
+): Effect.Effect<void, RelationEndpointClassMismatchError> => {
+  if (expectedClass !== undefined && summary.class !== expectedClass) {
+    return Effect.fail(
+      new RelationEndpointClassMismatchError({
+        field,
+        expectedClass,
+        actualClass: summary.class
+      })
+    )
+  }
+  return Effect.void
+}
+
+const resolveIssueLocator = (
+  locator: Extract<GenericObjectLocator, { kind: "issue" }>,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    if (locator.project !== undefined) {
+      const { issue } = yield* findProjectAndIssue({ project: locator.project, identifier: locator.issue })
+      return resolvedSummary(issue, "issue")
+    }
+
+    const match = String(locator.issue).match(/^([A-Z]+)-\d+$/i)
+    if (match !== null) {
+      const { client, project } = yield* findProject(match[1].toUpperCase())
+      const issue = yield* findIssueInProject(client, project, locator.issue)
+      return resolvedSummary(issue, "issue")
+    }
+
+    return yield* new GenericObjectLocatorInvalidError({
+      field,
+      reason: "issue locator without project must use a full project-prefixed identifier like HULY-123"
+    })
+  })
+
+const resolveDocumentWithoutTeamspace = (
+  client: HulyClientOperations,
+  identifier: string,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError> =>
+  Effect.gen(function*() {
+    const byId = yield* client.findOne<HulyDocument>(
+      documentPlugin.class.Document,
+      hulyQuery<HulyDocument>({ _id: toRef<HulyDocument>(identifier) })
+    )
+    if (byId !== undefined) {
+      return resolvedSummary(byId, "document")
+    }
+
+    const byTitle = yield* client.findAll<HulyDocument>(
+      documentPlugin.class.Document,
+      hulyQuery<HulyDocument>({ title: identifier }),
+      { limit: 2 }
+    )
+
+    if (byTitle.length === 0) {
+      return yield* new GenericObjectNotFoundError({
+        field,
+        identifier,
+        class: documentPlugin.class.Document
+      })
+    }
+    if (byTitle.length > 1) {
+      return yield* new GenericObjectIdentifierAmbiguousError({
+        field,
+        identifier,
+        candidates: byTitle.map((doc) => ({
+          id: doc._id,
+          class: doc._class,
+          display: doc.title
+        }))
+      })
+    }
+    return resolvedSummary(byTitle[0], "document")
+  })
+
+const resolveGenericObject = (
+  client: HulyClientOperations,
+  locator: GenericObjectLocator,
+  expectedClass: string | undefined,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    switch (locator.kind) {
+      case "raw": {
+        const className = locator.class ?? expectedClass
+        if (className === undefined) {
+          return yield* new GenericObjectLocatorInvalidError({
+            field,
+            reason: "raw object locator requires class unless association side class is known"
+          })
+        }
+        const doc = yield* findRawDoc(client, locator.id, className)
+        if (doc === undefined) {
+          return yield* new GenericObjectNotFoundError({
+            field,
+            identifier: locator.id,
+            class: className
+          })
+        }
+        const summary = resolvedSummary(doc, "raw")
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+      case "issue": {
+        const summary = yield* resolveIssueLocator(locator, field)
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+      case "document": {
+        const summary = locator.teamspace === undefined
+          ? yield* resolveDocumentWithoutTeamspace(client, locator.document, field)
+          : resolvedSummary(
+            (yield* findTeamspaceAndDocument({
+              teamspace: locator.teamspace,
+              document: locator.document
+            })).doc,
+            "document"
+          )
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+    }
+  })
+
+const unresolvedRelationEndpoint = (
+  id: string,
+  className: string,
+  warning: string
+): ResolvedObjectSummary => ({
+  id: NonEmptyString.make(id),
+  class: ObjectClassName.make(className),
+  display: NonEmptyString.make(id),
+  locatorKind: "raw",
+  warning
+})
+
+const resolveRelationEndpoint = (
+  client: HulyClientOperations,
+  id: string,
+  className: string
+): Effect.Effect<ResolvedObjectSummary, HulyClientError> =>
+  Effect.map(
+    findRawDoc(client, id, className),
+    (doc) =>
+      doc === undefined
+        ? unresolvedRelationEndpoint(id, className, `Could not resolve related ${className} document for display.`)
+        : resolvedSummary(doc, "raw")
+  )
+
+const relationToSummary = (
+  client: HulyClientOperations,
+  association: HulyAssociation,
+  relation: HulyRelation
+): Effect.Effect<RelationSummary, HulyClientError> =>
+  Effect.gen(function*() {
+    const source = yield* resolveRelationEndpoint(client, relation.docA, association.classA)
+    const target = yield* resolveRelationEndpoint(client, relation.docB, association.classB)
+    return {
+      relationId: RelationId.make(relation._id),
+      associationId: AssociationId.make(association._id),
+      associationName: optionalNonEmpty(associationName(association)),
+      source,
+      target,
+      createdOn: relation.createdOn,
+      modifiedOn: relation.modifiedOn
+    }
+  })
+
+const directionQueries = (
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): Array<StrictDocumentQuery<HulyRelation>> => {
+  const makeQuery = (reversed: boolean): StrictDocumentQuery<HulyRelation> => {
+    const query: StrictDocumentQuery<HulyRelation> = {
+      association: toRef<HulyAssociation>(association._id)
+    }
+    if (source !== undefined) {
+      if (reversed) query.docB = toRef<Doc>(source.id)
+      else query.docA = toRef<Doc>(source.id)
+    }
+    if (target !== undefined) {
+      if (reversed) query.docA = toRef<Doc>(target.id)
+      else query.docB = toRef<Doc>(target.id)
+    }
+    return query
+  }
+
+  if (direction === "target-to-source") {
+    return [makeQuery(true)]
+  }
+  if (direction === "either") {
+    return source === undefined && target === undefined
+      ? [makeQuery(false)]
+      : [makeQuery(false), makeQuery(true)]
+  }
+  return [makeQuery(false)]
+}
+
+const findRelationsForAssociation = (
+  client: HulyClientOperations,
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<HulyRelation>, HulyClientError> =>
+  Effect.gen(function*() {
+    const byId = new Map<string, HulyRelation>()
+    for (const query of directionQueries(association, source, target, direction)) {
+      const relations = yield* client.findAll<HulyRelation>(
+        core.class.Relation,
+        hulyQuery(query),
+        { limit }
+      )
+      for (const relation of relations) {
+        byId.set(relation._id, relation)
+      }
+    }
+    return [...byId.values()].slice(0, limit)
+  })
+
+const associationMatchesEndpoints = (
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): boolean => {
+  if (direction === "target-to-source") {
+    return (source === undefined || String(source.class) === association.classB)
+      && (target === undefined || String(target.class) === association.classA)
+  }
+
+  if (direction === "either") {
+    const matchesForward = (source === undefined || String(source.class) === association.classA)
+      && (target === undefined || String(target.class) === association.classB)
+    const matchesReverse = (source === undefined || String(source.class) === association.classB)
+      && (target === undefined || String(target.class) === association.classA)
+    return matchesForward || matchesReverse
+  }
+
+  return (source === undefined || String(source.class) === association.classA)
+    && (target === undefined || String(target.class) === association.classB)
+}
+
+const listRelationsForResolvedEndpoints = (
+  client: HulyClientOperations,
+  associations: ReadonlyArray<HulyAssociation>,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
+  Effect.gen(function*() {
+    const summaries: Array<RelationSummary> = []
+    for (const association of associations) {
+      if (!associationMatchesEndpoints(association, source, target, direction)) {
+        continue
+      }
+
+      const relations = yield* findRelationsForAssociation(client, association, source, target, direction, limit)
+      for (const relation of relations) {
+        summaries.push(yield* relationToSummary(client, association, relation))
+        if (summaries.length >= limit) {
+          break
+        }
+      }
+      if (summaries.length >= limit) {
+        break
+      }
+    }
+    return summaries
+  })
+
+export const listRelations = (
+  params: ListRelationsParams
+): Effect.Effect<ListRelationsResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const limit = clampLimit(params.limit)
+    const direction = params.direction ?? "source-to-target"
+
+    if (params.association === undefined) {
+      const associations = filterVisible(
+        yield* listAssociationDocs(client, {
+          includeSystem: false,
+          limit: ASSOCIATION_DISCOVERY_LIMIT
+        }),
+        {
+          includeSystem: false,
+          limit: ASSOCIATION_DISCOVERY_LIMIT
+        }
+      )
+      const source = params.source === undefined
+        ? undefined
+        : yield* resolveGenericObject(client, params.source, undefined, "source")
+      const target = params.target === undefined
+        ? undefined
+        : yield* resolveGenericObject(client, params.target, undefined, "target")
+      const summaries = yield* listRelationsForResolvedEndpoints(client, associations, source, target, direction, limit)
+
+      return {
+        relations: summaries,
+        total: summaries.length
+      }
+    }
+
+    const association = yield* resolveAssociation(client, params.association, { includeSystem: true })
+    const sourceClass = direction === "either"
+      ? undefined
+      : direction === "target-to-source"
+      ? association.classB
+      : association.classA
+    const targetClass = direction === "either"
+      ? undefined
+      : direction === "target-to-source"
+      ? association.classA
+      : association.classB
+    const source = params.source === undefined
+      ? undefined
+      : yield* resolveGenericObject(client, params.source, sourceClass, "source")
+    const target = params.target === undefined
+      ? undefined
+      : yield* resolveGenericObject(client, params.target, targetClass, "target")
+    const summaries = yield* listRelationsForResolvedEndpoints(client, [association], source, target, direction, limit)
+
+    return {
+      relations: summaries,
+      total: summaries.length
+    }
+  })
+
+export const createRelation = (
+  params: CreateRelationParams
+): Effect.Effect<CreateRelationResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const association = yield* resolveAssociation(client, params.association, { includeSystem: true })
+
+    return yield* new RelationMutationUnsupportedError({
+      associationId: AssociationId.make(association._id),
+      reason: WRITE_UNSUPPORTED_REASON
+    })
+  })
+
+export const deleteRelation = (
+  params: DeleteRelationParams
+): Effect.Effect<DeleteRelationResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const association = params.association === undefined
+      ? undefined
+      : yield* resolveAssociation(client, params.association, { includeSystem: true })
+
+    return yield* new RelationMutationUnsupportedError({
+      associationId: association === undefined ? undefined : AssociationId.make(association._id),
+      reason: WRITE_UNSUPPORTED_REASON
+    })
+  })

--- a/src/huly/operations/sdk-boundary.ts
+++ b/src/huly/operations/sdk-boundary.ts
@@ -1,4 +1,4 @@
-import type { Doc, PersonUuid, Ref } from "@hcengineering/core"
+import type { Class, Doc, PersonUuid, Ref } from "@hcengineering/core"
 import { Effect } from "effect"
 
 import type { NonEmptyString } from "../../domain/schemas/shared.js"
@@ -8,6 +8,12 @@ import { InvalidPersonUuidError } from "../errors.js"
 // Our domain uses Effect Schema brands. No type-safe bridge exists; this is the boundary cast.
 // eslint-disable-next-line no-restricted-syntax -- see above
 export const toRef = <T extends Doc>(id: NonEmptyString | Ref<T>): Ref<T> => id as Ref<T>
+
+// Huly class references are also branded strings. Dynamic generic-association
+// operations receive class IDs from association metadata, so this is the
+// centralized SDK boundary for converting validated class strings back to refs.
+// eslint-disable-next-line no-restricted-syntax -- see above
+export const toClassRef = <T extends Doc>(id: string | Ref<Class<T>>): Ref<Class<T>> => id as Ref<Class<T>>
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -120,7 +120,16 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "ProcessMasterTagAmbiguousError",
   "ProcessMasterTagNotFoundError",
   "ProcessCardIdentifierAmbiguousError",
-  "ProcessCardNotFoundError"
+  "ProcessCardNotFoundError",
+  "AssociationNotFoundError",
+  "AssociationIdentifierAmbiguousError",
+  "RelationNotFoundError",
+  "RelationIdentifierAmbiguousError",
+  "RelationMutationUnsupportedError",
+  "RelationEndpointClassMismatchError",
+  "GenericObjectIdentifierAmbiguousError",
+  "GenericObjectLocatorInvalidError",
+  "GenericObjectNotFoundError"
 ])
 
 const INTERNAL_ERROR_PREFIX: Partial<Record<HulyDomainError["_tag"], string>> = {

--- a/src/mcp/tools/generic-associations.ts
+++ b/src/mcp/tools/generic-associations.ts
@@ -1,0 +1,84 @@
+import {
+  createRelationParamsJsonSchema,
+  CreateRelationResultSchema,
+  deleteRelationParamsJsonSchema,
+  DeleteRelationResultSchema,
+  listAssociationsParamsJsonSchema,
+  ListAssociationsResultSchema,
+  listRelationsParamsJsonSchema,
+  ListRelationsResultSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams
+} from "../../domain/schemas/generic-associations.js"
+import {
+  createRelation,
+  deleteRelation,
+  listAssociations,
+  listRelations
+} from "../../huly/operations/generic-associations.js"
+import { createEncodedToolHandler, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "associations" as const
+
+export const genericAssociationTools: ReadonlyArray<RegisteredTool> = [
+  {
+    name: "list_associations",
+    description:
+      "List Huly association definitions: class-level typed links that define which document classes may be related. Use this before create_relation to discover association IDs, source/target classes, and whether relation writes are supported.",
+    category: CATEGORY,
+    inputSchema: listAssociationsParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "list_associations",
+      parseListAssociationsParams,
+      listAssociations,
+      ListAssociationsResultSchema
+    )
+  },
+  {
+    name: "list_relations",
+    description:
+      "List concrete Huly relation instances under an association, optionally filtered by source and target documents. Requires at least one filter to avoid broad workspace scans.",
+    category: CATEGORY,
+    inputSchema: listRelationsParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "list_relations",
+      parseListRelationsParams,
+      listRelations,
+      ListRelationsResultSchema
+    )
+  },
+  {
+    name: "create_relation",
+    description:
+      "Idempotently create one concrete relation between two resolved documents. Only succeeds for associations where list_associations reports canCreateRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated.",
+    category: CATEGORY,
+    inputSchema: createRelationParamsJsonSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    },
+    handler: createEncodedToolHandler(
+      "create_relation",
+      parseCreateRelationParams,
+      createRelation,
+      CreateRelationResultSchema
+    )
+  },
+  {
+    name: "delete_relation",
+    description:
+      "Idempotently delete one concrete relation by relation ID or by exact association/source/target triple. Only succeeds for associations where list_associations reports canDeleteRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated.",
+    category: CATEGORY,
+    inputSchema: deleteRelationParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "delete_relation",
+      parseDeleteRelationParams,
+      deleteRelation,
+      DeleteRelationResultSchema
+    )
+  }
+]

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -12,6 +12,7 @@ import { contactTools } from "./contacts.js"
 import { customFieldTools } from "./custom-fields.js"
 import { deletionTools } from "./deletion.js"
 import { documentTools } from "./documents.js"
+import { genericAssociationTools } from "./generic-associations.js"
 import { issueTools } from "./issues.js"
 import { labelTools } from "./labels.js"
 import { leadTools } from "./leads.js"
@@ -39,6 +40,7 @@ const allTools: ReadonlyArray<RegisteredTool> = [
   ...deletionTools,
   ...milestoneTools,
   ...documentTools,
+  ...genericAssociationTools,
   ...storageTools,
   ...attachmentTools,
   ...contactTools,

--- a/test/domain/schemas.generic-associations.test.ts
+++ b/test/domain/schemas.generic-associations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import {
+  deleteRelationParamsJsonSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams
+} from "../../src/domain/schemas/generic-associations.js"
+
+describe("generic association schemas", () => {
+  it.effect("parses list_associations filters", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseListAssociationsParams({
+        association: "issue-links",
+        sourceClass: "tracker:class:Issue",
+        writableOnly: true,
+        limit: 10
+      })
+
+      expect(parsed.association).toBe("issue-links")
+      expect(parsed.sourceClass).toBe("tracker:class:Issue")
+      expect(parsed.writableOnly).toBe(true)
+      expect(parsed.limit).toBe(10)
+    }))
+
+  it.effect("requires a filter for list_relations", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseListRelationsParams({}))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("parses raw, issue, and document locators", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseListRelationsParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" },
+        target: { kind: "issue", issue: "HULY-1" },
+        direction: "either"
+      })
+
+      expect(parsed.source?.kind).toBe("raw")
+      expect(parsed.target?.kind).toBe("issue")
+
+      const documentParsed = yield* parseCreateRelationParams({
+        association: "links",
+        source: { kind: "document", document: "Spec", teamspace: "Engineering" },
+        target: { kind: "raw", id: "doc-2", class: "document:class:Document" }
+      })
+      expect(documentParsed.source.kind).toBe("document")
+    }))
+
+  it.effect("rejects mixed locator shapes", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseListRelationsParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", issue: "HULY-1" }
+      }))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("rejects partial delete triples", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseDeleteRelationParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" }
+      }))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("accepts delete by relation ID", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseDeleteRelationParams({ relation: "rel-1" })
+      expect(parsed.relation).toBe("rel-1")
+    }))
+
+  it.effect("emits JSON schema for delete_relation", () =>
+    Effect.gen(function*() {
+      expect(deleteRelationParamsJsonSchema).toMatchObject({
+        type: "object"
+      })
+    }))
+})

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -1,8 +1,11 @@
 import { describe, it } from "@effect/vitest"
 import { Effect, Schema } from "effect"
 import { expect } from "vitest"
+import { RelationId } from "../../src/domain/schemas/shared.js"
 import {
   ActivityMessageNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
@@ -21,6 +24,9 @@ import {
   FileTooLargeError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   type HulyDomainError,
@@ -47,6 +53,10 @@ import {
   ProjectNotFoundError,
   ReactionNotFoundError,
   RecurringEventNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError,
   SavedMessageNotFoundError,
   TagCategoryNotFoundError,
   TagNotFoundError,
@@ -777,6 +787,24 @@ describe("Huly Errors", () => {
               return `process-card-ambiguous:${error.identifier}:${error.candidates.length}`
             case "ProcessCardNotFoundError":
               return `process-card:${error.identifier}`
+            case "AssociationNotFoundError":
+              return `association:${error.identifier}`
+            case "AssociationIdentifierAmbiguousError":
+              return `association-ambiguous:${error.identifier}:${error.candidates.length}`
+            case "RelationNotFoundError":
+              return `relation:${error.identifier}`
+            case "RelationIdentifierAmbiguousError":
+              return `relation-ambiguous:${error.identifier}:${error.relationIds.length}`
+            case "RelationMutationUnsupportedError":
+              return `relation-unsupported:${error.reason}`
+            case "RelationEndpointClassMismatchError":
+              return `relation-mismatch:${error.field}:${error.expectedClass}:${error.actualClass}`
+            case "GenericObjectIdentifierAmbiguousError":
+              return `generic-object-ambiguous:${error.field}:${error.candidates.length}`
+            case "GenericObjectLocatorInvalidError":
+              return `generic-object-invalid:${error.field}:${error.reason}`
+            case "GenericObjectNotFoundError":
+              return `generic-object-not-found:${error.field}:${error.identifier}:${error.class ?? ""}`
             case "CannotDirectMessageSelfError":
               return `dm-self:${error.identifier}`
             case "PersonNotAnEmployeeError":
@@ -861,6 +889,59 @@ describe("Huly Errors", () => {
             new LeadNotFoundError({ identifier: leadIdentifier("LEAD-1"), funnel: funnelIdentifier("funnel-1") })
           )
         ).toBe("lead:LEAD-1")
+        expect(matchError(new AssociationNotFoundError({ identifier: "blocks" }))).toBe("association:blocks")
+        expect(
+          matchError(
+            new AssociationIdentifierAmbiguousError({
+              identifier: "links",
+              candidates: [{ id: "assoc-1" }, { id: "assoc-2" }]
+            })
+          )
+        ).toBe("association-ambiguous:links:2")
+        expect(matchError(new RelationNotFoundError({ identifier: "rel-1" }))).toBe("relation:rel-1")
+        expect(
+          matchError(
+            new RelationIdentifierAmbiguousError({
+              identifier: "triple",
+              relationIds: [RelationId.make("rel-1"), RelationId.make("rel-2")]
+            })
+          )
+        ).toBe("relation-ambiguous:triple:2")
+        expect(
+          matchError(new RelationMutationUnsupportedError({ reason: "not validated" }))
+        ).toBe("relation-unsupported:not validated")
+        expect(
+          matchError(
+            new RelationEndpointClassMismatchError({
+              field: "source",
+              expectedClass: "tracker:class:Issue",
+              actualClass: "document:class:Document"
+            })
+          )
+        ).toBe("relation-mismatch:source:tracker:class:Issue:document:class:Document")
+        expect(
+          matchError(
+            new GenericObjectIdentifierAmbiguousError({
+              field: "source",
+              identifier: "Spec",
+              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+            })
+          )
+        ).toBe("generic-object-ambiguous:source:1")
+        expect(
+          matchError(
+            new GenericObjectLocatorInvalidError({ field: "source", reason: "raw object locator requires class" })
+          )
+        ).toBe("generic-object-invalid:source:raw object locator requires class")
+        expect(
+          matchError(
+            new GenericObjectNotFoundError({
+              field: "target",
+              identifier: "missing-doc",
+              class: "document:class:Document"
+            })
+          )
+        ).toBe("generic-object-not-found:target:missing-doc:document:class:Document")
         expect(matchError(new CannotDirectMessageSelfError({ identifier: "Self,User" }))).toBe("dm-self:Self,User")
         expect(matchError(new PersonNotAnEmployeeError({ identifier: "Ext,Contact" }))).toBe("not-employee:Ext,Contact")
       }))

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -1,0 +1,581 @@
+import { describe, it } from "@effect/vitest"
+import type {
+  Association as HulyAssociation,
+  Doc,
+  FindResult,
+  PersonId,
+  Ref,
+  Relation as HulyRelation,
+  Space
+} from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import type { Document as HulyDocument } from "@hcengineering/document"
+import type { Issue as HulyIssue } from "@hcengineering/tracker"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import { AssociationIdentifier } from "../../../src/domain/schemas/generic-associations.js"
+import { ObjectClassName } from "../../../src/domain/schemas/shared.js"
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationMutationUnsupportedError
+} from "../../../src/huly/errors.js"
+import { core, documentPlugin, tracker } from "../../../src/huly/huly-plugins.js"
+import {
+  createRelation,
+  deleteRelation,
+  listAssociations,
+  listRelations
+} from "../../../src/huly/operations/generic-associations.js"
+import { documentIdentifier, issueIdentifier } from "../../helpers/brands.js"
+
+const person = "person-1" as PersonId
+const space = "space-1" as Ref<Space>
+const assocId = AssociationIdentifier.make("assoc-1")
+const relatesAssociation = AssociationIdentifier.make("relates")
+const issueClass = ObjectClassName.make(tracker.class.Issue)
+const documentClass = ObjectClassName.make(documentPlugin.class.Document)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const association = (overrides: Partial<HulyAssociation>): HulyAssociation => ({
+  _id: "assoc-1" as Ref<HulyAssociation>,
+  _class: core.class.Association,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  classA: tracker.class.Issue,
+  classB: tracker.class.Issue,
+  nameA: "relates",
+  nameB: "relates",
+  type: "N:N",
+  ...overrides
+} as HulyAssociation)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const relation = (overrides: Partial<HulyRelation>): HulyRelation => ({
+  _id: "rel-1" as Ref<HulyRelation>,
+  _class: core.class.Relation,
+  space,
+  modifiedBy: person,
+  modifiedOn: 200,
+  createdBy: person,
+  createdOn: 200,
+  docA: "issue-1" as Ref<Doc>,
+  docB: "issue-2" as Ref<Doc>,
+  association: "assoc-1" as Ref<HulyAssociation>,
+  ...overrides
+} as HulyRelation)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const issue = (id: string, identifier: string): HulyIssue => ({
+  _id: id as Ref<HulyIssue>,
+  _class: tracker.class.Issue,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  title: identifier,
+  identifier,
+  number: 1
+} as HulyIssue)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const documentDoc = (id: string, title: string): HulyDocument => ({
+  _id: id as Ref<HulyDocument>,
+  _class: documentPlugin.class.Document,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  title
+} as HulyDocument)
+
+interface TestData {
+  readonly associations?: ReadonlyArray<HulyAssociation>
+  readonly relations?: ReadonlyArray<HulyRelation>
+  readonly issues?: ReadonlyArray<HulyIssue>
+  readonly documents?: ReadonlyArray<HulyDocument>
+}
+
+type FindAllObserver = (
+  request: {
+    readonly _class: unknown
+    readonly query: unknown
+    readonly options: unknown
+  }
+) => void
+
+const matchesQuery = (doc: Doc, query: Record<string, unknown>): boolean =>
+  Object.entries(query).every(([key, value]) => {
+    if (typeof value === "object" && value !== null && "$in" in value) {
+      const values = Reflect.get(value, "$in")
+      return Array.isArray(values) && values.includes(Reflect.get(doc, key))
+    }
+    return Reflect.get(doc, key) === value
+  })
+
+const resultFor = <T extends Doc>(
+  docs: ReadonlyArray<T>,
+  query: unknown,
+  options: unknown
+): FindResult<T> => {
+  const q = query as Record<string, unknown>
+  const opts = options as { limit?: number } | undefined
+  const matches = docs.filter((doc) => matchesQuery(doc, q))
+  return toFindResult(matches.slice(0, opts?.limit), matches.length)
+}
+
+const testLayer = (data: TestData, onFindAll?: FindAllObserver) => {
+  const associations = data.associations ?? []
+  const relations = data.relations ?? []
+  const issues = data.issues ?? []
+  const documents = data.documents ?? []
+
+  const findAll: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown, options: unknown) => {
+    onFindAll?.({ _class, query, options })
+    if (_class === core.class.Association) {
+      return Effect.succeed(resultFor(associations, query, options))
+    }
+    if (_class === core.class.Relation) {
+      return Effect.succeed(resultFor(relations, query, options))
+    }
+    if (_class === tracker.class.Issue) {
+      return Effect.succeed(resultFor(issues, query, options))
+    }
+    if (_class === documentPlugin.class.Document) {
+      return Effect.succeed(resultFor(documents, query, options))
+    }
+    return Effect.succeed(toFindResult([]))
+  }) as HulyClientOperations["findAll"]
+
+  const findOne: HulyClientOperations["findOne"] = ((_class: unknown, query: unknown) => {
+    const q = query as Record<string, unknown>
+    if (_class === core.class.Association) {
+      return Effect.succeed(associations.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === tracker.class.Issue) {
+      return Effect.succeed(issues.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === documentPlugin.class.Document) {
+      return Effect.succeed(documents.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === core.class.Relation) {
+      return Effect.succeed(relations.find((doc) => matchesQuery(doc, q)))
+    }
+    return Effect.succeed(undefined)
+  }) as HulyClientOperations["findOne"]
+
+  return HulyClient.testLayer({ findAll, findOne })
+}
+
+describe("listAssociations", () => {
+  it.effect("lists visible associations and hides core system associations by default", () =>
+    Effect.gen(function*() {
+      const visible = association({ _id: "assoc-visible" as Ref<HulyAssociation> })
+      const system = association({
+        _id: "assoc-system" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+
+      const result = yield* listAssociations({}).pipe(
+        Effect.provide(testLayer({ associations: [visible, system] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-visible"])
+      expect(result.associations[0].canListRelations).toBe(true)
+      expect(result.associations[0].canCreateRelation).toBe(false)
+    }))
+
+  it.effect("applies limit after hiding system associations", () =>
+    Effect.gen(function*() {
+      const system1 = association({
+        _id: "assoc-system-1" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const system2 = association({
+        _id: "assoc-system-2" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const visible = association({ _id: "assoc-visible" as Ref<HulyAssociation> })
+
+      const result = yield* listAssociations({ limit: 1 }).pipe(
+        Effect.provide(testLayer({ associations: [system1, system2, visible] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-visible"])
+      expect(result.total).toBe(1)
+    }))
+
+  it.effect("returns no writable associations until a write allowlist exists", () =>
+    Effect.gen(function*() {
+      const result = yield* listAssociations({ writableOnly: true }).pipe(
+        Effect.provide(testLayer({ associations: [association({})] }))
+      )
+
+      expect(result.associations).toEqual([])
+      expect(result.total).toBe(0)
+    }))
+
+  it.effect("resolves a selected association before applying writableOnly filtering", () =>
+    Effect.gen(function*() {
+      const result = yield* listAssociations({ association: assocId, writableOnly: true }).pipe(
+        Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] }))
+      )
+
+      expect(result.associations).toEqual([])
+      expect(result.total).toBe(0)
+    }))
+
+  it.effect("resolves a selected association ID beyond the discovery window", () =>
+    Effect.gen(function*() {
+      const nonMatches = Array.from({ length: 205 }, (_, index) =>
+        association({
+          _id: `assoc-other-${index}` as Ref<HulyAssociation>,
+          nameA: `other-${index}`,
+          nameB: `other-${index}`
+        }))
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        nameA: "outside-window",
+        nameB: "outside-window"
+      })
+
+      const result = yield* listAssociations({ association: AssociationIdentifier.make("assoc-target") }).pipe(
+        Effect.provide(testLayer({ associations: [...nonMatches, target] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("resolves a selected association name beyond the discovery window", () =>
+    Effect.gen(function*() {
+      const nonMatches = Array.from({ length: 205 }, (_, index) =>
+        association({
+          _id: `assoc-other-${index}` as Ref<HulyAssociation>,
+          nameA: `other-${index}`,
+          nameB: `other-${index}`
+        }))
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        nameA: "outside-window",
+        nameB: "outside-window"
+      })
+
+      const result = yield* listAssociations({ association: AssociationIdentifier.make("outside-window") }).pipe(
+        Effect.provide(testLayer({ associations: [...nonMatches, target] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("applies class filters before limiting selected association name lookups", () =>
+    Effect.gen(function*() {
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        classA: documentPlugin.class.Document,
+        classB: documentPlugin.class.Document
+      })
+
+      const result = yield* listAssociations({
+        association: relatesAssociation,
+        sourceClass: documentClass,
+        targetClass: documentClass
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [
+            association({ _id: "assoc-issue-1" as Ref<HulyAssociation> }),
+            association({ _id: "assoc-issue-2" as Ref<HulyAssociation> }),
+            target
+          ]
+        }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("fails on ambiguous association names", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listAssociations({ association: relatesAssociation }).pipe(
+          Effect.provide(testLayer({
+            associations: [
+              association({ _id: "assoc-1" as Ref<HulyAssociation> }),
+              association({ _id: "assoc-2" as Ref<HulyAssociation> })
+            ]
+          }))
+        )
+      )
+
+      expect(error).toBeInstanceOf(AssociationIdentifierAmbiguousError)
+    }))
+
+  it.effect("caps exact-name lookup queries while detecting ambiguity", () =>
+    Effect.gen(function*() {
+      const lookupLimits: Array<number | undefined> = []
+      const error = yield* Effect.flip(
+        listAssociations({ association: relatesAssociation }).pipe(
+          Effect.provide(testLayer(
+            {
+              associations: [
+                association({ _id: "assoc-1" as Ref<HulyAssociation> }),
+                association({ _id: "assoc-2" as Ref<HulyAssociation> }),
+                association({ _id: "assoc-3" as Ref<HulyAssociation> })
+              ]
+            },
+            ({ _class, options }) => {
+              if (_class === core.class.Association) {
+                const limit = typeof options === "object" && options !== null
+                  ? Reflect.get(options, "limit")
+                  : undefined
+                lookupLimits.push(typeof limit === "number" ? limit : undefined)
+              }
+            }
+          ))
+        )
+      )
+
+      expect(error).toBeInstanceOf(AssociationIdentifierAmbiguousError)
+      expect(lookupLimits).toEqual([2, 2])
+    }))
+})
+
+describe("listRelations", () => {
+  it.effect("lists relation instances with resolved endpoint display", () =>
+    Effect.gen(function*() {
+      const assoc = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "issue-1", class: issueClass },
+        target: { kind: "raw", id: "issue-2", class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [assoc],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("HULY-2")
+    }))
+
+  it.effect("matches symmetric associations in either direction", () =>
+    Effect.gen(function*() {
+      const assoc = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "issue-2", class: issueClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [assoc],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+    }))
+
+  it.effect("validates reversed endpoints against asymmetric association classes", () =>
+    Effect.gen(function*() {
+      const issueToDocument = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document,
+        nameA: "issue",
+        nameB: "document",
+        type: "1:N"
+      })
+      const rel = relation({
+        docA: "issue-1" as Ref<Doc>,
+        docB: "doc-1" as Ref<Doc>
+      })
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "doc-1", class: documentClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "target-to-source"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [issueToDocument],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1")],
+          documents: [documentDoc("doc-1", "Spec")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("Spec")
+    }))
+
+  it.effect("matches asymmetric associations in either direction", () =>
+    Effect.gen(function*() {
+      const issueToDocument = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document,
+        nameA: "issue",
+        nameB: "document",
+        type: "1:N"
+      })
+      const rel = relation({
+        docA: "issue-1" as Ref<Doc>,
+        docB: "doc-1" as Ref<Doc>
+      })
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "doc-1", class: documentClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [issueToDocument],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1")],
+          documents: [documentDoc("doc-1", "Spec")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("Spec")
+    }))
+
+  it.effect("skips incompatible associations when association is omitted", () =>
+    Effect.gen(function*() {
+      const documentAssociation = association({
+        _id: "assoc-doc" as Ref<HulyAssociation>,
+        classA: documentPlugin.class.Document,
+        classB: documentPlugin.class.Document
+      })
+      const issueAssociation = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: "issue-1", class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [documentAssociation, issueAssociation],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("fails when a locator resolves to the wrong endpoint class", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          association: assocId,
+          source: { kind: "raw", id: "doc-1", class: documentClass }
+        }).pipe(
+          Effect.provide(testLayer({
+            associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
+            documents: [documentDoc("doc-1", "Spec")]
+          }))
+        )
+      )
+
+      expect(error).toBeInstanceOf(RelationEndpointClassMismatchError)
+    }))
+
+  it.effect("fails with typed invalid locator error for raw locators without a known class", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "raw", id: "issue-1" }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectLocatorInvalidError)
+    }))
+
+  it.effect("fails with typed not found error for missing raw objects", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          association: assocId,
+          source: { kind: "raw", id: "missing-issue", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
+    }))
+
+  it.effect("fails with typed invalid locator error for issue locators without project or full key", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "issue", issue: issueIdentifier("123") }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectLocatorInvalidError)
+    }))
+
+  it.effect("fails with typed not found error for missing documents without teamspace", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "document", document: documentIdentifier("Missing Spec") }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
+    }))
+})
+
+describe("relation mutations", () => {
+  it.effect("createRelation fails clearly while writes are unsupported", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        createRelation({
+          association: assocId,
+          source: { kind: "raw", id: "issue-1", class: issueClass },
+          target: { kind: "raw", id: "issue-2", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(RelationMutationUnsupportedError)
+    }))
+
+  it.effect("deleteRelation rejects validated association deletes while writes are unsupported", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        deleteRelation({
+          association: assocId,
+          source: { kind: "raw", id: "issue-1", class: issueClass },
+          target: { kind: "raw", id: "issue-2", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(RelationMutationUnsupportedError)
+    }))
+})

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -3,8 +3,10 @@ import type { ParseResult } from "effect"
 import { Cause, Effect, Schema } from "effect"
 import { expect } from "vitest"
 import { ProcessId } from "../../src/domain/schemas/processes.js"
-import { CardId, MasterTagId, NonEmptyString } from "../../src/domain/schemas/shared.js"
+import { AssociationId, CardId, MasterTagId, NonEmptyString, RelationId } from "../../src/domain/schemas/shared.js"
 import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   CalendarNotAccessibleError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
@@ -12,6 +14,9 @@ import {
   FileNotFoundError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   HulyError,
@@ -30,7 +35,11 @@ import {
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
   ProcessNotFoundError,
-  ProjectNotFoundError
+  ProjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError
 } from "../../src/huly/errors.js"
 import {
   createSuccessResponse,
@@ -268,6 +277,54 @@ describe("Error Mapping to MCP", () => {
               candidates: [cardCandidate]
             }),
             new ProcessCardNotFoundError({ identifier: "Missing Card" })
+          ]
+
+          for (const error of errors) {
+            const response = mapDomainErrorToMcp(error)
+
+            expect(response.isError).toBe(true)
+            expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+            expect(response._meta.errorTag).toBeUndefined()
+            expect(response.content[0].text).toBe(error.message)
+          }
+        }))
+
+      it.effect("maps generic association and relation lookup errors with descriptive messages", () =>
+        Effect.gen(function*() {
+          const errors = [
+            new AssociationNotFoundError({ identifier: "relates" }),
+            new AssociationIdentifierAmbiguousError({
+              identifier: "relates",
+              candidates: [{ id: "assoc-1", name: "relates" }]
+            }),
+            new RelationNotFoundError({ identifier: "rel-1" }),
+            new RelationIdentifierAmbiguousError({
+              identifier: "assoc-1/source/target",
+              relationIds: [RelationId.make("rel-1")]
+            }),
+            new RelationMutationUnsupportedError({
+              associationId: AssociationId.make("assoc-1"),
+              reason: "not validated"
+            }),
+            new RelationEndpointClassMismatchError({
+              field: "source",
+              expectedClass: "tracker:class:Issue",
+              actualClass: "document:class:Document"
+            }),
+            new GenericObjectIdentifierAmbiguousError({
+              field: "target",
+              identifier: "Spec",
+              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+            }),
+            new GenericObjectLocatorInvalidError({
+              field: "source",
+              reason: "raw object locator requires class"
+            }),
+            new GenericObjectNotFoundError({
+              field: "target",
+              identifier: "missing-doc",
+              class: "document:class:Document"
+            })
           ]
 
           for (const error of errors) {

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -42,6 +42,7 @@ describe("CATEGORY_NAMES", () => {
       expect(CATEGORY_NAMES.has("documents")).toBe(true)
       expect(CATEGORY_NAMES.has("comments")).toBe(true)
       expect(CATEGORY_NAMES.has("task-management")).toBe(true)
+      expect(CATEGORY_NAMES.has("associations")).toBe(true)
       expect(CATEGORY_NAMES.size).toBeGreaterThan(5)
     }))
 })
@@ -110,6 +111,22 @@ describe("createFilteredRegistry", () => {
         expect(tool.category).toBe("task-management")
       }
     }))
+
+  it.effect("filters to association tools", () =>
+    Effect.gen(function*() {
+      const filtered = createFilteredRegistry(new Set(["associations"]))
+      const toolNames = filtered.definitions.map((tool) => tool.name)
+
+      expect(toolNames).toEqual([
+        "list_associations",
+        "list_relations",
+        "create_relation",
+        "delete_relation"
+      ])
+      for (const tool of filtered.definitions) {
+        expect(tool.category).toBe("associations")
+      }
+    }))
 })
 
 describe("handleToolCall", () => {
@@ -135,6 +152,7 @@ describe("TOOL_DEFINITIONS", () => {
       expect(keys.length).toBeGreaterThan(0)
       expect(keys.length).toBe(toolRegistry.tools.size)
       expect(keys).toContain("create_issue_status")
+      expect(keys).toContain("list_associations")
     }))
 
   it.effect("entries match toolRegistry", () =>

--- a/test/mcp/tools/generic-associations.test.ts
+++ b/test/mcp/tools/generic-associations.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "@effect/vitest"
+import type { AccountUuid, Association as HulyAssociation, PersonId, Ref, Space } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import type { HulyClientOperations } from "../../../src/huly/client.js"
+import { core, tracker } from "../../../src/huly/huly-plugins.js"
+import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import type { HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
+import { genericAssociationTools } from "../../../src/mcp/tools/generic-associations.js"
+
+const person = "person-1" as PersonId
+const space = "space-1" as Ref<Space>
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const makeAssociation = (): HulyAssociation => ({
+  _id: "assoc-1" as Ref<HulyAssociation>,
+  _class: core.class.Association,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  classA: tracker.class.Issue,
+  classB: tracker.class.Issue,
+  nameA: "relates",
+  nameB: "relates",
+  type: "N:N"
+} as HulyAssociation)
+
+const noopStorageClient: HulyStorageOperations = {
+  uploadFile: () => Effect.die(new Error("not implemented")),
+  getFileUrl: (blobId: string) => `https://test.huly.io/files?file=${blobId}`
+}
+
+const hulyClient: HulyClientOperations = {
+  getAccountUuid: () => "account-1" as AccountUuid,
+  getPrimarySocialId: () => person,
+  markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
+  findAll: ((_class: unknown) =>
+    _class === core.class.Association
+      ? Effect.succeed(toFindResult([makeAssociation()]))
+      : Effect.succeed(toFindResult([]))) as HulyClientOperations["findAll"],
+  findOne: () => Effect.succeed(undefined),
+  createDoc: () => Effect.die(new Error("not implemented")),
+  updateDoc: () => Effect.die(new Error("not implemented")),
+  addCollection: () => Effect.die(new Error("not implemented")),
+  removeDoc: () => Effect.die(new Error("not implemented")),
+  uploadMarkup: () => Effect.die(new Error("not implemented")),
+  fetchMarkup: () => Effect.succeed(""),
+  updateMarkup: () => Effect.die(new Error("not implemented")),
+  updateMixin: () => Effect.die(new Error("not implemented")),
+  createMixin: () => Effect.die(new Error("not implemented")),
+  searchFulltext: () => Effect.die(new Error("not implemented"))
+}
+
+const findTool = (name: string) => {
+  const tool = genericAssociationTools.find((candidate) => candidate.name === name)
+  if (tool === undefined) throw new Error(`Tool ${name} not found`)
+  return tool
+}
+
+describe("genericAssociationTools", () => {
+  it.effect("exports association tools in the associations category", () =>
+    Effect.gen(function*() {
+      expect(genericAssociationTools.map((tool) => tool.name)).toEqual([
+        "list_associations",
+        "list_relations",
+        "create_relation",
+        "delete_relation"
+      ])
+      for (const tool of genericAssociationTools) {
+        expect(tool.category).toBe("associations")
+      }
+    }))
+
+  it.effect("list_associations handler encodes successful output", () =>
+    Effect.gen(function*() {
+      const tool = findTool("list_associations")
+      const result = yield* Effect.promise(() => tool.handler({}, hulyClient, noopStorageClient))
+
+      expect(result.isError).toBeUndefined()
+      const parsed = JSON.parse(result.content[0].text) as { associations: Array<{ associationId: string }> }
+      expect(parsed.associations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("list_relations handler maps schema parse errors", () =>
+    Effect.gen(function*() {
+      const tool = findTool("list_relations")
+      const result = yield* Effect.promise(() => tool.handler({}, hulyClient, noopStorageClient))
+
+      expect(result.isError).toBe(true)
+    }))
+
+  it.effect("create_relation annotations mark the operation idempotent and non-destructive", () =>
+    Effect.gen(function*() {
+      const tool = findTool("create_relation")
+
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      })
+    }))
+})


### PR DESCRIPTION
## Summary
- add generic association/relation schemas, operations, and MCP tools
- expose read-side `list_associations` and `list_relations` with safe filtering and typed errors
- add guarded `create_relation` and `delete_relation` entrypoints that fail clearly until writable associations are live-validated
- add README/tool generation and integration script coverage

## Attribution / Prior Art
- Feature idea and product surface were inspired by [`dugynoo/huly-mcp`](https://github.com/dugynoo/huly-mcp).
- Implementation was produced from an independently written behavior spec and review loop; no external source code was copied into this branch.

## Validation
- `pnpm check-all`
- Review loop converged after 7 rounds with no actionable findings
- Pre-commit hook regenerated README tool docs, ran lint-staged, and ran gitleaks
- Not run: Docker/local-Huly integration, because `HULY_URL`/`.env.local`/`CLAUDE.local.md` are unavailable in this worktree