### PR TITLE
feat: Add generic association tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `activity`, `notifications`, `workspace`, `cards`, `custom-fields`, `labels`, `leads`, `processes`, `tag-categories`, `task-management`, `test-management`
+**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `cards`, `custom-fields`, `labels`, `leads`, `processes`, `tag-categories`, `task-management`, `test-management`
 
 ### Projects
 
@@ -383,6 +383,15 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 | Tool | Description |
 |------|-------------|
 | `fulltext_search` | Perform a global fulltext search across all Huly content. Searches issues, documents, messages, and other indexed content. Returns matching items sorted by relevance (newest first). |
+
+### Associations
+
+| Tool | Description |
+|------|-------------|
+| `list_associations` | List Huly association definitions: class-level typed links that define which document classes may be related. Use this before create_relation to discover association IDs, source/target classes, and whether relation writes are supported. |
+| `list_relations` | List concrete Huly relation instances under an association, optionally filtered by source and target documents. Requires at least one filter to avoid broad workspace scans. |
+| `create_relation` | Idempotently create one concrete relation between two resolved documents. Only succeeds for associations where list_associations reports canCreateRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated. |
+| `delete_relation` | Idempotently delete one concrete relation by relation ID or by exact association/source/target triple. Only succeeds for associations where list_associations reports canDeleteRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated. |
 
 ### Activity
 

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1197,6 +1197,37 @@ if [ -n "$WRITABLE_ASSOC_ID" ]; then
 else
   skip_test "create_relation/delete_relation" "read-only slice: no validated writable generic association allowlist"
 fi
+
+GENERIC_SOURCE_TEXT=$(run_capture "create_issue(for_generic_associations)" \
+  "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_issue\",\"arguments\":{\"project\":\"$PROJECT\",\"title\":\"Generic Associations Source $RUN_ID\"}},\"id\":2}")
+if [ $? -eq 0 ]; then
+  GENERIC_SOURCE_ID=$(echo "$GENERIC_SOURCE_TEXT" | jq -r '.identifier // empty' 2>/dev/null)
+  GENERIC_SOURCE_OBJ_ID=$(echo "$GENERIC_SOURCE_TEXT" | jq -r '.issueId // empty' 2>/dev/null)
+  GENERIC_SOURCE_OBJ_ID_JSON=$(json_string "$GENERIC_SOURCE_OBJ_ID")
+  if [ -n "$GENERIC_SOURCE_OBJ_ID" ]; then
+    OMITTED_RELATIONS_TEXT=$(run_capture "list_relations(source raw issue)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_relations\",\"arguments\":{\"source\":{\"kind\":\"raw\",\"id\":$GENERIC_SOURCE_OBJ_ID_JSON,\"class\":\"tracker:class:Issue\"},\"limit\":3}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_nonempty "list_relations(source raw issue) has total" "$OMITTED_RELATIONS_TEXT" ".total"
+    fi
+
+    EITHER_RELATIONS_TEXT=$(run_capture "list_relations(source raw issue,either)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_relations\",\"arguments\":{\"source\":{\"kind\":\"raw\",\"id\":$GENERIC_SOURCE_OBJ_ID_JSON,\"class\":\"tracker:class:Issue\"},\"direction\":\"either\",\"limit\":3}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_nonempty "list_relations(source raw issue,either) has total" "$EITHER_RELATIONS_TEXT" ".total"
+    fi
+  else
+    skip_test "list_relations(source raw issue)" "generic association source issue did not return issueId"
+    skip_test "list_relations(source raw issue,either)" "generic association source issue did not return issueId"
+  fi
+  if [ -n "$GENERIC_SOURCE_ID" ]; then
+    run_test "delete_issue(generic_assoc:$GENERIC_SOURCE_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_issue\",\"arguments\":{\"project\":\"$PROJECT\",\"identifier\":\"$GENERIC_SOURCE_ID\"}},\"id\":2}"
+  fi
+else
+  skip_test "list_relations(source raw issue)" "could not create disposable source issue"
+  skip_test "list_relations(source raw issue,either)" "could not create disposable source issue"
+fi
 echo ""
 
 ##############################

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -139,6 +139,19 @@ assert_json_field_equals() {
   return 1
 }
 
+assert_json_any_equals() {
+  local name="$1" json="$2" jq_expr="$3"
+  if printf '%s\n' "$json" | jq -e "$jq_expr" >/dev/null 2>&1; then
+    echo "PASS: $name"
+    PASSED=$((PASSED + 1))
+    return 0
+  fi
+  echo "FAIL: $name (no matching JSON item)"
+  FAILED=$((FAILED + 1))
+  ERRORS="${ERRORS}\n  - ${name}: no matching JSON item"
+  return 1
+}
+
 assert_json_blocks_contains_identifier() {
   local name="$1" json="$2" expected="$3"
   if printf '%s\n' "$json" | jq -e --arg expected "$expected" 'any(.blocks[]?; .identifier == $expected)' >/dev/null 2>&1; then
@@ -412,11 +425,20 @@ if [ $? -eq 0 ]; then
   ISSUE_OBJ_ID=$(echo "$ISSUE_TEXT" | jq -r '.issueId' 2>/dev/null)
   echo "  => $ISSUE_ID ($ISSUE_OBJ_ID)"
 
-  run_test "get_issue($ISSUE_ID)" \
+  GET_ISSUE_TEXT=$(run_capture "get_issue($ISSUE_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_issue\",\"arguments\":{\"project\":\"$PROJECT\",\"identifier\":\"$ISSUE_ID\"}},\"id\":2}"
+  )
+  if [ $? -eq 0 ] && [ -n "$ISSUE_OBJ_ID" ]; then
+    assert_json_field_equals "get_issue returns issueId" "$GET_ISSUE_TEXT" ".issueId" "$ISSUE_OBJ_ID"
+  fi
 
-  run_test "list_issues" \
-    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_issues\",\"arguments\":{\"project\":\"$PROJECT\",\"limit\":2}},\"id\":2}"
+  LIST_ISSUES_TEXT=$(run_capture "list_issues" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_issues\",\"arguments\":{\"project\":\"$PROJECT\",\"titleSearch\":\"IntTest Issue\",\"limit\":10}},\"id\":2}"
+  )
+  if [ $? -eq 0 ] && [ -n "$ISSUE_OBJ_ID" ]; then
+    assert_json_any_equals "list_issues includes issueId" "$LIST_ISSUES_TEXT" \
+      "any(.[]?; .identifier == \"$ISSUE_ID\" and .issueId == \"$ISSUE_OBJ_ID\")"
+  fi
 
   run_test "update_issue($ISSUE_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"update_issue\",\"arguments\":{\"project\":\"$PROJECT\",\"identifier\":\"$ISSUE_ID\",\"title\":\"Updated IntTest\",\"priority\":\"high\"}},\"id\":2}"
@@ -1172,9 +1194,16 @@ ASSOCIATIONS_TEXT=$(run_capture "list_associations" \
 ASSOC_ID=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
 ASSOC_SOURCE_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].sourceClass // empty' 2>/dev/null)
 ASSOC_TARGET_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].targetClass // empty' 2>/dev/null)
+ASSOC_WITH_LABEL=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[]? | select((.sourceClassLabel // "") != "" or (.targetClassLabel // "") != "") | .associationId' 2>/dev/null | head -n 1)
 
 if [ -n "$ASSOC_ID" ]; then
   assert_json_field_nonempty "list_associations has id" "$ASSOCIATIONS_TEXT" ".associations[0].associationId"
+  if [ -n "$ASSOC_WITH_LABEL" ]; then
+    assert_json_any_equals "list_associations returns class labels when known" "$ASSOCIATIONS_TEXT" \
+      "any(.associations[]?; .associationId == \"$ASSOC_WITH_LABEL\" and ((.sourceClassLabel // \"\") != \"\" or (.targetClassLabel // \"\") != \"\"))"
+  else
+    skip_test "list_associations class labels" "workspace returned no associations for known SDK classes"
+  fi
   run_test "list_associations(filter:$ASSOC_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_associations\",\"arguments\":{\"association\":\"$ASSOC_ID\"}},\"id\":2}"
   if [ -n "$ASSOC_SOURCE_CLASS" ] && [ -n "$ASSOC_TARGET_CLASS" ]; then

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1164,6 +1164,42 @@ run_test "fulltext_search" \
 echo ""
 
 ##############################
+# 13b. GENERIC ASSOCIATIONS
+##############################
+echo "=== 13b. Generic Associations ==="
+ASSOCIATIONS_TEXT=$(run_capture "list_associations" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_associations","arguments":{"limit":5}},"id":2}')
+ASSOC_ID=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
+ASSOC_SOURCE_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].sourceClass // empty' 2>/dev/null)
+ASSOC_TARGET_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].targetClass // empty' 2>/dev/null)
+
+if [ -n "$ASSOC_ID" ]; then
+  assert_json_field_nonempty "list_associations has id" "$ASSOCIATIONS_TEXT" ".associations[0].associationId"
+  run_test "list_associations(filter:$ASSOC_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_associations\",\"arguments\":{\"association\":\"$ASSOC_ID\"}},\"id\":2}"
+  if [ -n "$ASSOC_SOURCE_CLASS" ] && [ -n "$ASSOC_TARGET_CLASS" ]; then
+    run_test "list_associations(class filters)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_associations\",\"arguments\":{\"sourceClass\":\"$ASSOC_SOURCE_CLASS\",\"targetClass\":\"$ASSOC_TARGET_CLASS\",\"limit\":5}},\"id\":2}"
+  fi
+  run_test "list_relations($ASSOC_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_relations\",\"arguments\":{\"association\":\"$ASSOC_ID\",\"limit\":3}},\"id\":2}"
+else
+  skip_test "list_associations has id" "no visible associations found in workspace"
+  skip_test "list_associations(filter)" "no visible associations found in workspace"
+  skip_test "list_relations" "no visible associations found in workspace"
+fi
+
+WRITABLE_ASSOCIATIONS_TEXT=$(run_capture "list_associations(writableOnly)" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_associations","arguments":{"writableOnly":true,"limit":1}},"id":2}')
+WRITABLE_ASSOC_ID=$(echo "$WRITABLE_ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
+if [ -n "$WRITABLE_ASSOC_ID" ]; then
+  skip_test "create_relation/delete_relation" "writable association discovered but disposable endpoint fixture is not defined yet"
+else
+  skip_test "create_relation/delete_relation" "read-only slice: no validated writable generic association allowlist"
+fi
+echo ""
+
+##############################
 # 14. CARDS
 ##############################
 echo "=== 14. Cards ==="

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -85,6 +85,34 @@ run_capture() {
   return 0
 }
 
+run_capture_to_var() {
+  local output_var="$1" name="$2" payload="$3"
+  local result
+  result=$(call_tool "$payload")
+  if [ -z "$result" ]; then
+    echo "FAIL: $name (no response)" >&2
+    FAILED=$((FAILED + 1))
+    ERRORS="${ERRORS}\n  - ${name}: no response"
+    printf -v "$output_var" '%s' ""
+    return 1
+  fi
+  local is_error
+  is_error=$(echo "$result" | jq -r '.result.isError // false' 2>/dev/null)
+  if [ "$is_error" = "true" ]; then
+    local err_text
+    err_text=$(echo "$result" | jq -r '.result.content[0].text' 2>/dev/null | head -c 200)
+    echo "FAIL: $name => $err_text" >&2
+    FAILED=$((FAILED + 1))
+    ERRORS="${ERRORS}\n  - ${name}: ${err_text}"
+    printf -v "$output_var" '%s' ""
+    return 1
+  fi
+  echo "PASS: $name" >&2
+  PASSED=$((PASSED + 1))
+  printf -v "$output_var" '%s' "$(echo "$result" | jq -r '.result.content[0].text' 2>/dev/null)"
+  return 0
+}
+
 skip_test() {
   local name="$1"
   local reason="$2"
@@ -139,16 +167,31 @@ assert_json_field_equals() {
   return 1
 }
 
-assert_json_any_equals() {
-  local name="$1" json="$2" jq_expr="$3"
-  if printf '%s\n' "$json" | jq -e "$jq_expr" >/dev/null 2>&1; then
+assert_json_issue_summary_contains_issue_id() {
+  local name="$1" json="$2" identifier="$3" issue_id="$4"
+  if printf '%s\n' "$json" | jq -e --arg identifier "$identifier" --arg issue_id "$issue_id" \
+    'any(.[]?; .identifier == $identifier and .issueId == $issue_id)' >/dev/null 2>&1; then
     echo "PASS: $name"
     PASSED=$((PASSED + 1))
     return 0
   fi
-  echo "FAIL: $name (no matching JSON item)"
+  echo "FAIL: $name (issue summary missing issueId)"
   FAILED=$((FAILED + 1))
-  ERRORS="${ERRORS}\n  - ${name}: no matching JSON item"
+  ERRORS="${ERRORS}\n  - ${name}: issue summary missing issueId"
+  return 1
+}
+
+assert_json_association_has_expected_class_label() {
+  local name="$1" json="$2" class_id="$3" expected_label="$4"
+  if printf '%s\n' "$json" | jq -e --arg class_id "$class_id" --arg expected_label "$expected_label" \
+    'any(.associations[]?; (.sourceClass == $class_id and .sourceClassLabel == $expected_label) or (.targetClass == $class_id and .targetClassLabel == $expected_label))' >/dev/null 2>&1; then
+    echo "PASS: $name"
+    PASSED=$((PASSED + 1))
+    return 0
+  fi
+  echo "FAIL: $name (expected label $expected_label for $class_id)"
+  FAILED=$((FAILED + 1))
+  ERRORS="${ERRORS}\n  - ${name}: expected label ${expected_label} for ${class_id}"
   return 1
 }
 
@@ -425,19 +468,16 @@ if [ $? -eq 0 ]; then
   ISSUE_OBJ_ID=$(echo "$ISSUE_TEXT" | jq -r '.issueId' 2>/dev/null)
   echo "  => $ISSUE_ID ($ISSUE_OBJ_ID)"
 
-  GET_ISSUE_TEXT=$(run_capture "get_issue($ISSUE_ID)" \
+  run_capture_to_var GET_ISSUE_TEXT "get_issue($ISSUE_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_issue\",\"arguments\":{\"project\":\"$PROJECT\",\"identifier\":\"$ISSUE_ID\"}},\"id\":2}"
-  )
   if [ $? -eq 0 ] && [ -n "$ISSUE_OBJ_ID" ]; then
     assert_json_field_equals "get_issue returns issueId" "$GET_ISSUE_TEXT" ".issueId" "$ISSUE_OBJ_ID"
   fi
 
-  LIST_ISSUES_TEXT=$(run_capture "list_issues" \
+  run_capture_to_var LIST_ISSUES_TEXT "list_issues" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_issues\",\"arguments\":{\"project\":\"$PROJECT\",\"titleSearch\":\"IntTest Issue\",\"limit\":10}},\"id\":2}"
-  )
   if [ $? -eq 0 ] && [ -n "$ISSUE_OBJ_ID" ]; then
-    assert_json_any_equals "list_issues includes issueId" "$LIST_ISSUES_TEXT" \
-      "any(.[]?; .identifier == \"$ISSUE_ID\" and .issueId == \"$ISSUE_OBJ_ID\")"
+    assert_json_issue_summary_contains_issue_id "list_issues includes issueId" "$LIST_ISSUES_TEXT" "$ISSUE_ID" "$ISSUE_OBJ_ID"
   fi
 
   run_test "update_issue($ISSUE_ID)" \
@@ -1194,13 +1234,31 @@ ASSOCIATIONS_TEXT=$(run_capture "list_associations" \
 ASSOC_ID=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].associationId // empty' 2>/dev/null)
 ASSOC_SOURCE_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].sourceClass // empty' 2>/dev/null)
 ASSOC_TARGET_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[0].targetClass // empty' 2>/dev/null)
-ASSOC_WITH_LABEL=$(echo "$ASSOCIATIONS_TEXT" | jq -r '.associations[]? | select((.sourceClassLabel // "") != "" or (.targetClassLabel // "") != "") | .associationId' 2>/dev/null | head -n 1)
+ASSOC_KNOWN_CLASS=$(echo "$ASSOCIATIONS_TEXT" | jq -r '
+  first(.associations[]? | [.sourceClass, .targetClass][] | select(
+    . == "tracker:class:Issue"
+    or . == "tracker:class:Project"
+    or . == "document:class:Document"
+    or . == "document:class:Teamspace"
+    or . == "core:class:Relation"
+    or . == "core:class:Doc"
+  )) // empty
+' 2>/dev/null)
+case "$ASSOC_KNOWN_CLASS" in
+  "tracker:class:Issue") ASSOC_EXPECTED_LABEL="Issue" ;;
+  "tracker:class:Project") ASSOC_EXPECTED_LABEL="Project" ;;
+  "document:class:Document") ASSOC_EXPECTED_LABEL="Document" ;;
+  "document:class:Teamspace") ASSOC_EXPECTED_LABEL="Teamspace" ;;
+  "core:class:Relation") ASSOC_EXPECTED_LABEL="Relation" ;;
+  "core:class:Doc") ASSOC_EXPECTED_LABEL="Huly document" ;;
+  *) ASSOC_EXPECTED_LABEL="" ;;
+esac
 
 if [ -n "$ASSOC_ID" ]; then
   assert_json_field_nonempty "list_associations has id" "$ASSOCIATIONS_TEXT" ".associations[0].associationId"
-  if [ -n "$ASSOC_WITH_LABEL" ]; then
-    assert_json_any_equals "list_associations returns class labels when known" "$ASSOCIATIONS_TEXT" \
-      "any(.associations[]?; .associationId == \"$ASSOC_WITH_LABEL\" and ((.sourceClassLabel // \"\") != \"\" or (.targetClassLabel // \"\") != \"\"))"
+  if [ -n "$ASSOC_KNOWN_CLASS" ] && [ -n "$ASSOC_EXPECTED_LABEL" ]; then
+    assert_json_association_has_expected_class_label "list_associations labels $ASSOC_KNOWN_CLASS" \
+      "$ASSOCIATIONS_TEXT" "$ASSOC_KNOWN_CLASS" "$ASSOC_EXPECTED_LABEL"
   else
     skip_test "list_associations class labels" "workspace returned no associations for known SDK classes"
   fi

--- a/scripts/update-readme-tools.ts
+++ b/scripts/update-readme-tools.ts
@@ -51,6 +51,7 @@ const categoryOrder = [
   "calendar",
   "time tracking",
   "search",
+  "associations",
   "activity",
   "notifications",
   "workspace"

--- a/src/domain/schemas/activity.ts
+++ b/src/domain/schemas/activity.ts
@@ -3,13 +3,13 @@ import { JSONSchema, Schema } from "effect"
 import {
   ActivityMessageId,
   ChannelIdentifier,
+  DocId,
   DocumentIdentifier,
   EmojiCode,
   IssueIdentifier,
   LimitParam,
   MAX_LIMIT,
   MentionId,
-  NonEmptyString,
   ObjectClassName,
   PersonId,
   ProjectIdentifier,
@@ -31,7 +31,7 @@ type ActivityAction = Schema.Schema.Type<typeof ActivityAction>
 
 export interface ActivityMessage {
   readonly id: ActivityMessageId
-  readonly objectId: NonEmptyString
+  readonly objectId: DocId
   readonly objectClass: ObjectClassName
   readonly modifiedBy?: PersonId | undefined
   readonly modifiedOn?: Timestamp | undefined
@@ -65,7 +65,7 @@ export interface Mention {
 const hasAll = (...values: ReadonlyArray<unknown>): boolean => values.every(value => value !== undefined)
 
 export const ListActivityParamsSchema = Schema.Struct({
-  objectId: Schema.optional(NonEmptyString.annotations({
+  objectId: Schema.optional(DocId.annotations({
     description:
       "Advanced: internal Huly object ID to get activity for. Use with objectClass. Prefer project+issueIdentifier, teamspace+document, or channel when available."
   })),
@@ -316,7 +316,7 @@ export interface UnsaveMessageResult {
 
 export const ActivityMessageWireSchema = Schema.Struct({
   id: ActivityMessageId,
-  objectId: NonEmptyString,
+  objectId: DocId,
   objectClass: ObjectClassName,
   modifiedBy: Schema.optional(PersonId),
   modifiedOn: Schema.optional(Timestamp),

--- a/src/domain/schemas/attachments.ts
+++ b/src/domain/schemas/attachments.ts
@@ -3,6 +3,7 @@ import { JSONSchema, Schema } from "effect"
 import type { BlobId } from "./shared.js"
 import {
   AttachmentId,
+  DocId,
   DocumentIdentifier,
   IssueIdentifier,
   LimitParam,
@@ -39,7 +40,7 @@ export interface Attachment {
 }
 
 export const ListAttachmentsParamsSchema = Schema.Struct({
-  objectId: NonEmptyString.annotations({
+  objectId: DocId.annotations({
     description: "ID of the parent object (issue, document, etc.)"
   }),
   objectClass: ObjectClassName.annotations({
@@ -102,7 +103,7 @@ const hasFileSource = (params: {
 }
 
 const AddAttachmentParamsBase = Schema.Struct({
-  objectId: NonEmptyString.annotations({
+  objectId: DocId.annotations({
     description: "ID of the parent object (issue, document, etc.)"
   }),
   objectClass: ObjectClassName.annotations({

--- a/src/domain/schemas/calendar.ts
+++ b/src/domain/schemas/calendar.ts
@@ -1,13 +1,22 @@
 import { JSONSchema, Schema } from "effect"
 
-import { CalendarId, Email, EmptyParamsSchema, EventId, LimitParam, NonEmptyString, Timestamp } from "./shared.js"
+import {
+  CalendarId,
+  Email,
+  EmptyParamsSchema,
+  enumValuesDescription,
+  EventId,
+  LimitParam,
+  NonEmptyString,
+  Timestamp
+} from "./shared.js"
 import type { PersonId, PersonName } from "./shared.js"
 
 export const VisibilityValues = ["public", "freeBusy", "private"] as const
 
 export const VisibilitySchema = Schema.Literal(...VisibilityValues).annotations({
   title: "Visibility",
-  description: "Event visibility level"
+  description: `Event visibility level: ${enumValuesDescription(VisibilityValues)}`
 })
 
 export type Visibility = Schema.Schema.Type<typeof VisibilitySchema>
@@ -26,7 +35,7 @@ export const RecurringFrequencyValues = [
 
 export const RecurringFrequencySchema = Schema.Literal(...RecurringFrequencyValues).annotations({
   title: "RecurringFrequency",
-  description: "Recurring event frequency (RFC5545)"
+  description: `Recurring event frequency (RFC5545): ${enumValuesDescription(RecurringFrequencyValues)}`
 })
 
 export type RecurringFrequency = Schema.Schema.Type<typeof RecurringFrequencySchema>
@@ -35,7 +44,7 @@ export const WeekdayValues = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const
 
 export const WeekdaySchema = Schema.Literal(...WeekdayValues).annotations({
   title: "Weekday",
-  description: "Day of week abbreviation"
+  description: `Day of week abbreviation: ${enumValuesDescription(WeekdayValues)}`
 })
 
 export type Weekday = Schema.Schema.Type<typeof WeekdaySchema>

--- a/src/domain/schemas/contacts.test.ts
+++ b/src/domain/schemas/contacts.test.ts
@@ -2,9 +2,11 @@ import { Effect, Either, Schema } from "effect"
 import { describe, expect, it } from "vitest"
 
 import {
+  AddOrganizationChannelParamsSchema,
   CreatePersonParamsSchema,
   GetPersonParamsSchema,
   ListPersonsParamsSchema,
+  parseAddOrganizationChannelParams,
   parseCreatePersonParams,
   parseGetPersonParams,
   parseListPersonsParams,
@@ -229,6 +231,36 @@ describe("Contact Schemas", () => {
           Schema.decodeUnknown(UpdatePersonParamsSchema)({
             personId: "abc123",
             firstName: ""
+          })
+        )
+      )
+      expect(Either.isLeft(result)).toBe(true)
+    })
+  })
+
+  describe("AddOrganizationChannelParamsSchema", () => {
+    // test-revizorro: approved
+    it("accepts supported organization channel provider", () => {
+      const result = Schema.decodeUnknownSync(AddOrganizationChannelParamsSchema)({
+        organizationId: "org-1",
+        provider: "whatsapp",
+        value: "+15551234"
+      })
+      expect(result).toEqual({
+        organizationId: "org-1",
+        provider: "whatsapp",
+        value: "+15551234"
+      })
+    })
+
+    // test-revizorro: approved
+    it("rejects unsupported organization channel provider", () => {
+      const result = Effect.runSync(
+        Effect.either(
+          parseAddOrganizationChannelParams({
+            organizationId: "org-1",
+            provider: "fax",
+            value: "555-1234"
           })
         )
       )

--- a/src/domain/schemas/contacts.test.ts
+++ b/src/domain/schemas/contacts.test.ts
@@ -239,7 +239,6 @@ describe("Contact Schemas", () => {
   })
 
   describe("AddOrganizationChannelParamsSchema", () => {
-    // test-revizorro: approved
     it("accepts supported organization channel provider", () => {
       const result = Schema.decodeUnknownSync(AddOrganizationChannelParamsSchema)({
         organizationId: "org-1",
@@ -253,7 +252,6 @@ describe("Contact Schemas", () => {
       })
     })
 
-    // test-revizorro: approved
     it("rejects unsupported organization channel provider", () => {
       const result = Effect.runSync(
         Effect.either(

--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -285,6 +285,7 @@ export const ListPersonOrganizationsParamsSchema = Schema.Union(
 
 export type ListPersonOrganizationsParams = Schema.Schema.Type<typeof ListPersonOrganizationsParamsSchema>
 
+// MCP-facing contact channel names backed by Huly SDK contact.channelProvider refs in organization-channel-providers.
 const OrganizationChannelProviderValues = [
   "email",
   "phone",

--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -1,7 +1,7 @@
 import { JSONSchema, Schema } from "effect"
 
 import type { ContactProvider, OrganizationId, PersonName, UrlString } from "./shared.js"
-import { Email, LimitParam, MemberReference, NonEmptyString, PersonId } from "./shared.js"
+import { Email, enumValuesDescription, LimitParam, MemberReference, NonEmptyString, PersonId } from "./shared.js"
 
 // No codec needed — internal type, not used for runtime validation
 export interface PersonSummary {
@@ -321,7 +321,7 @@ export const AddOrganizationChannelParamsSchema = Schema.Struct({
     description: "Organization ID or exact name"
   }),
   provider: OrganizationChannelProviderSchema.annotations({
-    description: `Channel type: ${OrganizationChannelProviderValues.join(", ")}`
+    description: `Channel type: ${enumValuesDescription(OrganizationChannelProviderValues)}`
   }),
   value: NonEmptyString.annotations({
     description: "Channel value (email address, phone number, URL, username)"

--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -285,7 +285,7 @@ export const ListPersonOrganizationsParamsSchema = Schema.Union(
 
 export type ListPersonOrganizationsParams = Schema.Schema.Type<typeof ListPersonOrganizationsParamsSchema>
 
-const OrganizationChannelProviderDescriptionValues = [
+const OrganizationChannelProviderValues = [
   "email",
   "phone",
   "linkedin",
@@ -293,8 +293,14 @@ const OrganizationChannelProviderDescriptionValues = [
   "github",
   "facebook",
   "telegram",
-  "homepage"
+  "homepage",
+  "whatsapp",
+  "skype",
+  "profile",
+  "viber"
 ] as const
+const OrganizationChannelProviderSchema = Schema.Literal(...OrganizationChannelProviderValues)
+export type OrganizationChannelProvider = Schema.Schema.Type<typeof OrganizationChannelProviderSchema>
 
 export const RemoveOrganizationMemberParamsSchema = Schema.Struct({
   organizationId: NonEmptyString.annotations({
@@ -314,8 +320,8 @@ export const AddOrganizationChannelParamsSchema = Schema.Struct({
   organizationId: NonEmptyString.annotations({
     description: "Organization ID or exact name"
   }),
-  provider: NonEmptyString.annotations({
-    description: `Channel type: ${OrganizationChannelProviderDescriptionValues.join(", ")}`
+  provider: OrganizationChannelProviderSchema.annotations({
+    description: `Channel type: ${OrganizationChannelProviderValues.join(", ")}`
   }),
   value: NonEmptyString.annotations({
     description: "Channel value (email address, phone number, URL, username)"

--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -285,6 +285,17 @@ export const ListPersonOrganizationsParamsSchema = Schema.Union(
 
 export type ListPersonOrganizationsParams = Schema.Schema.Type<typeof ListPersonOrganizationsParamsSchema>
 
+const OrganizationChannelProviderDescriptionValues = [
+  "email",
+  "phone",
+  "linkedin",
+  "twitter",
+  "github",
+  "facebook",
+  "telegram",
+  "homepage"
+] as const
+
 export const RemoveOrganizationMemberParamsSchema = Schema.Struct({
   organizationId: NonEmptyString.annotations({
     description: "Organization ID or exact name"
@@ -304,7 +315,7 @@ export const AddOrganizationChannelParamsSchema = Schema.Struct({
     description: "Organization ID or exact name"
   }),
   provider: NonEmptyString.annotations({
-    description: "Channel type: email, phone, linkedin, twitter, github, facebook, telegram, homepage"
+    description: `Channel type: ${OrganizationChannelProviderDescriptionValues.join(", ")}`
   }),
   value: NonEmptyString.annotations({
     description: "Channel value (email address, phone number, URL, username)"

--- a/src/domain/schemas/custom-fields.ts
+++ b/src/domain/schemas/custom-fields.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, Schema } from "effect"
 
-import { CustomFieldId, LimitParam, NonEmptyString, ObjectClassName } from "./shared.js"
+import { CustomFieldId, DocId, LimitParam, NonEmptyString, ObjectClassName } from "./shared.js"
 
 export const ListCustomFieldsParamsSchema = Schema.Struct({
   targetClass: Schema.optional(
@@ -22,10 +22,10 @@ export const ListCustomFieldsParamsSchema = Schema.Struct({
 export type ListCustomFieldsParams = Schema.Schema.Type<typeof ListCustomFieldsParamsSchema>
 
 export const GetCustomFieldValuesParamsSchema = Schema.Struct({
-  objectId: NonEmptyString.annotations({
+  objectId: DocId.annotations({
     description: "Document ID to read custom field values from"
   }),
-  objectClass: NonEmptyString.annotations({
+  objectClass: ObjectClassName.annotations({
     description:
       "Class of the document (e.g. 'tracker:class:Issue', 'card:class:Card', or a dynamic master tag class ID)"
   })
@@ -37,14 +37,14 @@ export const GetCustomFieldValuesParamsSchema = Schema.Struct({
 export type GetCustomFieldValuesParams = Schema.Schema.Type<typeof GetCustomFieldValuesParamsSchema>
 
 export const SetCustomFieldParamsSchema = Schema.Struct({
-  objectId: NonEmptyString.annotations({
+  objectId: DocId.annotations({
     description: "Document ID to set the custom field value on"
   }),
-  objectClass: NonEmptyString.annotations({
+  objectClass: ObjectClassName.annotations({
     description:
       "Class of the document (e.g. 'tracker:class:Issue', 'card:class:Card', or a dynamic master tag class ID)"
   }),
-  fieldId: NonEmptyString.annotations({
+  fieldId: CustomFieldId.annotations({
     description: "Custom field attribute ID (the _id from list_custom_fields)"
   }),
   value: Schema.String.annotations({
@@ -130,7 +130,7 @@ export interface CustomFieldValue {
 }
 
 export interface SetCustomFieldResult {
-  readonly objectId: NonEmptyString
+  readonly objectId: DocId
   readonly fieldId: CustomFieldId
   readonly label: string
   readonly value: unknown
@@ -200,7 +200,7 @@ export const CustomFieldValueWireSchema = Schema.Struct({
 })
 
 export const SetCustomFieldResultWireSchema = Schema.Struct({
-  objectId: NonEmptyString,
+  objectId: DocId,
   fieldId: CustomFieldId,
   label: Schema.String,
   value: Schema.Unknown,

--- a/src/domain/schemas/custom-fields.ts
+++ b/src/domain/schemas/custom-fields.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, Schema } from "effect"
 
-import { CustomFieldId, DocId, LimitParam, NonEmptyString, ObjectClassName } from "./shared.js"
+import { CustomFieldId, DocId, enumValuesDescription, LimitParam, NonEmptyString, ObjectClassName } from "./shared.js"
 
 export const ListCustomFieldsParamsSchema = Schema.Struct({
   targetClass: Schema.optional(
@@ -69,7 +69,9 @@ const CUSTOM_FIELD_TYPE_NAMES = [
   "unknown"
 ] as const
 
-export const CustomFieldTypeNameSchema = Schema.Literal(...CUSTOM_FIELD_TYPE_NAMES)
+export const CustomFieldTypeNameSchema = Schema.Literal(...CUSTOM_FIELD_TYPE_NAMES).annotations({
+  description: `Custom field type: ${enumValuesDescription(CUSTOM_FIELD_TYPE_NAMES)}`
+})
 
 export type CustomFieldTypeName = typeof CUSTOM_FIELD_TYPE_NAMES[number]
 

--- a/src/domain/schemas/deletion.ts
+++ b/src/domain/schemas/deletion.ts
@@ -6,14 +6,14 @@ const EntityTypeValues = ["issue", "project", "component", "milestone"] as const
 
 const EntityTypeSchema = Schema.Literal(...EntityTypeValues).annotations({
   title: "EntityType",
-  description: "Type of entity to preview deletion for"
+  description: `Type of entity to preview deletion for: ${EntityTypeValues.join(", ")}`
 })
 
 export type EntityType = Schema.Schema.Type<typeof EntityTypeSchema>
 
 export const PreviewDeletionParamsSchema = Schema.Struct({
   entityType: EntityTypeSchema.annotations({
-    description: "Type of entity: issue, project, component, or milestone"
+    description: `Type of entity: ${EntityTypeValues.join(", ")}`
   }),
   project: ProjectIdentifier.annotations({
     description: "Project identifier (e.g., 'HULY'). For entityType='project', this IS the target project."

--- a/src/domain/schemas/deletion.ts
+++ b/src/domain/schemas/deletion.ts
@@ -1,19 +1,19 @@
 import { JSONSchema, Schema } from "effect"
 
-import { ProjectIdentifier } from "./shared.js"
+import { enumValuesDescription, ProjectIdentifier } from "./shared.js"
 
 const EntityTypeValues = ["issue", "project", "component", "milestone"] as const
 
 const EntityTypeSchema = Schema.Literal(...EntityTypeValues).annotations({
   title: "EntityType",
-  description: `Type of entity to preview deletion for: ${EntityTypeValues.join(", ")}`
+  description: `Type of entity to preview deletion for: ${enumValuesDescription(EntityTypeValues)}`
 })
 
 export type EntityType = Schema.Schema.Type<typeof EntityTypeSchema>
 
 export const PreviewDeletionParamsSchema = Schema.Struct({
   entityType: EntityTypeSchema.annotations({
-    description: `Type of entity: ${EntityTypeValues.join(", ")}`
+    description: `Type of entity: ${enumValuesDescription(EntityTypeValues)}`
   }),
   project: ProjectIdentifier.annotations({
     description: "Project identifier (e.g., 'HULY'). For entityType='project', this IS the target project."

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -2,6 +2,7 @@ import { JSONSchema, Schema } from "effect"
 
 import {
   AssociationId,
+  DocId,
   DocumentIdentifier,
   IssueIdentifier,
   LimitParam,
@@ -35,7 +36,7 @@ export type RelationIfExists = Schema.Schema.Type<typeof RelationIfExistsSchema>
 
 const RawObjectLocatorSchema = Schema.Struct({
   kind: Schema.Literal("raw"),
-  id: NonEmptyString.annotations({
+  id: DocId.annotations({
     description: "Raw Huly document _id"
   }),
   class: Schema.optional(ObjectClassName.annotations({
@@ -76,7 +77,7 @@ export const GenericObjectLocatorSchema = Schema.Union(
 export type GenericObjectLocator = Schema.Schema.Type<typeof GenericObjectLocatorSchema>
 
 export const ResolvedObjectSummarySchema = Schema.Struct({
-  id: NonEmptyString,
+  id: DocId,
   class: ObjectClassName,
   display: NonEmptyString,
   locatorKind: Schema.Literal("raw", "issue", "document"),

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -20,15 +20,21 @@ export type AssociationIdentifier = Schema.Schema.Type<typeof AssociationIdentif
 export const RelationIdentifier = NonEmptyString.pipe(Schema.brand("RelationIdentifier"))
 export type RelationIdentifier = Schema.Schema.Type<typeof RelationIdentifier>
 
-export const CardinalitySchema = Schema.Literal(
+const CardinalityValues = [
   "one-to-one",
   "one-to-many",
   "many-to-many"
-)
+] as const
+export const CardinalitySchema = Schema.Literal(...CardinalityValues)
 export type Cardinality = Schema.Schema.Type<typeof CardinalitySchema>
 
-export const RelationDirectionSchema = Schema.Literal("source-to-target", "target-to-source", "either")
+const RelationDirectionValues = ["source-to-target", "target-to-source", "either"] as const
+export const RelationDirectionSchema = Schema.Literal(...RelationDirectionValues)
 export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
+export const DefaultRelationDirection = "source-to-target" satisfies RelationDirection
+const relationDirectionDescription = `Relation traversal direction: ${
+  RelationDirectionValues.join(", ")
+}. Defaults to ${DefaultRelationDirection}.`
 
 export const RelationIfExistsSchema = Schema.Literal("return_existing", "fail")
 export type RelationIfExists = Schema.Schema.Type<typeof RelationIfExistsSchema>
@@ -157,7 +163,7 @@ export const ListRelationsParamsSchema = Schema.Struct({
     description: "Optional target endpoint filter"
   })),
   direction: Schema.optional(RelationDirectionSchema.annotations({
-    description: "source-to-target, target-to-source, or either. Defaults to source-to-target."
+    description: relationDirectionDescription
   })),
   limit: Schema.optional(LimitParam.annotations({
     description: "Maximum number of relations to return (default: 50)"

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -25,10 +25,12 @@ const CardinalityValues = [
   "one-to-many",
   "many-to-many"
 ] as const
+// MCP-facing vocabulary derived from Huly SDK Association["type"]; operations maintain the exact SDK mapping.
 export const CardinalitySchema = Schema.Literal(...CardinalityValues)
 export type Cardinality = Schema.Schema.Type<typeof CardinalitySchema>
 
 const RelationDirectionValues = ["source-to-target", "target-to-source", "either"] as const
+// MCP-only traversal vocabulary; it controls how caller source/target map onto Huly Relation docA/docB.
 export const RelationDirectionSchema = Schema.Literal(...RelationDirectionValues)
 export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
 export const DefaultRelationDirection = "source-to-target" satisfies RelationDirection

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -4,6 +4,7 @@ import {
   AssociationId,
   DocId,
   DocumentIdentifier,
+  enumValuesDescription,
   IssueIdentifier,
   LimitParam,
   NonEmptyString,
@@ -26,7 +27,9 @@ const CardinalityValues = [
   "many-to-many"
 ] as const
 // MCP-facing vocabulary derived from Huly SDK Association["type"]; operations maintain the exact SDK mapping.
-export const CardinalitySchema = Schema.Literal(...CardinalityValues)
+export const CardinalitySchema = Schema.Literal(...CardinalityValues).annotations({
+  description: `Association cardinality: ${enumValuesDescription(CardinalityValues)}`
+})
 export type Cardinality = Schema.Schema.Type<typeof CardinalitySchema>
 
 const RelationDirectionValues = ["source-to-target", "target-to-source", "either"] as const
@@ -35,7 +38,7 @@ export const RelationDirectionSchema = Schema.Literal(...RelationDirectionValues
 export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
 export const DefaultRelationDirection = "source-to-target" satisfies RelationDirection
 const relationDirectionDescription = `Relation traversal direction: ${
-  RelationDirectionValues.join(", ")
+  enumValuesDescription(RelationDirectionValues)
 }. Defaults to ${DefaultRelationDirection}.`
 
 export const RelationIfExistsSchema = Schema.Literal("return_existing", "fail")

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -23,10 +23,9 @@ export type RelationIdentifier = Schema.Schema.Type<typeof RelationIdentifier>
 export const CardinalitySchema = Schema.Literal(
   "one-to-one",
   "one-to-many",
-  "many-to-one",
-  "many-to-many",
-  "unknown"
+  "many-to-many"
 )
+export type Cardinality = Schema.Schema.Type<typeof CardinalitySchema>
 
 export const RelationDirectionSchema = Schema.Literal("source-to-target", "target-to-source", "either")
 export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
@@ -95,7 +94,7 @@ export const AssociationSummarySchema = Schema.Struct({
   sourceRole: Schema.optional(NonEmptyString),
   targetRole: Schema.optional(NonEmptyString),
   relationClass: Schema.optional(ObjectClassName),
-  cardinality: Schema.optional(CardinalitySchema),
+  cardinality: CardinalitySchema,
   symmetric: Schema.Boolean,
   system: Schema.Boolean,
   canListRelations: Schema.Boolean,

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -160,7 +160,7 @@ export const ListAssociationsResultSchema = Schema.Struct({
 })
 export type ListAssociationsResult = Schema.Schema.Type<typeof ListAssociationsResultSchema>
 
-export const ListRelationsParamsSchema = Schema.Struct({
+const ListRelationsParamsBaseSchema = Schema.Struct({
   association: Schema.optional(AssociationIdentifier.annotations({
     description: "Association _id or name. If omitted, relations are listed only across supported visible associations."
   })),
@@ -176,7 +176,12 @@ export const ListRelationsParamsSchema = Schema.Struct({
   limit: Schema.optional(LimitParam.annotations({
     description: "Maximum number of relations to return (default: 50)"
   }))
-}).pipe(
+}).annotations({
+  title: "ListRelationsParams",
+  description: "Parameters for listing concrete Huly relation instances"
+})
+
+export const ListRelationsParamsSchema = ListRelationsParamsBaseSchema.pipe(
   Schema.filter((params) =>
     params.association === undefined && params.source === undefined && params.target === undefined
       ? "Provide at least one of association, source, or target to avoid broad workspace scans."
@@ -272,7 +277,14 @@ export const DeleteRelationResultSchema = Schema.Struct({
 export type DeleteRelationResult = Schema.Schema.Type<typeof DeleteRelationResultSchema>
 
 export const listAssociationsParamsJsonSchema = JSONSchema.make(ListAssociationsParamsSchema)
-export const listRelationsParamsJsonSchema = JSONSchema.make(ListRelationsParamsSchema)
+export const listRelationsParamsJsonSchema = {
+  ...JSONSchema.make(ListRelationsParamsBaseSchema),
+  anyOf: [
+    { required: ["association"] },
+    { required: ["source"] },
+    { required: ["target"] }
+  ]
+}
 export const createRelationParamsJsonSchema = JSONSchema.make(CreateRelationParamsSchema)
 export const deleteRelationParamsJsonSchema = {
   ...JSONSchema.make(DeleteRelationParamsSchema),

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -21,6 +21,9 @@ export type AssociationIdentifier = Schema.Schema.Type<typeof AssociationIdentif
 export const RelationIdentifier = NonEmptyString.pipe(Schema.brand("RelationIdentifier"))
 export type RelationIdentifier = Schema.Schema.Type<typeof RelationIdentifier>
 
+export const ListRelationsWarning = NonEmptyString.pipe(Schema.brand("ListRelationsWarning"))
+export type ListRelationsWarning = Schema.Schema.Type<typeof ListRelationsWarning>
+
 const CardinalityValues = [
   "one-to-one",
   "one-to-many",
@@ -187,7 +190,13 @@ export type ListRelationsParams = Schema.Schema.Type<typeof ListRelationsParamsS
 
 export const ListRelationsResultSchema = Schema.Struct({
   relations: Schema.Array(RelationSummarySchema),
-  total: Schema.Number
+  total: Schema.Number,
+  warnings: Schema.optional(
+    Schema.NonEmptyArray(ListRelationsWarning).annotations({
+      description:
+        "Non-fatal warnings about result completeness or resolution. Treat these as guidance for narrowing a follow-up call."
+    })
+  )
 })
 export type ListRelationsResult = Schema.Schema.Type<typeof ListRelationsResultSchema>
 

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -1,0 +1,264 @@
+import { JSONSchema, Schema } from "effect"
+
+import {
+  AssociationId,
+  DocumentIdentifier,
+  IssueIdentifier,
+  LimitParam,
+  NonEmptyString,
+  ObjectClassName,
+  ProjectIdentifier,
+  RelationId,
+  TeamspaceIdentifier,
+  Timestamp
+} from "./shared.js"
+
+export const AssociationIdentifier = NonEmptyString.pipe(Schema.brand("AssociationIdentifier"))
+export type AssociationIdentifier = Schema.Schema.Type<typeof AssociationIdentifier>
+
+export const RelationIdentifier = NonEmptyString.pipe(Schema.brand("RelationIdentifier"))
+export type RelationIdentifier = Schema.Schema.Type<typeof RelationIdentifier>
+
+export const CardinalitySchema = Schema.Literal(
+  "one-to-one",
+  "one-to-many",
+  "many-to-one",
+  "many-to-many",
+  "unknown"
+)
+
+export const RelationDirectionSchema = Schema.Literal("source-to-target", "target-to-source", "either")
+export type RelationDirection = Schema.Schema.Type<typeof RelationDirectionSchema>
+
+export const RelationIfExistsSchema = Schema.Literal("return_existing", "fail")
+export type RelationIfExists = Schema.Schema.Type<typeof RelationIfExistsSchema>
+
+const RawObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("raw"),
+  id: NonEmptyString.annotations({
+    description: "Raw Huly document _id"
+  }),
+  class: Schema.optional(ObjectClassName.annotations({
+    description:
+      "Raw Huly document class, such as tracker:class:Issue. Required unless the association side determines the expected class."
+  }))
+})
+
+const IssueObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("issue"),
+  issue: IssueIdentifier.annotations({
+    description: "Issue identifier, such as HULY-123, or a numeric issue number when project is also provided."
+  }),
+  project: Schema.optional(ProjectIdentifier.annotations({
+    description: "Project identifier. Optional when issue already includes a project prefix like HULY-123."
+  }))
+})
+
+const DocumentObjectLocatorSchema = Schema.Struct({
+  kind: Schema.Literal("document"),
+  document: DocumentIdentifier.annotations({
+    description: "Document title or ID"
+  }),
+  teamspace: Schema.optional(TeamspaceIdentifier.annotations({
+    description: "Teamspace name or ID. If omitted, document title matches must be unique across the workspace."
+  }))
+})
+
+export const GenericObjectLocatorSchema = Schema.Union(
+  RawObjectLocatorSchema,
+  IssueObjectLocatorSchema,
+  DocumentObjectLocatorSchema
+).annotations({
+  title: "GenericObjectLocator",
+  description:
+    "Explicit locator for a Huly document endpoint. Use raw for known _id values, issue for tracker issues, or document for Huly documents. Card locators are intentionally not included until a robust card resolver is available."
+})
+export type GenericObjectLocator = Schema.Schema.Type<typeof GenericObjectLocatorSchema>
+
+export const ResolvedObjectSummarySchema = Schema.Struct({
+  id: NonEmptyString,
+  class: ObjectClassName,
+  display: NonEmptyString,
+  locatorKind: Schema.Literal("raw", "issue", "document"),
+  warning: Schema.optional(Schema.String)
+})
+export type ResolvedObjectSummary = Schema.Schema.Type<typeof ResolvedObjectSummarySchema>
+
+export const AssociationSummarySchema = Schema.Struct({
+  associationId: AssociationId,
+  name: Schema.optional(NonEmptyString),
+  label: Schema.optional(NonEmptyString),
+  description: Schema.optional(Schema.String),
+  sourceClass: ObjectClassName,
+  targetClass: ObjectClassName,
+  sourceRole: Schema.optional(NonEmptyString),
+  targetRole: Schema.optional(NonEmptyString),
+  relationClass: Schema.optional(ObjectClassName),
+  cardinality: Schema.optional(CardinalitySchema),
+  symmetric: Schema.Boolean,
+  system: Schema.Boolean,
+  canListRelations: Schema.Boolean,
+  canCreateRelation: Schema.Boolean,
+  canDeleteRelation: Schema.Boolean,
+  unsupportedReason: Schema.optional(Schema.String)
+})
+export type AssociationSummary = Schema.Schema.Type<typeof AssociationSummarySchema>
+
+export const RelationSummarySchema = Schema.Struct({
+  relationId: RelationId,
+  associationId: AssociationId,
+  associationName: Schema.optional(NonEmptyString),
+  source: ResolvedObjectSummarySchema,
+  target: ResolvedObjectSummarySchema,
+  createdOn: Schema.optional(Timestamp),
+  modifiedOn: Schema.optional(Timestamp)
+})
+export type RelationSummary = Schema.Schema.Type<typeof RelationSummarySchema>
+
+export const ListAssociationsParamsSchema = Schema.Struct({
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id, source/target role name, or stable association name"
+  })),
+  sourceClass: Schema.optional(ObjectClassName.annotations({
+    description: "Only return associations whose source class matches this Huly class ID"
+  })),
+  targetClass: Schema.optional(ObjectClassName.annotations({
+    description: "Only return associations whose target class matches this Huly class ID"
+  })),
+  writableOnly: Schema.optional(Schema.Boolean.annotations({
+    description: "Only return associations whose relation create/delete path has been validated and allowlisted"
+  })),
+  includeSystem: Schema.optional(Schema.Boolean.annotations({
+    description: "Include internal/system associations. Defaults to false."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: "Maximum number of associations to return (default: 50)"
+  }))
+}).annotations({
+  title: "ListAssociationsParams",
+  description: "Parameters for listing generic Huly association definitions"
+})
+export type ListAssociationsParams = Schema.Schema.Type<typeof ListAssociationsParamsSchema>
+
+export const ListAssociationsResultSchema = Schema.Struct({
+  associations: Schema.Array(AssociationSummarySchema),
+  total: Schema.Number
+})
+export type ListAssociationsResult = Schema.Schema.Type<typeof ListAssociationsResultSchema>
+
+export const ListRelationsParamsSchema = Schema.Struct({
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id or name. If omitted, relations are listed only across supported visible associations."
+  })),
+  source: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Optional source endpoint filter"
+  })),
+  target: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Optional target endpoint filter"
+  })),
+  direction: Schema.optional(RelationDirectionSchema.annotations({
+    description: "source-to-target, target-to-source, or either. Defaults to source-to-target."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: "Maximum number of relations to return (default: 50)"
+  }))
+}).pipe(
+  Schema.filter((params) =>
+    params.association === undefined && params.source === undefined && params.target === undefined
+      ? "Provide at least one of association, source, or target to avoid broad workspace scans."
+      : undefined
+  )
+).annotations({
+  title: "ListRelationsParams",
+  description: "Parameters for listing concrete Huly relation instances"
+})
+export type ListRelationsParams = Schema.Schema.Type<typeof ListRelationsParamsSchema>
+
+export const ListRelationsResultSchema = Schema.Struct({
+  relations: Schema.Array(RelationSummarySchema),
+  total: Schema.Number
+})
+export type ListRelationsResult = Schema.Schema.Type<typeof ListRelationsResultSchema>
+
+export const CreateRelationParamsSchema = Schema.Struct({
+  association: AssociationIdentifier.annotations({
+    description: "Association _id or unambiguous name returned by list_associations"
+  }),
+  source: GenericObjectLocatorSchema.annotations({
+    description: "Source endpoint document"
+  }),
+  target: GenericObjectLocatorSchema.annotations({
+    description: "Target endpoint document"
+  }),
+  ifExists: Schema.optional(RelationIfExistsSchema.annotations({
+    description: "return_existing (default) returns an existing relation; fail reports an existing relation as an error"
+  }))
+}).annotations({
+  title: "CreateRelationParams",
+  description: "Parameters for idempotently creating a concrete generic relation"
+})
+export type CreateRelationParams = Schema.Schema.Type<typeof CreateRelationParamsSchema>
+
+export const CreateRelationResultSchema = Schema.Struct({
+  relationId: RelationId,
+  associationId: AssociationId,
+  source: ResolvedObjectSummarySchema,
+  target: ResolvedObjectSummarySchema,
+  created: Schema.Boolean,
+  existing: Schema.Boolean
+})
+export type CreateRelationResult = Schema.Schema.Type<typeof CreateRelationResultSchema>
+
+export const DeleteRelationParamsSchema = Schema.Struct({
+  relation: Schema.optional(RelationIdentifier.annotations({
+    description: "Concrete relation _id to delete"
+  })),
+  association: Schema.optional(AssociationIdentifier.annotations({
+    description: "Association _id or unambiguous name. Required when deleting by source/target triple."
+  })),
+  source: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Source endpoint. Required when deleting by source/target triple."
+  })),
+  target: Schema.optional(GenericObjectLocatorSchema.annotations({
+    description: "Target endpoint. Required when deleting by source/target triple."
+  }))
+}).pipe(
+  Schema.filter((params) => {
+    const hasRelation = params.relation !== undefined
+    const hasTriple = params.association !== undefined && params.source !== undefined && params.target !== undefined
+    const hasPartialTriple = params.association !== undefined || params.source !== undefined
+      || params.target !== undefined
+
+    if (hasRelation && hasPartialTriple) {
+      return "Provide either relation, or association + source + target, not both."
+    }
+    if (!hasRelation && !hasTriple) {
+      return "Provide relation, or the full association + source + target triple. Partial triples are not allowed."
+    }
+    return undefined
+  })
+).annotations({
+  title: "DeleteRelationParams",
+  description: "Parameters for idempotently deleting one concrete generic relation"
+})
+export type DeleteRelationParams = Schema.Schema.Type<typeof DeleteRelationParamsSchema>
+
+export const DeleteRelationResultSchema = Schema.Struct({
+  relationId: Schema.optional(RelationId),
+  associationId: Schema.optional(AssociationId),
+  deleted: Schema.Boolean,
+  reason: Schema.optional(Schema.Literal("not_found", "deleted"))
+})
+export type DeleteRelationResult = Schema.Schema.Type<typeof DeleteRelationResultSchema>
+
+export const listAssociationsParamsJsonSchema = JSONSchema.make(ListAssociationsParamsSchema)
+export const listRelationsParamsJsonSchema = JSONSchema.make(ListRelationsParamsSchema)
+export const createRelationParamsJsonSchema = JSONSchema.make(CreateRelationParamsSchema)
+export const deleteRelationParamsJsonSchema = JSONSchema.make(DeleteRelationParamsSchema)
+
+const strictParseOptions = { onExcessProperty: "error" } as const
+
+export const parseListAssociationsParams = Schema.decodeUnknown(ListAssociationsParamsSchema, strictParseOptions)
+export const parseListRelationsParams = Schema.decodeUnknown(ListRelationsParamsSchema, strictParseOptions)
+export const parseCreateRelationParams = Schema.decodeUnknown(CreateRelationParamsSchema, strictParseOptions)
+export const parseDeleteRelationParams = Schema.decodeUnknown(DeleteRelationParamsSchema, strictParseOptions)

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -215,37 +215,37 @@ export const CreateRelationResultSchema = Schema.Struct({
 })
 export type CreateRelationResult = Schema.Schema.Type<typeof CreateRelationResultSchema>
 
-export const DeleteRelationParamsSchema = Schema.Struct({
-  relation: Schema.optional(RelationIdentifier.annotations({
+const DeleteRelationByIdParamsSchema = Schema.Struct({
+  relation: RelationIdentifier.annotations({
     description: "Concrete relation _id to delete"
-  })),
-  association: Schema.optional(AssociationIdentifier.annotations({
-    description: "Association _id or unambiguous name. Required when deleting by source/target triple."
-  })),
-  source: Schema.optional(GenericObjectLocatorSchema.annotations({
-    description: "Source endpoint. Required when deleting by source/target triple."
-  })),
-  target: Schema.optional(GenericObjectLocatorSchema.annotations({
-    description: "Target endpoint. Required when deleting by source/target triple."
-  }))
-}).pipe(
-  Schema.filter((params) => {
-    const hasRelation = params.relation !== undefined
-    const hasTriple = params.association !== undefined && params.source !== undefined && params.target !== undefined
-    const hasPartialTriple = params.association !== undefined || params.source !== undefined
-      || params.target !== undefined
-
-    if (hasRelation && hasPartialTriple) {
-      return "Provide either relation, or association + source + target, not both."
-    }
-    if (!hasRelation && !hasTriple) {
-      return "Provide relation, or the full association + source + target triple. Partial triples are not allowed."
-    }
-    return undefined
   })
+}).annotations({
+  title: "DeleteRelationByIdParams",
+  description: "Delete one concrete relation by its relation ID."
+})
+
+const DeleteRelationByTripleParamsSchema = Schema.Struct({
+  association: AssociationIdentifier.annotations({
+    description: "Association _id or unambiguous name"
+  }),
+  source: GenericObjectLocatorSchema.annotations({
+    description: "Source endpoint"
+  }),
+  target: GenericObjectLocatorSchema.annotations({
+    description: "Target endpoint"
+  })
+}).annotations({
+  title: "DeleteRelationByTripleParams",
+  description: "Delete one concrete relation by exact association + source + target triple."
+})
+
+export const DeleteRelationParamsSchema = Schema.Union(
+  DeleteRelationByIdParamsSchema,
+  DeleteRelationByTripleParamsSchema
 ).annotations({
   title: "DeleteRelationParams",
-  description: "Parameters for idempotently deleting one concrete generic relation"
+  description:
+    "Parameters for idempotently deleting one concrete generic relation. Provide either relation, or the full association + source + target triple."
 })
 export type DeleteRelationParams = Schema.Schema.Type<typeof DeleteRelationParamsSchema>
 
@@ -260,7 +260,10 @@ export type DeleteRelationResult = Schema.Schema.Type<typeof DeleteRelationResul
 export const listAssociationsParamsJsonSchema = JSONSchema.make(ListAssociationsParamsSchema)
 export const listRelationsParamsJsonSchema = JSONSchema.make(ListRelationsParamsSchema)
 export const createRelationParamsJsonSchema = JSONSchema.make(CreateRelationParamsSchema)
-export const deleteRelationParamsJsonSchema = JSONSchema.make(DeleteRelationParamsSchema)
+export const deleteRelationParamsJsonSchema = {
+  ...JSONSchema.make(DeleteRelationParamsSchema),
+  type: "object"
+}
 
 const strictParseOptions = { onExcessProperty: "error" } as const
 

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -104,7 +104,13 @@ export const AssociationSummarySchema = Schema.Struct({
   label: Schema.optional(NonEmptyString),
   description: Schema.optional(Schema.String),
   sourceClass: ObjectClassName,
+  sourceClassLabel: Schema.optional(NonEmptyString.annotations({
+    description: "Best-effort human display label for sourceClass when the class is known to this server"
+  })),
   targetClass: ObjectClassName,
+  targetClassLabel: Schema.optional(NonEmptyString.annotations({
+    description: "Best-effort human display label for targetClass when the class is known to this server"
+  })),
   sourceRole: Schema.optional(NonEmptyString),
   targetRole: Schema.optional(NonEmptyString),
   relationClass: Schema.optional(ObjectClassName),

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- barrel re-export index; no logic, only re-exports from domain modules */
 export {
   AssociationId,
+  DocId,
   emptyParamsJsonSchema,
   EmptyParamsSchema,
   IssueId,
@@ -231,6 +232,7 @@ export {
   ProcessStateSummarySchema,
   type ProcessSummary,
   ProcessSummarySchema,
+  ProcessTransitionId,
   type ProcessTransitionSummary,
   ProcessTransitionSummarySchema
 } from "./processes.js"

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- barrel re-export index; no logic, only re-exports from domain modules */
 export {
+  AssociationId,
   emptyParamsJsonSchema,
   EmptyParamsSchema,
   IssueId,
@@ -15,10 +16,53 @@ export {
   PositiveNumber,
   ProjectTypeId,
   ReactionId,
+  RelationId,
   SavedMessageId,
   TaskTypeId,
   Timestamp
 } from "./shared.js"
+
+export {
+  AssociationIdentifier,
+  type AssociationSummary,
+  AssociationSummarySchema,
+  CardinalitySchema,
+  type CreateRelationParams,
+  createRelationParamsJsonSchema,
+  CreateRelationParamsSchema,
+  type CreateRelationResult,
+  CreateRelationResultSchema,
+  type DeleteRelationParams,
+  deleteRelationParamsJsonSchema,
+  DeleteRelationParamsSchema,
+  type DeleteRelationResult,
+  DeleteRelationResultSchema,
+  type GenericObjectLocator,
+  GenericObjectLocatorSchema,
+  type ListAssociationsParams,
+  listAssociationsParamsJsonSchema,
+  ListAssociationsParamsSchema,
+  type ListAssociationsResult,
+  ListAssociationsResultSchema,
+  type ListRelationsParams,
+  listRelationsParamsJsonSchema,
+  ListRelationsParamsSchema,
+  type ListRelationsResult,
+  ListRelationsResultSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams,
+  type RelationDirection,
+  RelationDirectionSchema,
+  RelationIdentifier,
+  type RelationIfExists,
+  RelationIfExistsSchema,
+  type RelationSummary,
+  RelationSummarySchema,
+  type ResolvedObjectSummary,
+  ResolvedObjectSummarySchema
+} from "./generic-associations.js"
 
 export {
   type CreateProjectParams,

--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -6,6 +6,7 @@ import {
   ColorCode,
   ComponentIdentifier,
   Email,
+  enumValuesDescription,
   IssueIdentifier,
   LimitParam,
   NonEmptyString,
@@ -36,13 +37,15 @@ export const IssuePrioritySchema = Schema.transformOrFail(
       const match = normalizedPriorityLookup.get(normalizeForComparison(input))
       return match !== undefined
         ? ParseResult.succeed(match)
-        : ParseResult.fail(new ParseResult.Type(ast, input, `Expected one of: ${IssuePriorityValues.join(", ")}`))
+        : ParseResult.fail(
+          new ParseResult.Type(ast, input, `Expected one of: ${enumValuesDescription(IssuePriorityValues)}`)
+        )
     },
     encode: ParseResult.succeed
   }
 ).annotations({
   title: "IssuePriority",
-  description: "Issue priority level",
+  description: `Issue priority level: ${enumValuesDescription(IssuePriorityValues)}`,
   jsonSchema: { type: "string", enum: [...IssuePriorityValues] }
 })
 

--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -73,7 +73,8 @@ export const PersonRefSchema = Schema.Struct({
 export type PersonRef = Schema.Schema.Type<typeof PersonRefSchema>
 
 const IssueIdOutputSchema = IssueId.annotations({
-  description: "Raw Huly issue _id. Use this as a raw object locator id for relation and activity tools."
+  description:
+    "Raw Huly issue _id. For raw objectId/objectClass tools, pair this with objectClass 'tracker:class:Issue'. Prefer friendly issue locators when a tool provides them."
 })
 
 export const IssueSummarySchema = Schema.Struct({

--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -1,12 +1,12 @@
 import { JSONSchema, ParseResult, Schema } from "effect"
 
 import { normalizeForComparison } from "../../utils/normalize.js"
-import type { IssueId } from "./shared.js"
 import {
   ColorCode,
   ComponentIdentifier,
   Email,
   enumValuesDescription,
+  IssueId,
   IssueIdentifier,
   LimitParam,
   NonEmptyString,
@@ -72,7 +72,12 @@ export const PersonRefSchema = Schema.Struct({
 
 export type PersonRef = Schema.Schema.Type<typeof PersonRefSchema>
 
+const IssueIdOutputSchema = IssueId.annotations({
+  description: "Raw Huly issue _id. Use this as a raw object locator id for relation and activity tools."
+})
+
 export const IssueSummarySchema = Schema.Struct({
+  issueId: IssueIdOutputSchema,
   identifier: IssueIdentifier,
   // String, not NonEmptyString: Huly allows storing issues with empty titles
   title: Schema.String,
@@ -90,6 +95,7 @@ export const IssueSummarySchema = Schema.Struct({
 export type IssueSummary = Schema.Schema.Type<typeof IssueSummarySchema>
 
 export const IssueSchema = Schema.Struct({
+  issueId: IssueIdOutputSchema,
   identifier: IssueIdentifier,
   // String, not NonEmptyString: Huly allows storing issues with empty titles
   title: Schema.String,

--- a/src/domain/schemas/leads.ts
+++ b/src/domain/schemas/leads.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, ParseResult, Schema } from "effect"
 
-import { LimitParam, PersonName, PersonRefInput, StatusName, Timestamp } from "./shared.js"
+import { DocId, LimitParam, NonEmptyString, PersonName, PersonRefInput, StatusName, Timestamp } from "./shared.js"
 
 // --- Lead IDs ---
 // Upstream Huly reference:
@@ -8,12 +8,10 @@ import { LimitParam, PersonName, PersonRefInput, StatusName, Timestamp } from ".
 // Funnel is a Project-derived space; expose the stable `_id` as the machine identifier.
 // Lead identifiers use the upstream `LEAD-<number>` convention.
 
-const HulyRef = <T extends string>(tag: T) => Schema.Trim.pipe(Schema.nonEmptyString(), Schema.brand(tag))
-
-export const FunnelReference = HulyRef("FunnelReference")
+export const FunnelReference = NonEmptyString.pipe(Schema.brand("FunnelReference"))
 export type FunnelReference = Schema.Schema.Type<typeof FunnelReference>
 
-export const FunnelIdentifier = HulyRef("FunnelIdentifier")
+export const FunnelIdentifier = DocId.pipe(Schema.brand("FunnelIdentifier"))
 export type FunnelIdentifier = Schema.Schema.Type<typeof FunnelIdentifier>
 
 // Specific upstream proof for the LEAD prefix:

--- a/src/domain/schemas/milestones.ts
+++ b/src/domain/schemas/milestones.ts
@@ -1,6 +1,7 @@
 import { JSONSchema, Schema } from "effect"
 
 import {
+  enumValuesDescription,
   IssueIdentifier,
   LimitParam,
   MilestoneId,
@@ -15,7 +16,7 @@ export const MilestoneStatusValues = ["planned", "in-progress", "completed", "ca
 
 export const MilestoneStatusSchema = Schema.Literal(...MilestoneStatusValues).annotations({
   title: "MilestoneStatus",
-  description: "Milestone status"
+  description: `Milestone status: ${enumValuesDescription(MilestoneStatusValues)}`
 })
 
 export type MilestoneStatus = Schema.Schema.Type<typeof MilestoneStatusSchema>

--- a/src/domain/schemas/notifications.ts
+++ b/src/domain/schemas/notifications.ts
@@ -2,8 +2,8 @@ import { JSONSchema, Schema } from "effect"
 
 import type { NotificationTypeId } from "./shared.js"
 import {
+  DocId,
   LimitParam,
-  NonEmptyString,
   NotificationContextId,
   NotificationId,
   NotificationProviderId,
@@ -15,7 +15,7 @@ export interface NotificationSummary {
   readonly id: NotificationId
   readonly isViewed: boolean
   readonly archived: boolean
-  readonly objectId?: string | undefined
+  readonly objectId?: DocId | undefined
   readonly objectClass?: ObjectClassName | undefined
   readonly title?: string | undefined
   readonly body?: string | undefined
@@ -27,7 +27,7 @@ export interface Notification {
   readonly id: NotificationId
   readonly isViewed: boolean
   readonly archived: boolean
-  readonly objectId?: string | undefined
+  readonly objectId?: DocId | undefined
   readonly objectClass?: ObjectClassName | undefined
   readonly docNotifyContextId?: NotificationContextId | undefined
   readonly title?: string | undefined
@@ -39,7 +39,7 @@ export interface Notification {
 
 export interface DocNotifyContextSummary {
   readonly id: NotificationContextId
-  readonly objectId: string
+  readonly objectId: DocId
   readonly objectClass: ObjectClassName
   readonly isPinned: boolean
   readonly hidden: boolean
@@ -140,7 +140,7 @@ export type DeleteNotificationParams = Schema.Schema.Type<typeof DeleteNotificat
 // --- Get Notification Context Params ---
 
 export const GetNotificationContextParamsSchema = Schema.Struct({
-  objectId: NonEmptyString.annotations({
+  objectId: DocId.annotations({
     description: "Object ID to get notification context for"
   }),
   objectClass: ObjectClassName.annotations({

--- a/src/domain/schemas/processes.ts
+++ b/src/domain/schemas/processes.ts
@@ -1,18 +1,21 @@
 import { JSONSchema, Schema } from "effect"
 
-import { CardId, LimitParam, MasterTagId, NonEmptyString, Timestamp } from "./shared.js"
+import { CardId, DocId, LimitParam, MasterTagId, NonEmptyString, Timestamp } from "./shared.js"
 
-export const ProcessId = NonEmptyString.pipe(Schema.brand("ProcessId"))
+export const ProcessId = DocId.pipe(Schema.brand("ProcessId"))
 export type ProcessId = Schema.Schema.Type<typeof ProcessId>
 
 export const ProcessIdentifier = NonEmptyString.pipe(Schema.brand("ProcessIdentifier"))
 export type ProcessIdentifier = Schema.Schema.Type<typeof ProcessIdentifier>
 
-export const ProcessExecutionId = NonEmptyString.pipe(Schema.brand("ProcessExecutionId"))
+export const ProcessExecutionId = DocId.pipe(Schema.brand("ProcessExecutionId"))
 export type ProcessExecutionId = Schema.Schema.Type<typeof ProcessExecutionId>
 
-export const ProcessStateId = NonEmptyString.pipe(Schema.brand("ProcessStateId"))
+export const ProcessStateId = DocId.pipe(Schema.brand("ProcessStateId"))
 export type ProcessStateId = Schema.Schema.Type<typeof ProcessStateId>
+
+export const ProcessTransitionId = DocId.pipe(Schema.brand("ProcessTransitionId"))
+export type ProcessTransitionId = Schema.Schema.Type<typeof ProcessTransitionId>
 
 export const ProcessCardIdentifier = NonEmptyString.pipe(Schema.brand("ProcessCardIdentifier"))
 export type ProcessCardIdentifier = Schema.Schema.Type<typeof ProcessCardIdentifier>
@@ -52,7 +55,7 @@ export const ProcessStateSummarySchema = Schema.Struct({
 export type ProcessStateSummary = Schema.Schema.Type<typeof ProcessStateSummarySchema>
 
 export const ProcessTransitionSummarySchema = Schema.Struct({
-  id: NonEmptyString,
+  id: ProcessTransitionId,
   fromStateId: Schema.optional(ProcessStateId),
   fromStateTitle: Schema.optional(NonEmptyString),
   toStateId: ProcessStateId,

--- a/src/domain/schemas/relations.ts
+++ b/src/domain/schemas/relations.ts
@@ -10,11 +10,20 @@ import {
 } from "./shared.js"
 
 export const RelationTypeValues = ["blocks", "is-blocked-by", "relates-to"] as const
+type RelationTypeValue = (typeof RelationTypeValues)[number]
+
+const RelationTypeDescriptions = {
+  blocks: "source blocks target",
+  "is-blocked-by": "source is blocked by target",
+  "relates-to": "bidirectional link"
+} satisfies Record<RelationTypeValue, string>
+
+const relationTypeDescription = RelationTypeValues.map((value) => `'${value}' (${RelationTypeDescriptions[value]})`)
+  .join(", ")
 
 export const RelationTypeSchema = Schema.Literal(...RelationTypeValues).annotations({
   title: "RelationType",
-  description:
-    "Type of issue relation: 'blocks' (source blocks target), 'is-blocked-by' (source is blocked by target), 'relates-to' (bidirectional link)",
+  description: `Type of issue relation: ${relationTypeDescription}`,
   jsonSchema: { type: "string", enum: [...RelationTypeValues] }
 })
 

--- a/src/domain/schemas/relations.ts
+++ b/src/domain/schemas/relations.ts
@@ -2,6 +2,7 @@ import { JSONSchema, Schema } from "effect"
 
 import {
   DocumentId,
+  enumValuesDescription,
   IssueId,
   IssueIdentifier,
   ObjectClassName,
@@ -18,8 +19,9 @@ const RelationTypeDescriptions = {
   "relates-to": "bidirectional link"
 } satisfies Record<RelationTypeValue, string>
 
-const relationTypeDescription = RelationTypeValues.map((value) => `'${value}' (${RelationTypeDescriptions[value]})`)
-  .join(", ")
+const relationTypeDescription = enumValuesDescription(
+  RelationTypeValues.map((value) => `'${value}' (${RelationTypeDescriptions[value]})`)
+)
 
 export const RelationTypeSchema = Schema.Literal(...RelationTypeValues).annotations({
   title: "RelationType",

--- a/src/domain/schemas/search.ts
+++ b/src/domain/schemas/search.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, Schema } from "effect"
 
-import { LimitParam, NonEmptyString } from "./shared.js"
+import { DocId, LimitParam, NonEmptyString, ObjectClassName } from "./shared.js"
 
 export const FulltextSearchParamsSchema = Schema.Struct({
   query: NonEmptyString.annotations({
@@ -21,8 +21,8 @@ export type FulltextSearchParams = Schema.Schema.Type<typeof FulltextSearchParam
 // --- API boundary schemas for Huly SearchResult ---
 
 const SearchResultDocInner = Schema.Struct({
-  _id: Schema.String,
-  _class: Schema.String,
+  _id: DocId,
+  _class: ObjectClassName,
   createdOn: Schema.optional(Schema.Number)
 })
 
@@ -46,8 +46,8 @@ export const parseSearchResult = Schema.decodeUnknown(SearchResultSchema)
 // --- Output types (internal, post-mapping) ---
 
 export interface SearchResultItem {
-  readonly id: string
-  readonly class: string
+  readonly id: DocId
+  readonly class: ObjectClassName
   readonly title?: string | undefined
   readonly description?: string | undefined
   readonly score?: number | undefined

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -24,6 +24,8 @@ export const EmptyParamsSchema = Schema.Struct({}).annotations({
 
 export const emptyParamsJsonSchema = JSONSchema.make(EmptyParamsSchema)
 
+export const enumValuesDescription = (values: ReadonlyArray<string>): string => values.join(", ")
+
 // === Tier 1: Huly Internal Refs (opaque IDs from _id) ===
 
 export const DocId = NonEmptyString.pipe(Schema.brand("DocId"))

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -26,7 +26,10 @@ export const emptyParamsJsonSchema = JSONSchema.make(EmptyParamsSchema)
 
 // === Tier 1: Huly Internal Refs (opaque IDs from _id) ===
 
-const HulyRef = <T extends string>(tag: T) => NonEmptyString.pipe(Schema.brand(tag))
+export const DocId = NonEmptyString.pipe(Schema.brand("DocId"))
+export type DocId = Schema.Schema.Type<typeof DocId>
+
+const HulyRef = <T extends string>(tag: T) => DocId.pipe(Schema.brand(tag))
 
 export const PersonId = HulyRef("PersonId")
 export type PersonId = Schema.Schema.Type<typeof PersonId>

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -37,6 +37,12 @@ export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>
 export const IssueId = HulyRef("IssueId")
 export type IssueId = Schema.Schema.Type<typeof IssueId>
 
+export const AssociationId = HulyRef("AssociationId")
+export type AssociationId = Schema.Schema.Type<typeof AssociationId>
+
+export const RelationId = HulyRef("RelationId")
+export type RelationId = Schema.Schema.Type<typeof RelationId>
+
 export const ComponentId = HulyRef("ComponentId")
 export type ComponentId = Schema.Schema.Type<typeof ComponentId>
 

--- a/src/domain/schemas/task-management.ts
+++ b/src/domain/schemas/task-management.ts
@@ -1,6 +1,6 @@
 import { JSONSchema, Schema } from "effect"
 
-import { IssueStatusId, NonEmptyString, ProjectTypeId, TaskTypeId } from "./shared.js"
+import { enumValuesDescription, IssueStatusId, NonEmptyString, ProjectTypeId, TaskTypeId } from "./shared.js"
 
 const StatusCategoryValues = ["backlog", "todo", "active", "done", "canceled"] as const
 const UnknownStatusCategoryValue = "unknown"
@@ -109,7 +109,7 @@ export const CreateIssueStatusParamsSchema = Schema.Struct({
   })),
   name: NonEmptyString.annotations({ description: "Display name for the workflow status to add." }),
   category: CreateStatusCategoryValueSchema.annotations({
-    description: `Business category for the status: ${StatusCategoryValues.join(", ")}.`
+    description: `Business category for the status: ${enumValuesDescription(StatusCategoryValues)}.`
   }),
   taskType: Schema.optional(TaskTypeRefSchema.annotations({
     description:

--- a/src/domain/schemas/task-management.ts
+++ b/src/domain/schemas/task-management.ts
@@ -2,10 +2,13 @@ import { JSONSchema, Schema } from "effect"
 
 import { IssueStatusId, NonEmptyString, ProjectTypeId, TaskTypeId } from "./shared.js"
 
-export const StatusCategoryValueSchema = Schema.Literal("backlog", "todo", "active", "done", "canceled", "unknown")
+const StatusCategoryValues = ["backlog", "todo", "active", "done", "canceled"] as const
+const UnknownStatusCategoryValue = "unknown"
+
+export const StatusCategoryValueSchema = Schema.Literal(...StatusCategoryValues, UnknownStatusCategoryValue)
 export type StatusCategoryValue = Schema.Schema.Type<typeof StatusCategoryValueSchema>
 
-export const CreateStatusCategoryValueSchema = Schema.Literal("backlog", "todo", "active", "done", "canceled")
+export const CreateStatusCategoryValueSchema = Schema.Literal(...StatusCategoryValues)
 export type CreateStatusCategoryValue = Schema.Schema.Type<typeof CreateStatusCategoryValueSchema>
 
 export const TaskTypeKindSchema = Schema.Literal("task", "subtask", "both")
@@ -106,7 +109,7 @@ export const CreateIssueStatusParamsSchema = Schema.Struct({
   })),
   name: NonEmptyString.annotations({ description: "Display name for the workflow status to add." }),
   category: CreateStatusCategoryValueSchema.annotations({
-    description: "Business category for the status: backlog, todo, active, done, or canceled."
+    description: `Business category for the status: ${StatusCategoryValues.join(", ")}.`
   }),
   taskType: Schema.optional(TaskTypeRefSchema.annotations({
     description:

--- a/src/domain/schemas/test-management-core.ts
+++ b/src/domain/schemas/test-management-core.ts
@@ -5,16 +5,18 @@ import { LimitParam, NonEmptyString, TestCaseIdentifier, TestProjectIdentifier, 
 
 // --- Enum value arrays and schemas ---
 
+const enumValuesDescription = (values: ReadonlyArray<string>): string => values.join(", ")
+
 export const TestCaseTypeValues = ["functional", "performance", "regression", "security", "smoke", "usability"] as const
 export type TestCaseTypeStr = (typeof TestCaseTypeValues)[number]
 export const TestCaseTypeSchema = Schema.Literal(...TestCaseTypeValues).annotations({
-  description: "Test case type: functional, performance, regression, security, smoke, usability"
+  description: `Test case type: ${enumValuesDescription(TestCaseTypeValues)}`
 })
 
 export const TestCasePriorityValues = ["low", "medium", "high", "urgent"] as const
 export type TestCasePriorityStr = (typeof TestCasePriorityValues)[number]
 export const TestCasePrioritySchema = Schema.Literal(...TestCasePriorityValues).annotations({
-  description: "Test case priority: low, medium, high, urgent"
+  description: `Test case priority: ${enumValuesDescription(TestCasePriorityValues)}`
 })
 
 export const TestCaseStatusValues = [
@@ -26,13 +28,13 @@ export const TestCaseStatusValues = [
 ] as const
 export type TestCaseStatusStr = (typeof TestCaseStatusValues)[number]
 export const TestCaseStatusSchema = Schema.Literal(...TestCaseStatusValues).annotations({
-  description: "Test case status: draft, ready-for-review, fix-review-comments, approved, rejected"
+  description: `Test case status: ${enumValuesDescription(TestCaseStatusValues)}`
 })
 
 export const TestRunStatusValues = ["untested", "blocked", "passed", "failed"] as const
 export type TestRunStatusStr = (typeof TestRunStatusValues)[number]
 export const TestRunStatusSchema = Schema.Literal(...TestRunStatusValues).annotations({
-  description: "Test run result status: untested, blocked, passed, failed"
+  description: `Test run result status: ${enumValuesDescription(TestRunStatusValues)}`
 })
 
 // --- Summary types ---

--- a/src/domain/schemas/test-management-core.ts
+++ b/src/domain/schemas/test-management-core.ts
@@ -1,11 +1,16 @@
 import { JSONSchema, Schema } from "effect"
 
 import type { TestCaseId, TestProjectId, TestSuiteId } from "./shared.js"
-import { LimitParam, NonEmptyString, TestCaseIdentifier, TestProjectIdentifier, TestSuiteIdentifier } from "./shared.js"
+import {
+  enumValuesDescription,
+  LimitParam,
+  NonEmptyString,
+  TestCaseIdentifier,
+  TestProjectIdentifier,
+  TestSuiteIdentifier
+} from "./shared.js"
 
 // --- Enum value arrays and schemas ---
-
-const enumValuesDescription = (values: ReadonlyArray<string>): string => values.join(", ")
 
 export const TestCaseTypeValues = ["functional", "performance", "regression", "security", "smoke", "usability"] as const
 export type TestCaseTypeStr = (typeof TestCaseTypeValues)[number]

--- a/src/domain/schemas/test-management-plans.ts
+++ b/src/domain/schemas/test-management-plans.ts
@@ -2,6 +2,7 @@ import { JSONSchema, Schema } from "effect"
 
 import type { TestPlanId, TestPlanItemId, TestResultId, TestRunId } from "./shared.js"
 import {
+  enumValuesDescription,
   LimitParam,
   NonEmptyString,
   TestCaseIdentifier,
@@ -218,7 +219,9 @@ export interface GetTestResultDetail {
   readonly description?: string
 }
 
-const statusField = TestRunStatusSchema.annotations({ description: `Status: ${TestRunStatusValues.join(", ")}` })
+const statusField = TestRunStatusSchema.annotations({
+  description: `Status: ${enumValuesDescription(TestRunStatusValues)}`
+})
 
 export const CreateTestResultParamsSchema = Schema.Struct({
   project: projectField,

--- a/src/domain/schemas/test-management-plans.ts
+++ b/src/domain/schemas/test-management-plans.ts
@@ -13,7 +13,7 @@ import {
   Timestamp
 } from "./shared.js"
 
-import { TestRunStatusSchema, type TestRunStatusStr } from "./test-management-core.js"
+import { TestRunStatusSchema, type TestRunStatusStr, TestRunStatusValues } from "./test-management-core.js"
 
 const projectField = TestProjectIdentifier.annotations({ description: "Test project ID or name" })
 const limitField = LimitParam.annotations({ description: "Max items to return (default: 50)" })
@@ -218,7 +218,7 @@ export interface GetTestResultDetail {
   readonly description?: string
 }
 
-const statusField = TestRunStatusSchema.annotations({ description: "Status: untested, blocked, passed, failed" })
+const statusField = TestRunStatusSchema.annotations({ description: `Status: ${TestRunStatusValues.join(", ")}` })
 
 export const CreateTestResultParamsSchema = Schema.Struct({
   project: projectField,

--- a/src/domain/schemas/workspace.ts
+++ b/src/domain/schemas/workspace.ts
@@ -5,6 +5,7 @@ import {
   AccountId,
   Email,
   EmptyParamsSchema,
+  enumValuesDescription,
   LimitParam,
   NonEmptyString,
   PersonUuid,
@@ -29,7 +30,7 @@ export const AccountRoleValues = [
 
 export const AccountRoleSchema = Schema.Literal(...AccountRoleValues).annotations({
   title: "AccountRole",
-  description: "Workspace member role"
+  description: `Workspace member role: ${enumValuesDescription(AccountRoleValues)}`
 })
 
 export type AccountRole = Schema.Schema.Type<typeof AccountRoleSchema>

--- a/src/domain/schemas/workspace.ts
+++ b/src/domain/schemas/workspace.ts
@@ -17,21 +17,6 @@ import {
   WorkspaceVersion
 } from "./shared.js"
 
-export const AccountRoleSchema = Schema.Literal(
-  "READONLYGUEST",
-  "DocGuest",
-  "GUEST",
-  "USER",
-  "MAINTAINER",
-  "OWNER",
-  "ADMIN"
-).annotations({
-  title: "AccountRole",
-  description: "Workspace member role"
-})
-
-export type AccountRole = Schema.Schema.Type<typeof AccountRoleSchema>
-
 export const AccountRoleValues = [
   "READONLYGUEST",
   "DocGuest",
@@ -41,6 +26,13 @@ export const AccountRoleValues = [
   "OWNER",
   "ADMIN"
 ] as const
+
+export const AccountRoleSchema = Schema.Literal(...AccountRoleValues).annotations({
+  title: "AccountRole",
+  description: "Workspace member role"
+})
+
+export type AccountRole = Schema.Schema.Type<typeof AccountRoleSchema>
 
 // No codec needed — internal type, not used for runtime validation
 export interface WorkspaceMember {

--- a/src/huly/errors-custom-fields.ts
+++ b/src/huly/errors-custom-fields.ts
@@ -5,6 +5,8 @@
  */
 import { Schema } from "effect"
 
+import { DocId, ObjectClassName } from "../domain/schemas/shared.js"
+
 export class CustomFieldNotFoundError extends Schema.TaggedError<CustomFieldNotFoundError>()(
   "CustomFieldNotFoundError",
   {
@@ -19,8 +21,8 @@ export class CustomFieldNotFoundError extends Schema.TaggedError<CustomFieldNotF
 export class CustomFieldObjectNotFoundError extends Schema.TaggedError<CustomFieldObjectNotFoundError>()(
   "CustomFieldObjectNotFoundError",
   {
-    objectId: Schema.String,
-    objectClass: Schema.String
+    objectId: DocId,
+    objectClass: ObjectClassName
   }
 ) {
   override get message(): string {

--- a/src/huly/errors-generic-associations.ts
+++ b/src/huly/errors-generic-associations.ts
@@ -1,9 +1,9 @@
 import { Schema } from "effect"
 
-import { AssociationId, RelationId } from "../domain/schemas/shared.js"
+import { AssociationId, DocId, ObjectClassName, RelationId } from "../domain/schemas/shared.js"
 
 const CandidateSchema = Schema.Struct({
-  id: Schema.String,
+  id: AssociationId,
   name: Schema.optional(Schema.String),
   sourceClass: Schema.optional(Schema.String),
   targetClass: Schema.optional(Schema.String)
@@ -102,8 +102,8 @@ export class GenericObjectIdentifierAmbiguousError extends Schema.TaggedError<Ge
     field: Schema.String,
     identifier: Schema.String,
     candidates: Schema.Array(Schema.Struct({
-      id: Schema.String,
-      class: Schema.String,
+      id: DocId,
+      class: ObjectClassName,
       display: Schema.String
     }))
   }

--- a/src/huly/errors-generic-associations.ts
+++ b/src/huly/errors-generic-associations.ts
@@ -1,0 +1,142 @@
+import { Schema } from "effect"
+
+import { AssociationId, RelationId } from "../domain/schemas/shared.js"
+
+const CandidateSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.optional(Schema.String),
+  sourceClass: Schema.optional(Schema.String),
+  targetClass: Schema.optional(Schema.String)
+})
+
+type Candidate = Schema.Schema.Type<typeof CandidateSchema>
+
+const formatCandidates = (candidates: ReadonlyArray<Candidate>): string =>
+  candidates.map((candidate) => {
+    const name = candidate.name === undefined ? "" : `${candidate.name} `
+    const classes = candidate.sourceClass === undefined || candidate.targetClass === undefined
+      ? ""
+      : ` ${candidate.sourceClass} -> ${candidate.targetClass}`
+    return `${name}(${candidate.id}${classes})`
+  }).join("; ")
+
+export class AssociationNotFoundError extends Schema.TaggedError<AssociationNotFoundError>()(
+  "AssociationNotFoundError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Association '${this.identifier}' not found. Call list_associations to discover valid association IDs.`
+  }
+}
+
+export class AssociationIdentifierAmbiguousError extends Schema.TaggedError<AssociationIdentifierAmbiguousError>()(
+  "AssociationIdentifierAmbiguousError",
+  {
+    identifier: Schema.String,
+    candidates: Schema.Array(CandidateSchema)
+  }
+) {
+  override get message(): string {
+    return `Association '${this.identifier}' matched multiple definitions: ${
+      formatCandidates(this.candidates)
+    }. Call list_associations with sourceClass and targetClass to choose one.`
+  }
+}
+
+export class RelationNotFoundError extends Schema.TaggedError<RelationNotFoundError>()(
+  "RelationNotFoundError",
+  {
+    identifier: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Relation '${this.identifier}' not found.`
+  }
+}
+
+export class RelationIdentifierAmbiguousError extends Schema.TaggedError<RelationIdentifierAmbiguousError>()(
+  "RelationIdentifierAmbiguousError",
+  {
+    identifier: Schema.String,
+    relationIds: Schema.Array(RelationId)
+  }
+) {
+  override get message(): string {
+    return `Relation selector '${this.identifier}' matched multiple relations: ${
+      this.relationIds.join(", ")
+    }. Delete by relation ID instead.`
+  }
+}
+
+export class RelationMutationUnsupportedError extends Schema.TaggedError<RelationMutationUnsupportedError>()(
+  "RelationMutationUnsupportedError",
+  {
+    associationId: Schema.optional(AssociationId),
+    reason: Schema.String
+  }
+) {
+  override get message(): string {
+    const id = this.associationId === undefined ? "" : ` for association '${this.associationId}'`
+    return `Generic relation mutation${id} is not supported: ${this.reason}. Call list_associations with writableOnly=true to discover writable associations.`
+  }
+}
+
+export class RelationEndpointClassMismatchError extends Schema.TaggedError<RelationEndpointClassMismatchError>()(
+  "RelationEndpointClassMismatchError",
+  {
+    field: Schema.String,
+    expectedClass: Schema.String,
+    actualClass: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Relation endpoint '${this.field}' has class '${this.actualClass}', expected '${this.expectedClass}'.`
+  }
+}
+
+export class GenericObjectIdentifierAmbiguousError extends Schema.TaggedError<GenericObjectIdentifierAmbiguousError>()(
+  "GenericObjectIdentifierAmbiguousError",
+  {
+    field: Schema.String,
+    identifier: Schema.String,
+    candidates: Schema.Array(Schema.Struct({
+      id: Schema.String,
+      class: Schema.String,
+      display: Schema.String
+    }))
+  }
+) {
+  override get message(): string {
+    const candidates = this.candidates.map((candidate) => `${candidate.display} (${candidate.id}, ${candidate.class})`)
+      .join("; ")
+    return `Object locator '${this.field}' for '${this.identifier}' is ambiguous. Use a raw locator with one of these IDs: ${candidates}`
+  }
+}
+
+export class GenericObjectLocatorInvalidError extends Schema.TaggedError<GenericObjectLocatorInvalidError>()(
+  "GenericObjectLocatorInvalidError",
+  {
+    field: Schema.String,
+    reason: Schema.String
+  }
+) {
+  override get message(): string {
+    return `Object locator '${this.field}' is invalid: ${this.reason}`
+  }
+}
+
+export class GenericObjectNotFoundError extends Schema.TaggedError<GenericObjectNotFoundError>()(
+  "GenericObjectNotFoundError",
+  {
+    field: Schema.String,
+    identifier: Schema.String,
+    class: Schema.optional(Schema.String)
+  }
+) {
+  override get message(): string {
+    const classHint = this.class === undefined ? "" : ` with class '${this.class}'`
+    return `Object locator '${this.field}' for '${this.identifier}'${classHint} not found.`
+  }
+}

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -47,6 +47,17 @@ import {
   InvalidContentTypeError,
   InvalidFileDataError
 } from "./errors-files.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError
+} from "./errors-generic-associations.js"
 import { TagCategoryNotFoundError, TagNotFoundError } from "./errors-labels.js"
 import { FunnelNotFoundError, LeadNotFoundError } from "./errors-leads.js"
 import {
@@ -92,6 +103,8 @@ import {
 
 export {
   ActivityMessageNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
@@ -115,6 +128,9 @@ export {
   FileTooLargeError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   HulyError,
@@ -145,6 +161,10 @@ export {
   ProjectNotFoundError,
   ReactionNotFoundError,
   RecurringEventNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError,
   SavedMessageNotFoundError,
   TagCategoryNotFoundError,
   TagNotFoundError,
@@ -230,6 +250,15 @@ export type HulyDomainError =
   | ProcessMasterTagNotFoundError
   | ProcessCardIdentifierAmbiguousError
   | ProcessCardNotFoundError
+  | AssociationNotFoundError
+  | AssociationIdentifierAmbiguousError
+  | RelationNotFoundError
+  | RelationIdentifierAmbiguousError
+  | RelationMutationUnsupportedError
+  | RelationEndpointClassMismatchError
+  | GenericObjectIdentifierAmbiguousError
+  | GenericObjectLocatorInvalidError
+  | GenericObjectNotFoundError
 
 /**
  * Schema for all Huly domain errors (for serialization).
@@ -301,7 +330,16 @@ export const HulyDomainError: Schema.Union<
     typeof ProcessMasterTagAmbiguousError,
     typeof ProcessMasterTagNotFoundError,
     typeof ProcessCardIdentifierAmbiguousError,
-    typeof ProcessCardNotFoundError
+    typeof ProcessCardNotFoundError,
+    typeof AssociationNotFoundError,
+    typeof AssociationIdentifierAmbiguousError,
+    typeof RelationNotFoundError,
+    typeof RelationIdentifierAmbiguousError,
+    typeof RelationMutationUnsupportedError,
+    typeof RelationEndpointClassMismatchError,
+    typeof GenericObjectIdentifierAmbiguousError,
+    typeof GenericObjectLocatorInvalidError,
+    typeof GenericObjectNotFoundError
   ]
 > = Schema.Union(
   HulyError,
@@ -369,5 +407,14 @@ export const HulyDomainError: Schema.Union<
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
   ProcessCardIdentifierAmbiguousError,
-  ProcessCardNotFoundError
+  ProcessCardNotFoundError,
+  AssociationNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  RelationNotFoundError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationEndpointClassMismatchError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError
 )

--- a/src/huly/operations/activity.ts
+++ b/src/huly/operations/activity.ts
@@ -29,9 +29,9 @@ import {
 } from "../../domain/schemas/activity.js"
 import {
   ActivityMessageId,
+  DocId,
   EmojiCode,
   MentionId,
-  NonEmptyString,
   ObjectClassName,
   PersonId,
   ReactionId,
@@ -91,7 +91,7 @@ const optionalPersonId = (value: string | undefined): PersonId | undefined =>
 
 interface ActivityTarget {
   readonly client: HulyClient["Type"]
-  readonly objectId: NonEmptyString
+  readonly objectId: DocId
   readonly objectClass: ObjectClassName
 }
 
@@ -101,7 +101,7 @@ const activityTarget = (
   objectClass: string
 ): ActivityTarget => ({
   client,
-  objectId: NonEmptyString.make(objectId),
+  objectId: DocId.make(objectId),
   objectClass: ObjectClassName.make(objectClass)
 })
 
@@ -173,7 +173,7 @@ export const listActivity = (
 
     const result: Array<ActivityMessage> = messages.map((msg) => ({
       id: ActivityMessageId.make(msg._id),
-      objectId: NonEmptyString.make(msg.attachedTo),
+      objectId: DocId.make(msg.attachedTo),
       objectClass: ObjectClassName.make(msg.attachedToClass),
       modifiedBy: PersonId.make(msg.modifiedBy),
       modifiedOn: optionalTimestamp(msg.modifiedOn),

--- a/src/huly/operations/calendar.ts
+++ b/src/huly/operations/calendar.ts
@@ -68,17 +68,26 @@ type DeleteEventError = HulyClientError | EventNotFoundError
 
 // --- Operations ---
 
-const toWritableCalendarAccess = (access: HulyCalendar["access"]): WritableCalendarAccess | undefined => {
-  switch (access) {
-    case AccessLevel.Writer:
-      return "writer"
-    case AccessLevel.Owner:
-      return "owner"
-    case AccessLevel.FreeBusyReader:
-    case AccessLevel.Reader:
-      return undefined
-  }
-}
+const CALENDAR_ACCESS_TO_WRITABLE = {
+  [AccessLevel.FreeBusyReader]: undefined,
+  [AccessLevel.Reader]: undefined,
+  [AccessLevel.Writer]: "writer",
+  [AccessLevel.Owner]: "owner"
+} satisfies Record<HulyCalendar["access"], WritableCalendarAccess | undefined>
+
+type MappedWritableCalendarAccess = Exclude<
+  typeof CALENDAR_ACCESS_TO_WRITABLE[keyof typeof CALENDAR_ACCESS_TO_WRITABLE],
+  undefined
+>
+type ExactWritableCalendarAccessMapping = [WritableCalendarAccess] extends [MappedWritableCalendarAccess]
+  ? [MappedWritableCalendarAccess] extends [WritableCalendarAccess] ? true : never
+  : never
+
+const exactWritableCalendarAccessMapping = <T extends true>(value: T): T => value
+exactWritableCalendarAccessMapping<ExactWritableCalendarAccessMapping>(true)
+
+const toWritableCalendarAccess = (access: HulyCalendar["access"]): WritableCalendarAccess | undefined =>
+  CALENDAR_ACCESS_TO_WRITABLE[access]
 
 export const listEvents = (
   params: ListEventsParams

--- a/src/huly/operations/custom-fields.ts
+++ b/src/huly/operations/custom-fields.ts
@@ -17,7 +17,7 @@ import type {
   SetCustomFieldResult,
   UnknownCustomFieldTypeDetails
 } from "../../domain/schemas/custom-fields.js"
-import { CustomFieldId, NonEmptyString, ObjectClassName } from "../../domain/schemas/shared.js"
+import { CustomFieldId, ObjectClassName } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
 import { CustomFieldNotFoundError, CustomFieldObjectNotFoundError } from "../errors-custom-fields.js"
 import { core } from "../huly-plugins.js"
@@ -328,7 +328,7 @@ export const setCustomField = (
     }
 
     return {
-      objectId: NonEmptyString.make(params.objectId),
+      objectId: params.objectId,
       fieldId: decodedAttr.id,
       label: decodedAttr.label,
       value: parsedValue,

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect"
 
 import type {
   AssociationSummary,
+  Cardinality,
   CreateRelationParams,
   CreateRelationResult,
   DeleteRelationParams,
@@ -103,16 +104,13 @@ const isSystemAssociation = (association: HulyAssociation): boolean =>
 const isSymmetric = (association: HulyAssociation): boolean =>
   association.classA === association.classB && association.nameA === association.nameB
 
-const cardinality = (type: HulyAssociation["type"]): AssociationSummary["cardinality"] => {
-  switch (type) {
-    case "1:1":
-      return "one-to-one"
-    case "1:N":
-      return "one-to-many"
-    case "N:N":
-      return "many-to-many"
-  }
-}
+const ASSOCIATION_CARDINALITY = {
+  "1:1": "one-to-one",
+  "1:N": "one-to-many",
+  "N:N": "many-to-many"
+} satisfies Record<HulyAssociation["type"], Cardinality>
+
+const cardinality = (type: HulyAssociation["type"]): Cardinality => ASSOCIATION_CARDINALITY[type]
 
 const toAssociationSummary = (association: HulyAssociation): AssociationSummary => ({
   associationId: AssociationId.make(association._id),

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- generic association discovery, relation lookup, and guarded mutation entrypoints are kept together to preserve one feature boundary */
-import type { Association as HulyAssociation, Doc, Relation as HulyRelation } from "@hcengineering/core"
+import type { Association as HulyAssociation, Class, Doc, Ref, Relation as HulyRelation } from "@hcengineering/core"
 import { SortingOrder } from "@hcengineering/core"
 import type { Document as HulyDocument } from "@hcengineering/document"
 import { Effect } from "effect"
@@ -21,7 +21,14 @@ import type {
   ResolvedObjectSummary
 } from "../../domain/schemas/generic-associations.js"
 import { DefaultRelationDirection } from "../../domain/schemas/generic-associations.js"
-import { AssociationId, DocId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
+import {
+  AssociationId,
+  DocId,
+  MAX_LIMIT,
+  NonEmptyString,
+  ObjectClassName,
+  RelationId
+} from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
 import type {
   DocumentNotFoundError,
@@ -73,6 +80,11 @@ type AssociationFilters = {
 
 type AssociationListFilters = AssociationFilters & {
   readonly writableOnly: boolean
+}
+
+type RelationAssociationPair = {
+  readonly relation: HulyRelation
+  readonly association: HulyAssociation
 }
 
 const WRITE_UNSUPPORTED_REASON = "no generic association relation write path has been live-validated for this workspace"
@@ -360,6 +372,40 @@ const findRawDoc = (
     hulyQuery<Doc>({ _id: toRef<Doc>(id) })
   )
 
+const chunkValues = <T>(values: ReadonlyArray<T>, size: number): Array<ReadonlyArray<T>> => {
+  const chunks: Array<ReadonlyArray<T>> = []
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size))
+  }
+  return chunks
+}
+
+const uniqueValues = <T>(values: Iterable<T>): Array<T> => [...new Set(values)]
+
+const findDocsByClass = (
+  client: HulyClientOperations,
+  className: Ref<Class<Doc>>,
+  ids: ReadonlyArray<Ref<Doc>>
+): Effect.Effect<Map<Ref<Doc>, Doc>, HulyClientError> =>
+  ids.length === 0
+    ? Effect.succeed(new Map())
+    : Effect.gen(function*() {
+      const docsById = new Map<Ref<Doc>, Doc>()
+      for (const chunk of chunkValues(ids, MAX_LIMIT)) {
+        const docs = yield* client.findAll<Doc>(
+          className,
+          hulyQuery<Doc>({
+            _id: { $in: [...chunk] }
+          }),
+          { limit: chunk.length }
+        )
+        for (const doc of docs) {
+          docsById.set(doc._id, doc)
+        }
+      }
+      return docsById
+    })
+
 const validateExpectedClass = (
   summary: ResolvedObjectSummary,
   expectedClass: string | undefined,
@@ -502,36 +548,59 @@ const unresolvedRelationEndpoint = (
   warning
 })
 
-const resolveRelationEndpoint = (
-  client: HulyClientOperations,
-  id: string,
-  className: string
-): Effect.Effect<ResolvedObjectSummary, HulyClientError> =>
-  Effect.map(
-    findRawDoc(client, id, className),
-    (doc) =>
-      doc === undefined
-        ? unresolvedRelationEndpoint(id, className, `Could not resolve related ${className} document for display.`)
-        : resolvedSummary(doc, "raw")
-  )
+const resolveRelationEndpointFromCache = (
+  docsByClass: ReadonlyMap<Ref<Class<Doc>>, ReadonlyMap<Ref<Doc>, Doc>>,
+  id: Ref<Doc>,
+  className: Ref<Class<Doc>>
+): ResolvedObjectSummary => {
+  const doc = docsByClass.get(className)?.get(id)
+  return doc === undefined
+    ? unresolvedRelationEndpoint(id, className, `Could not resolve related ${className} document for display.`)
+    : resolvedSummary(doc, "raw")
+}
 
 const relationToSummary = (
-  client: HulyClientOperations,
   association: HulyAssociation,
-  relation: HulyRelation
-): Effect.Effect<RelationSummary, HulyClientError> =>
+  relation: HulyRelation,
+  docsByClass: ReadonlyMap<Ref<Class<Doc>>, ReadonlyMap<Ref<Doc>, Doc>>
+): RelationSummary => ({
+  relationId: RelationId.make(relation._id),
+  associationId: AssociationId.make(association._id),
+  associationName: optionalNonEmpty(associationName(association)),
+  source: resolveRelationEndpointFromCache(docsByClass, relation.docA, association.classA),
+  target: resolveRelationEndpointFromCache(docsByClass, relation.docB, association.classB),
+  createdOn: relation.createdOn,
+  modifiedOn: relation.modifiedOn
+})
+
+const relationsToSummaries = (
+  client: HulyClientOperations,
+  pairs: ReadonlyArray<RelationAssociationPair>
+): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
   Effect.gen(function*() {
-    const source = yield* resolveRelationEndpoint(client, relation.docA, association.classA)
-    const target = yield* resolveRelationEndpoint(client, relation.docB, association.classB)
-    return {
-      relationId: RelationId.make(relation._id),
-      associationId: AssociationId.make(association._id),
-      associationName: optionalNonEmpty(associationName(association)),
-      source,
-      target,
-      createdOn: relation.createdOn,
-      modifiedOn: relation.modifiedOn
+    const idsByClass = new Map<Ref<Class<Doc>>, Set<Ref<Doc>>>()
+    const addEndpoint = (className: Ref<Class<Doc>>, id: Ref<Doc>): void => {
+      const ids = idsByClass.get(className) ?? new Set<Ref<Doc>>()
+      ids.add(id)
+      idsByClass.set(className, ids)
     }
+
+    for (const { association, relation } of pairs) {
+      addEndpoint(association.classA, relation.docA)
+      addEndpoint(association.classB, relation.docB)
+    }
+
+    const docsByClassEntries = yield* Effect.forEach(
+      [...idsByClass.entries()],
+      ([className, ids]) =>
+        Effect.map(
+          findDocsByClass(client, className, [...ids]),
+          (docs): readonly [Ref<Class<Doc>>, Map<Ref<Doc>, Doc>] => [className, docs]
+        )
+    )
+    const docsByClass = new Map(docsByClassEntries)
+
+    return pairs.map(({ association, relation }) => relationToSummary(association, relation, docsByClass))
   })
 
 const directionQueries = (
@@ -565,6 +634,92 @@ const directionQueries = (
   }
   return [makeQuery(false)]
 }
+
+const relationDirectionQueries = (
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): Array<StrictDocumentQuery<HulyRelation>> => {
+  const makeQuery = (reversed: boolean): StrictDocumentQuery<HulyRelation> => {
+    const query: StrictDocumentQuery<HulyRelation> = {}
+    if (source !== undefined) {
+      if (reversed) query.docB = toRef<Doc>(source.id)
+      else query.docA = toRef<Doc>(source.id)
+    }
+    if (target !== undefined) {
+      if (reversed) query.docA = toRef<Doc>(target.id)
+      else query.docB = toRef<Doc>(target.id)
+    }
+    return query
+  }
+
+  if (direction === "target-to-source") {
+    return [makeQuery(true)]
+  }
+  if (direction === "either") {
+    return [makeQuery(false), makeQuery(true)]
+  }
+  return [makeQuery(false)]
+}
+
+const associationEndpointQueries = (
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): Array<StrictDocumentQuery<HulyAssociation>> => {
+  const makeQuery = (reversed: boolean): StrictDocumentQuery<HulyAssociation> => {
+    const query: StrictDocumentQuery<HulyAssociation> = {}
+    if (source !== undefined) {
+      if (reversed) query.classB = toClassRef(source.class)
+      else query.classA = toClassRef(source.class)
+    }
+    if (target !== undefined) {
+      if (reversed) query.classA = toClassRef(target.class)
+      else query.classB = toClassRef(target.class)
+    }
+    return query
+  }
+
+  const queries = direction === "target-to-source"
+    ? [makeQuery(true)]
+    : direction === "either"
+    ? [makeQuery(false), makeQuery(true)]
+    : [makeQuery(false)]
+  const byKey = new Map<string, StrictDocumentQuery<HulyAssociation>>()
+  for (const query of queries) {
+    byKey.set(`${String(query.classA)}\u0000${String(query.classB)}`, query)
+  }
+  return [...byKey.values()]
+}
+
+const findVisibleAssociationsForEndpoints = (
+  client: HulyClientOperations,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): Effect.Effect<Array<HulyAssociation>, HulyClientError> =>
+  Effect.gen(function*() {
+    const byId = new Map<Ref<HulyAssociation>, HulyAssociation>()
+    for (const query of associationEndpointQueries(source, target, direction)) {
+      const associations = yield* client.findAll<HulyAssociation>(
+        core.class.Association,
+        hulyQuery(query),
+        {
+          limit: ASSOCIATION_DISCOVERY_LIMIT,
+          sort: { modifiedOn: SortingOrder.Descending }
+        }
+      )
+      for (const association of associations) {
+        if (
+          associationMatchesFilters(association, VISIBLE_ASSOCIATION_FILTERS)
+          && associationMatchesEndpoints(association, source, target, direction)
+        ) {
+          byId.set(association._id, association)
+        }
+      }
+    }
+    return [...byId.values()]
+  })
 
 const findRelationsForAssociation = (
   client: HulyClientOperations,
@@ -621,7 +776,7 @@ const listRelationsForResolvedEndpoints = (
   limit: number
 ): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
   Effect.gen(function*() {
-    const summaries: Array<RelationSummary> = []
+    const pairs: Array<RelationAssociationPair> = []
     for (const association of associations) {
       if (!associationMatchesEndpoints(association, source, target, direction)) {
         continue
@@ -629,16 +784,79 @@ const listRelationsForResolvedEndpoints = (
 
       const relations = yield* findRelationsForAssociation(client, association, source, target, direction, limit)
       for (const relation of relations) {
-        summaries.push(yield* relationToSummary(client, association, relation))
-        if (summaries.length >= limit) {
+        pairs.push({ relation, association })
+        if (pairs.length >= limit) {
           break
         }
       }
-      if (summaries.length >= limit) {
+      if (pairs.length >= limit) {
         break
       }
     }
-    return summaries
+    return yield* relationsToSummaries(client, pairs)
+  })
+
+const findRelationsForAssociationIdsAndEndpoints = (
+  client: HulyClientOperations,
+  associationIds: ReadonlyArray<Ref<HulyAssociation>>,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<HulyRelation>, HulyClientError> =>
+  Effect.gen(function*() {
+    if (associationIds.length === 0) {
+      return []
+    }
+    const byId = new Map<string, HulyRelation>()
+    for (const query of relationDirectionQueries(source, target, direction)) {
+      const relations = yield* client.findAll<HulyRelation>(
+        core.class.Relation,
+        hulyQuery<HulyRelation>({
+          ...query,
+          association: { $in: [...associationIds] }
+        }),
+        {
+          limit,
+          sort: { modifiedOn: SortingOrder.Descending }
+        }
+      )
+      for (const relation of relations) {
+        byId.set(relation._id, relation)
+      }
+    }
+    return [...byId.values()]
+      .sort((left, right) => right.modifiedOn - left.modifiedOn)
+      .slice(0, limit)
+  })
+
+const listRelationsWithoutAssociation = (
+  client: HulyClientOperations,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
+  Effect.gen(function*() {
+    const associations = yield* findVisibleAssociationsForEndpoints(client, source, target, direction)
+    const associationsById = new Map(associations.map((association) => [association._id, association]))
+    const relations = yield* findRelationsForAssociationIdsAndEndpoints(
+      client,
+      uniqueValues(associations.map((association) => association._id)),
+      source,
+      target,
+      direction,
+      limit
+    )
+    const pairs = relations.flatMap((relation): Array<RelationAssociationPair> => {
+      const association = associationsById.get(relation.association)
+      if (association === undefined) {
+        return []
+      }
+      return [{ relation, association }]
+    })
+
+    return yield* relationsToSummaries(client, pairs.slice(0, limit))
   })
 
 export const listRelations = (
@@ -650,23 +868,13 @@ export const listRelations = (
     const direction = params.direction ?? DefaultRelationDirection
 
     if (params.association === undefined) {
-      const associations = filterVisible(
-        yield* listAssociationDocs(client, {
-          includeSystem: false,
-          limit: ASSOCIATION_DISCOVERY_LIMIT
-        }),
-        {
-          ...VISIBLE_ASSOCIATION_FILTERS,
-          writableOnly: false
-        }
-      )
       const source = params.source === undefined
         ? undefined
         : yield* resolveGenericObject(client, params.source, undefined, "source")
       const target = params.target === undefined
         ? undefined
         : yield* resolveGenericObject(client, params.target, undefined, "target")
-      const summaries = yield* listRelationsForResolvedEndpoints(client, associations, source, target, direction, limit)
+      const summaries = yield* listRelationsWithoutAssociation(client, source, target, direction, limit)
 
       return {
         relations: summaries,

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -716,9 +716,9 @@ export const deleteRelation = (
 ): Effect.Effect<DeleteRelationResult, GenericAssociationsError, HulyClient> =>
   Effect.gen(function*() {
     const client = yield* HulyClient
-    const association = params.association === undefined
-      ? undefined
-      : yield* resolveAssociation(client, params.association, MUTATION_ASSOCIATION_FILTERS)
+    const association = "association" in params
+      ? yield* resolveAssociation(client, params.association, MUTATION_ASSOCIATION_FILTERS)
+      : undefined
 
     return yield* new RelationMutationUnsupportedError({
       associationId: association === undefined ? undefined : AssociationId.make(association._id),

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -19,7 +19,7 @@ import type {
   RelationSummary,
   ResolvedObjectSummary
 } from "../../domain/schemas/generic-associations.js"
-import { AssociationId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
+import { AssociationId, DocId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
 import type {
   DocumentNotFoundError,
@@ -57,7 +57,7 @@ type GenericAssociationsError =
   | IssueNotFoundError
 
 type AssociationCandidate = {
-  readonly id: string
+  readonly id: AssociationId
   readonly name?: string | undefined
   readonly sourceClass?: string | undefined
   readonly targetClass?: string | undefined
@@ -132,7 +132,7 @@ const toAssociationSummary = (association: HulyAssociation): AssociationSummary 
 })
 
 const toCandidate = (association: HulyAssociation): AssociationCandidate => ({
-  id: association._id,
+  id: AssociationId.make(association._id),
   name: associationName(association),
   sourceClass: association.classA,
   targetClass: association.classB
@@ -335,7 +335,7 @@ const resolvedSummary = (
   locatorKind: ResolvedObjectSummary["locatorKind"],
   warning?: string
 ): ResolvedObjectSummary => ({
-  id: NonEmptyString.make(doc._id),
+  id: DocId.make(doc._id),
   class: ObjectClassName.make(doc._class),
   display: NonEmptyString.make(displayFromDoc(doc)),
   locatorKind,
@@ -424,8 +424,8 @@ const resolveDocumentWithoutTeamspace = (
         field,
         identifier,
         candidates: byTitle.map((doc) => ({
-          id: doc._id,
-          class: doc._class,
+          id: DocId.make(doc._id),
+          class: ObjectClassName.make(doc._class),
           display: doc.title
         }))
       })
@@ -487,7 +487,7 @@ const unresolvedRelationEndpoint = (
   className: string,
   warning: string
 ): ResolvedObjectSummary => ({
-  id: NonEmptyString.make(id),
+  id: DocId.make(id),
   class: ObjectClassName.make(className),
   display: NonEmptyString.make(id),
   locatorKind: "raw",

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -123,12 +123,12 @@ const associationName = (association: HulyAssociation): string | undefined =>
 const optionalNonEmpty = (value: string | undefined): NonEmptyString | undefined =>
   value === undefined ? undefined : NonEmptyString.make(value)
 
-const classLabelEntry = (classRef: string, label: string): readonly [string, NonEmptyString] => [
-  classRef,
+const classLabelEntry = (classRef: Ref<Class<Doc>>, label: string): readonly [ObjectClassName, NonEmptyString] => [
+  ObjectClassName.make(classRef),
   NonEmptyString.make(label)
 ]
 
-const KNOWN_CLASS_LABELS = new Map<string, NonEmptyString>([
+const KNOWN_CLASS_LABELS: ReadonlyMap<ObjectClassName, NonEmptyString> = new Map([
   classLabelEntry(core.class.Doc, "Huly document"),
   classLabelEntry(core.class.AttachedDoc, "Huly attached document"),
   classLabelEntry(core.class.Relation, "Relation"),
@@ -141,7 +141,7 @@ const KNOWN_CLASS_LABELS = new Map<string, NonEmptyString>([
   classLabelEntry(tracker.class.Milestone, "Milestone")
 ])
 
-const classLabel = (classRef: string): NonEmptyString | undefined => KNOWN_CLASS_LABELS.get(classRef)
+const classLabel = (classRef: ObjectClassName): NonEmptyString | undefined => KNOWN_CLASS_LABELS.get(classRef)
 
 const isSystemAssociation = (association: HulyAssociation): boolean =>
   String(association.classA).startsWith("core:class:") || String(association.classB).startsWith("core:class:")
@@ -165,24 +165,29 @@ exactCardinalityMapping<ExactCardinalityMapping>(true)
 
 const cardinality = (type: HulyAssociation["type"]): Cardinality => ASSOCIATION_CARDINALITY[type]
 
-const toAssociationSummary = (association: HulyAssociation): AssociationSummary => ({
-  associationId: AssociationId.make(association._id),
-  name: optionalNonEmpty(associationName(association)),
-  sourceClass: ObjectClassName.make(association.classA),
-  sourceClassLabel: classLabel(association.classA),
-  targetClass: ObjectClassName.make(association.classB),
-  targetClassLabel: classLabel(association.classB),
-  sourceRole: NonEmptyString.make(association.nameA),
-  targetRole: NonEmptyString.make(association.nameB),
-  relationClass: ObjectClassName.make(core.class.Relation),
-  cardinality: cardinality(association.type),
-  symmetric: isSymmetric(association),
-  system: isSystemAssociation(association),
-  canListRelations: true,
-  canCreateRelation: false,
-  canDeleteRelation: false,
-  unsupportedReason: WRITE_UNSUPPORTED_REASON
-})
+const toAssociationSummary = (association: HulyAssociation): AssociationSummary => {
+  const sourceClass = ObjectClassName.make(association.classA)
+  const targetClass = ObjectClassName.make(association.classB)
+
+  return {
+    associationId: AssociationId.make(association._id),
+    name: optionalNonEmpty(associationName(association)),
+    sourceClass,
+    sourceClassLabel: classLabel(sourceClass),
+    targetClass,
+    targetClassLabel: classLabel(targetClass),
+    sourceRole: NonEmptyString.make(association.nameA),
+    targetRole: NonEmptyString.make(association.nameB),
+    relationClass: ObjectClassName.make(core.class.Relation),
+    cardinality: cardinality(association.type),
+    symmetric: isSymmetric(association),
+    system: isSystemAssociation(association),
+    canListRelations: true,
+    canCreateRelation: false,
+    canDeleteRelation: false,
+    unsupportedReason: WRITE_UNSUPPORTED_REASON
+  }
+}
 
 const toCandidate = (association: HulyAssociation): AssociationCandidate => ({
   id: AssociationId.make(association._id),

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -20,6 +20,7 @@ import type {
   RelationSummary,
   ResolvedObjectSummary
 } from "../../domain/schemas/generic-associations.js"
+import { DefaultRelationDirection } from "../../domain/schemas/generic-associations.js"
 import { AssociationId, DocId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
 import type {
@@ -109,6 +110,14 @@ const ASSOCIATION_CARDINALITY = {
   "1:N": "one-to-many",
   "N:N": "many-to-many"
 } satisfies Record<HulyAssociation["type"], Cardinality>
+
+type MappedCardinality = typeof ASSOCIATION_CARDINALITY[keyof typeof ASSOCIATION_CARDINALITY]
+type ExactCardinalityMapping = [Cardinality] extends [MappedCardinality]
+  ? [MappedCardinality] extends [Cardinality] ? true : never
+  : never
+
+const exactCardinalityMapping = <T extends true>(value: T): T => value
+exactCardinalityMapping<ExactCardinalityMapping>(true)
 
 const cardinality = (type: HulyAssociation["type"]): Cardinality => ASSOCIATION_CARDINALITY[type]
 
@@ -637,7 +646,7 @@ export const listRelations = (
   Effect.gen(function*() {
     const client = yield* HulyClient
     const limit = clampLimit(params.limit)
-    const direction = params.direction ?? "source-to-target"
+    const direction = params.direction ?? DefaultRelationDirection
 
     if (params.association === undefined) {
       const associations = filterVisible(

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -76,6 +76,7 @@ type AssociationListFilters = AssociationFilters & {
 }
 
 const WRITE_UNSUPPORTED_REASON = "no generic association relation write path has been live-validated for this workspace"
+// Broad association scans use this local guardrail, not an SDK page size. Keep it at the public max result cap.
 const ASSOCIATION_DISCOVERY_LIMIT = 200
 const ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT = 2
 

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -1,0 +1,720 @@
+/* eslint-disable max-lines -- generic association discovery, relation lookup, and guarded mutation entrypoints are kept together to preserve one feature boundary */
+import type { Association as HulyAssociation, Doc, Relation as HulyRelation } from "@hcengineering/core"
+import { SortingOrder } from "@hcengineering/core"
+import type { Document as HulyDocument } from "@hcengineering/document"
+import { Effect } from "effect"
+
+import type {
+  AssociationSummary,
+  CreateRelationParams,
+  CreateRelationResult,
+  DeleteRelationParams,
+  DeleteRelationResult,
+  GenericObjectLocator,
+  ListAssociationsParams,
+  ListAssociationsResult,
+  ListRelationsParams,
+  ListRelationsResult,
+  RelationDirection,
+  RelationSummary,
+  ResolvedObjectSummary
+} from "../../domain/schemas/generic-associations.js"
+import { AssociationId, NonEmptyString, ObjectClassName, RelationId } from "../../domain/schemas/shared.js"
+import { HulyClient, type HulyClientError, type HulyClientOperations } from "../client.js"
+import type {
+  DocumentNotFoundError,
+  IssueNotFoundError,
+  ProjectNotFoundError,
+  TeamspaceNotFoundError
+} from "../errors.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationMutationUnsupportedError
+} from "../errors.js"
+import { core, documentPlugin } from "../huly-plugins.js"
+import { findTeamspaceAndDocument } from "./documents.js"
+import { findIssueInProject, findProject, findProjectAndIssue } from "./issues-shared.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { toClassRef, toRef } from "./sdk-boundary.js"
+
+type GenericAssociationsError =
+  | HulyClientError
+  | AssociationNotFoundError
+  | AssociationIdentifierAmbiguousError
+  | ProjectNotFoundError
+  | TeamspaceNotFoundError
+  | DocumentNotFoundError
+  | RelationMutationUnsupportedError
+  | RelationEndpointClassMismatchError
+  | GenericObjectIdentifierAmbiguousError
+  | GenericObjectLocatorInvalidError
+  | GenericObjectNotFoundError
+  | IssueNotFoundError
+
+type AssociationCandidate = {
+  readonly id: string
+  readonly name?: string | undefined
+  readonly sourceClass?: string | undefined
+  readonly targetClass?: string | undefined
+}
+
+type AssociationFilters = {
+  readonly includeSystem: boolean
+  readonly sourceClass: ObjectClassName | undefined
+  readonly targetClass: ObjectClassName | undefined
+}
+
+type AssociationListFilters = AssociationFilters & {
+  readonly writableOnly: boolean
+}
+
+const WRITE_UNSUPPORTED_REASON = "no generic association relation write path has been live-validated for this workspace"
+const ASSOCIATION_DISCOVERY_LIMIT = 200
+const ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT = 2
+
+const MUTATION_ASSOCIATION_FILTERS: AssociationFilters = {
+  includeSystem: true,
+  sourceClass: undefined,
+  targetClass: undefined
+}
+
+const VISIBLE_ASSOCIATION_FILTERS: AssociationFilters = {
+  includeSystem: false,
+  sourceClass: undefined,
+  targetClass: undefined
+}
+
+const associationName = (association: HulyAssociation): string | undefined =>
+  association.nameA === association.nameB
+    ? association.nameA
+    : `${association.nameA} -> ${association.nameB}`
+
+const optionalNonEmpty = (value: string | undefined): NonEmptyString | undefined =>
+  value === undefined ? undefined : NonEmptyString.make(value)
+
+const isSystemAssociation = (association: HulyAssociation): boolean =>
+  String(association.classA).startsWith("core:class:") || String(association.classB).startsWith("core:class:")
+
+const isSymmetric = (association: HulyAssociation): boolean =>
+  association.classA === association.classB && association.nameA === association.nameB
+
+const cardinality = (type: HulyAssociation["type"]): AssociationSummary["cardinality"] => {
+  switch (type) {
+    case "1:1":
+      return "one-to-one"
+    case "1:N":
+      return "one-to-many"
+    case "N:N":
+      return "many-to-many"
+  }
+}
+
+const toAssociationSummary = (association: HulyAssociation): AssociationSummary => ({
+  associationId: AssociationId.make(association._id),
+  name: optionalNonEmpty(associationName(association)),
+  sourceClass: ObjectClassName.make(association.classA),
+  targetClass: ObjectClassName.make(association.classB),
+  sourceRole: NonEmptyString.make(association.nameA),
+  targetRole: NonEmptyString.make(association.nameB),
+  relationClass: ObjectClassName.make(core.class.Relation),
+  cardinality: cardinality(association.type),
+  symmetric: isSymmetric(association),
+  system: isSystemAssociation(association),
+  canListRelations: true,
+  canCreateRelation: false,
+  canDeleteRelation: false,
+  unsupportedReason: WRITE_UNSUPPORTED_REASON
+})
+
+const toCandidate = (association: HulyAssociation): AssociationCandidate => ({
+  id: association._id,
+  name: associationName(association),
+  sourceClass: association.classA,
+  targetClass: association.classB
+})
+
+const matchesAssociationIdentifier = (association: HulyAssociation, identifier: string): boolean => {
+  const normalized = identifier.trim().toLowerCase()
+  return association._id.toLowerCase() === normalized
+    || association.nameA.toLowerCase() === normalized
+    || association.nameB.toLowerCase() === normalized
+    || associationName(association)?.toLowerCase() === normalized
+}
+
+const associationFiltersFromParams = (
+  params: Pick<ListAssociationsParams, "sourceClass" | "targetClass" | "includeSystem">
+): AssociationFilters => ({
+  includeSystem: params.includeSystem === true,
+  sourceClass: params.sourceClass,
+  targetClass: params.targetClass
+})
+
+const associationListFiltersFromParams = (params: ListAssociationsParams): AssociationListFilters => ({
+  ...associationFiltersFromParams(params),
+  writableOnly: params.writableOnly === true
+})
+
+const associationMatchesFilters = (
+  association: HulyAssociation,
+  filters: AssociationFilters
+): boolean =>
+  (filters.includeSystem || !isSystemAssociation(association))
+  && (filters.sourceClass === undefined || association.classA === String(filters.sourceClass))
+  && (filters.targetClass === undefined || association.classB === String(filters.targetClass))
+
+const filterVisible = (
+  associations: ReadonlyArray<HulyAssociation>,
+  filters: AssociationListFilters
+): Array<HulyAssociation> =>
+  associations.filter((association) =>
+    associationMatchesFilters(association, filters)
+    && !filters.writableOnly
+  )
+
+const listAssociationDocs = (
+  client: HulyClientOperations,
+  params: ListAssociationsParams
+): Effect.Effect<Array<HulyAssociation>, HulyClientError> => {
+  const query: StrictDocumentQuery<HulyAssociation> = {}
+
+  if (params.sourceClass !== undefined) {
+    query.classA = toClassRef(params.sourceClass)
+  }
+  if (params.targetClass !== undefined) {
+    query.classB = toClassRef(params.targetClass)
+  }
+
+  return Effect.map(
+    client.findAll<HulyAssociation>(
+      core.class.Association,
+      hulyQuery(query),
+      {
+        limit: clampLimit(params.limit),
+        sort: { modifiedOn: SortingOrder.Descending }
+      }
+    ),
+    (result) => [...result]
+  )
+}
+
+const associationClassFilterQuery = (
+  filters: Pick<AssociationFilters, "sourceClass" | "targetClass">
+): StrictDocumentQuery<HulyAssociation> => {
+  const query: StrictDocumentQuery<HulyAssociation> = {}
+
+  if (filters.sourceClass !== undefined) {
+    query.classA = toClassRef(filters.sourceClass)
+  }
+  if (filters.targetClass !== undefined) {
+    query.classB = toClassRef(filters.targetClass)
+  }
+
+  return query
+}
+
+const resolveAssociation = (
+  client: HulyClientOperations,
+  identifier: string,
+  filters: AssociationFilters
+): Effect.Effect<HulyAssociation, GenericAssociationsError> =>
+  Effect.gen(function*() {
+    const exactId = yield* client.findOne<HulyAssociation>(
+      core.class.Association,
+      hulyQuery<HulyAssociation>({ _id: toRef<HulyAssociation>(identifier) })
+    )
+    if (exactId !== undefined) {
+      if (!associationMatchesFilters(exactId, filters)) {
+        return yield* new AssociationNotFoundError({ identifier })
+      }
+      return exactId
+    }
+
+    const nameCandidates = new Map<string, HulyAssociation>()
+    const addCandidates = (associations: ReadonlyArray<HulyAssociation>): void => {
+      for (const association of associations) {
+        if (matchesAssociationIdentifier(association, identifier) && associationMatchesFilters(association, filters)) {
+          nameCandidates.set(association._id, association)
+        }
+      }
+    }
+
+    addCandidates(
+      yield* client.findAll<HulyAssociation>(
+        core.class.Association,
+        hulyQuery<HulyAssociation>({
+          ...associationClassFilterQuery(filters),
+          nameA: identifier
+        }),
+        { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+      )
+    )
+    addCandidates(
+      yield* client.findAll<HulyAssociation>(
+        core.class.Association,
+        hulyQuery<HulyAssociation>({
+          ...associationClassFilterQuery(filters),
+          nameB: identifier
+        }),
+        { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+      )
+    )
+
+    const rolePair = identifier.split(" -> ")
+    if (rolePair.length === 2) {
+      addCandidates(
+        yield* client.findAll<HulyAssociation>(
+          core.class.Association,
+          hulyQuery<HulyAssociation>({
+            ...associationClassFilterQuery(filters),
+            nameA: rolePair[0],
+            nameB: rolePair[1]
+          }),
+          { limit: ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT }
+        )
+      )
+    }
+
+    const candidates = [...nameCandidates.values()]
+
+    if (candidates.length === 0) {
+      return yield* new AssociationNotFoundError({ identifier })
+    }
+    if (candidates.length > 1) {
+      return yield* new AssociationIdentifierAmbiguousError({
+        identifier,
+        candidates: candidates.map(toCandidate)
+      })
+    }
+    return candidates[0]
+  })
+
+export const listAssociations = (
+  params: ListAssociationsParams
+): Effect.Effect<ListAssociationsResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+
+    if (params.association !== undefined) {
+      const association = yield* resolveAssociation(client, params.association, associationFiltersFromParams(params))
+      const summary = toAssociationSummary(association)
+      return {
+        associations: params.writableOnly === true && !summary.canCreateRelation ? [] : [summary],
+        total: params.writableOnly === true && !summary.canCreateRelation ? 0 : 1
+      }
+    }
+
+    const associations = filterVisible(
+      yield* listAssociationDocs(client, { ...params, limit: ASSOCIATION_DISCOVERY_LIMIT }),
+      associationListFiltersFromParams(params)
+    ).slice(0, clampLimit(params.limit))
+    const summaries = associations.map(toAssociationSummary)
+
+    return {
+      associations: summaries,
+      total: summaries.length
+    }
+  })
+
+const displayFromDoc = (doc: Doc): string => {
+  for (const field of ["identifier", "title", "name"]) {
+    const value = Reflect.get(doc, field)
+    if (typeof value === "string" && value.trim() !== "") {
+      return value
+    }
+  }
+  return doc._id
+}
+
+const resolvedSummary = (
+  doc: Doc,
+  locatorKind: ResolvedObjectSummary["locatorKind"],
+  warning?: string
+): ResolvedObjectSummary => ({
+  id: NonEmptyString.make(doc._id),
+  class: ObjectClassName.make(doc._class),
+  display: NonEmptyString.make(displayFromDoc(doc)),
+  locatorKind,
+  warning
+})
+
+const findRawDoc = (
+  client: HulyClientOperations,
+  id: string,
+  className: string
+): Effect.Effect<Doc | undefined, HulyClientError> =>
+  client.findOne<Doc>(
+    toClassRef(className),
+    hulyQuery<Doc>({ _id: toRef<Doc>(id) })
+  )
+
+const validateExpectedClass = (
+  summary: ResolvedObjectSummary,
+  expectedClass: string | undefined,
+  field: string
+): Effect.Effect<void, RelationEndpointClassMismatchError> => {
+  if (expectedClass !== undefined && summary.class !== expectedClass) {
+    return Effect.fail(
+      new RelationEndpointClassMismatchError({
+        field,
+        expectedClass,
+        actualClass: summary.class
+      })
+    )
+  }
+  return Effect.void
+}
+
+const resolveIssueLocator = (
+  locator: Extract<GenericObjectLocator, { kind: "issue" }>,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    if (locator.project !== undefined) {
+      const { issue } = yield* findProjectAndIssue({ project: locator.project, identifier: locator.issue })
+      return resolvedSummary(issue, "issue")
+    }
+
+    const match = String(locator.issue).match(/^([A-Z]+)-\d+$/i)
+    if (match !== null) {
+      const { client, project } = yield* findProject(match[1].toUpperCase())
+      const issue = yield* findIssueInProject(client, project, locator.issue)
+      return resolvedSummary(issue, "issue")
+    }
+
+    return yield* new GenericObjectLocatorInvalidError({
+      field,
+      reason: "issue locator without project must use a full project-prefixed identifier like HULY-123"
+    })
+  })
+
+const resolveDocumentWithoutTeamspace = (
+  client: HulyClientOperations,
+  identifier: string,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError> =>
+  Effect.gen(function*() {
+    const byId = yield* client.findOne<HulyDocument>(
+      documentPlugin.class.Document,
+      hulyQuery<HulyDocument>({ _id: toRef<HulyDocument>(identifier) })
+    )
+    if (byId !== undefined) {
+      return resolvedSummary(byId, "document")
+    }
+
+    const byTitle = yield* client.findAll<HulyDocument>(
+      documentPlugin.class.Document,
+      hulyQuery<HulyDocument>({ title: identifier }),
+      { limit: 2 }
+    )
+
+    if (byTitle.length === 0) {
+      return yield* new GenericObjectNotFoundError({
+        field,
+        identifier,
+        class: documentPlugin.class.Document
+      })
+    }
+    if (byTitle.length > 1) {
+      return yield* new GenericObjectIdentifierAmbiguousError({
+        field,
+        identifier,
+        candidates: byTitle.map((doc) => ({
+          id: doc._id,
+          class: doc._class,
+          display: doc.title
+        }))
+      })
+    }
+    return resolvedSummary(byTitle[0], "document")
+  })
+
+const resolveGenericObject = (
+  client: HulyClientOperations,
+  locator: GenericObjectLocator,
+  expectedClass: string | undefined,
+  field: string
+): Effect.Effect<ResolvedObjectSummary, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    switch (locator.kind) {
+      case "raw": {
+        const className = locator.class ?? expectedClass
+        if (className === undefined) {
+          return yield* new GenericObjectLocatorInvalidError({
+            field,
+            reason: "raw object locator requires class unless association side class is known"
+          })
+        }
+        const doc = yield* findRawDoc(client, locator.id, className)
+        if (doc === undefined) {
+          return yield* new GenericObjectNotFoundError({
+            field,
+            identifier: locator.id,
+            class: className
+          })
+        }
+        const summary = resolvedSummary(doc, "raw")
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+      case "issue": {
+        const summary = yield* resolveIssueLocator(locator, field)
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+      case "document": {
+        const summary = locator.teamspace === undefined
+          ? yield* resolveDocumentWithoutTeamspace(client, locator.document, field)
+          : resolvedSummary(
+            (yield* findTeamspaceAndDocument({
+              teamspace: locator.teamspace,
+              document: locator.document
+            })).doc,
+            "document"
+          )
+        yield* validateExpectedClass(summary, expectedClass, field)
+        return summary
+      }
+    }
+  })
+
+const unresolvedRelationEndpoint = (
+  id: string,
+  className: string,
+  warning: string
+): ResolvedObjectSummary => ({
+  id: NonEmptyString.make(id),
+  class: ObjectClassName.make(className),
+  display: NonEmptyString.make(id),
+  locatorKind: "raw",
+  warning
+})
+
+const resolveRelationEndpoint = (
+  client: HulyClientOperations,
+  id: string,
+  className: string
+): Effect.Effect<ResolvedObjectSummary, HulyClientError> =>
+  Effect.map(
+    findRawDoc(client, id, className),
+    (doc) =>
+      doc === undefined
+        ? unresolvedRelationEndpoint(id, className, `Could not resolve related ${className} document for display.`)
+        : resolvedSummary(doc, "raw")
+  )
+
+const relationToSummary = (
+  client: HulyClientOperations,
+  association: HulyAssociation,
+  relation: HulyRelation
+): Effect.Effect<RelationSummary, HulyClientError> =>
+  Effect.gen(function*() {
+    const source = yield* resolveRelationEndpoint(client, relation.docA, association.classA)
+    const target = yield* resolveRelationEndpoint(client, relation.docB, association.classB)
+    return {
+      relationId: RelationId.make(relation._id),
+      associationId: AssociationId.make(association._id),
+      associationName: optionalNonEmpty(associationName(association)),
+      source,
+      target,
+      createdOn: relation.createdOn,
+      modifiedOn: relation.modifiedOn
+    }
+  })
+
+const directionQueries = (
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): Array<StrictDocumentQuery<HulyRelation>> => {
+  const makeQuery = (reversed: boolean): StrictDocumentQuery<HulyRelation> => {
+    const query: StrictDocumentQuery<HulyRelation> = {
+      association: toRef<HulyAssociation>(association._id)
+    }
+    if (source !== undefined) {
+      if (reversed) query.docB = toRef<Doc>(source.id)
+      else query.docA = toRef<Doc>(source.id)
+    }
+    if (target !== undefined) {
+      if (reversed) query.docA = toRef<Doc>(target.id)
+      else query.docB = toRef<Doc>(target.id)
+    }
+    return query
+  }
+
+  if (direction === "target-to-source") {
+    return [makeQuery(true)]
+  }
+  if (direction === "either") {
+    return source === undefined && target === undefined
+      ? [makeQuery(false)]
+      : [makeQuery(false), makeQuery(true)]
+  }
+  return [makeQuery(false)]
+}
+
+const findRelationsForAssociation = (
+  client: HulyClientOperations,
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<HulyRelation>, HulyClientError> =>
+  Effect.gen(function*() {
+    const byId = new Map<string, HulyRelation>()
+    for (const query of directionQueries(association, source, target, direction)) {
+      const relations = yield* client.findAll<HulyRelation>(
+        core.class.Relation,
+        hulyQuery(query),
+        { limit }
+      )
+      for (const relation of relations) {
+        byId.set(relation._id, relation)
+      }
+    }
+    return [...byId.values()].slice(0, limit)
+  })
+
+const associationMatchesEndpoints = (
+  association: HulyAssociation,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection
+): boolean => {
+  if (direction === "target-to-source") {
+    return (source === undefined || String(source.class) === association.classB)
+      && (target === undefined || String(target.class) === association.classA)
+  }
+
+  if (direction === "either") {
+    const matchesForward = (source === undefined || String(source.class) === association.classA)
+      && (target === undefined || String(target.class) === association.classB)
+    const matchesReverse = (source === undefined || String(source.class) === association.classB)
+      && (target === undefined || String(target.class) === association.classA)
+    return matchesForward || matchesReverse
+  }
+
+  return (source === undefined || String(source.class) === association.classA)
+    && (target === undefined || String(target.class) === association.classB)
+}
+
+const listRelationsForResolvedEndpoints = (
+  client: HulyClientOperations,
+  associations: ReadonlyArray<HulyAssociation>,
+  source: ResolvedObjectSummary | undefined,
+  target: ResolvedObjectSummary | undefined,
+  direction: RelationDirection,
+  limit: number
+): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
+  Effect.gen(function*() {
+    const summaries: Array<RelationSummary> = []
+    for (const association of associations) {
+      if (!associationMatchesEndpoints(association, source, target, direction)) {
+        continue
+      }
+
+      const relations = yield* findRelationsForAssociation(client, association, source, target, direction, limit)
+      for (const relation of relations) {
+        summaries.push(yield* relationToSummary(client, association, relation))
+        if (summaries.length >= limit) {
+          break
+        }
+      }
+      if (summaries.length >= limit) {
+        break
+      }
+    }
+    return summaries
+  })
+
+export const listRelations = (
+  params: ListRelationsParams
+): Effect.Effect<ListRelationsResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const limit = clampLimit(params.limit)
+    const direction = params.direction ?? "source-to-target"
+
+    if (params.association === undefined) {
+      const associations = filterVisible(
+        yield* listAssociationDocs(client, {
+          includeSystem: false,
+          limit: ASSOCIATION_DISCOVERY_LIMIT
+        }),
+        {
+          ...VISIBLE_ASSOCIATION_FILTERS,
+          writableOnly: false
+        }
+      )
+      const source = params.source === undefined
+        ? undefined
+        : yield* resolveGenericObject(client, params.source, undefined, "source")
+      const target = params.target === undefined
+        ? undefined
+        : yield* resolveGenericObject(client, params.target, undefined, "target")
+      const summaries = yield* listRelationsForResolvedEndpoints(client, associations, source, target, direction, limit)
+
+      return {
+        relations: summaries,
+        total: summaries.length
+      }
+    }
+
+    const association = yield* resolveAssociation(client, params.association, MUTATION_ASSOCIATION_FILTERS)
+    const sourceClass = direction === "either"
+      ? undefined
+      : direction === "target-to-source"
+      ? association.classB
+      : association.classA
+    const targetClass = direction === "either"
+      ? undefined
+      : direction === "target-to-source"
+      ? association.classA
+      : association.classB
+    const source = params.source === undefined
+      ? undefined
+      : yield* resolveGenericObject(client, params.source, sourceClass, "source")
+    const target = params.target === undefined
+      ? undefined
+      : yield* resolveGenericObject(client, params.target, targetClass, "target")
+    const summaries = yield* listRelationsForResolvedEndpoints(client, [association], source, target, direction, limit)
+
+    return {
+      relations: summaries,
+      total: summaries.length
+    }
+  })
+
+export const createRelation = (
+  params: CreateRelationParams
+): Effect.Effect<CreateRelationResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const association = yield* resolveAssociation(client, params.association, MUTATION_ASSOCIATION_FILTERS)
+
+    return yield* new RelationMutationUnsupportedError({
+      associationId: AssociationId.make(association._id),
+      reason: WRITE_UNSUPPORTED_REASON
+    })
+  })
+
+export const deleteRelation = (
+  params: DeleteRelationParams
+): Effect.Effect<DeleteRelationResult, GenericAssociationsError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const association = params.association === undefined
+      ? undefined
+      : yield* resolveAssociation(client, params.association, MUTATION_ASSOCIATION_FILTERS)
+
+    return yield* new RelationMutationUnsupportedError({
+      associationId: association === undefined ? undefined : AssociationId.make(association._id),
+      reason: WRITE_UNSUPPORTED_REASON
+    })
+  })

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -46,7 +46,7 @@ import {
   RelationEndpointClassMismatchError,
   RelationMutationUnsupportedError
 } from "../errors.js"
-import { core, documentPlugin } from "../huly-plugins.js"
+import { core, documentPlugin, tracker } from "../huly-plugins.js"
 import { findTeamspaceAndDocument } from "./documents.js"
 import { findIssueInProject, findProject, findProjectAndIssue } from "./issues-shared.js"
 import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
@@ -123,6 +123,26 @@ const associationName = (association: HulyAssociation): string | undefined =>
 const optionalNonEmpty = (value: string | undefined): NonEmptyString | undefined =>
   value === undefined ? undefined : NonEmptyString.make(value)
 
+const classLabelEntry = (classRef: string, label: string): readonly [string, NonEmptyString] => [
+  classRef,
+  NonEmptyString.make(label)
+]
+
+const KNOWN_CLASS_LABELS = new Map<string, NonEmptyString>([
+  classLabelEntry(core.class.Doc, "Huly document"),
+  classLabelEntry(core.class.AttachedDoc, "Huly attached document"),
+  classLabelEntry(core.class.Relation, "Relation"),
+  classLabelEntry(documentPlugin.class.Document, "Document"),
+  classLabelEntry(documentPlugin.class.Teamspace, "Teamspace"),
+  classLabelEntry(tracker.class.Project, "Project"),
+  classLabelEntry(tracker.class.Issue, "Issue"),
+  classLabelEntry(tracker.class.IssueTemplate, "Issue template"),
+  classLabelEntry(tracker.class.Component, "Component"),
+  classLabelEntry(tracker.class.Milestone, "Milestone")
+])
+
+const classLabel = (classRef: string): NonEmptyString | undefined => KNOWN_CLASS_LABELS.get(classRef)
+
 const isSystemAssociation = (association: HulyAssociation): boolean =>
   String(association.classA).startsWith("core:class:") || String(association.classB).startsWith("core:class:")
 
@@ -149,7 +169,9 @@ const toAssociationSummary = (association: HulyAssociation): AssociationSummary 
   associationId: AssociationId.make(association._id),
   name: optionalNonEmpty(associationName(association)),
   sourceClass: ObjectClassName.make(association.classA),
+  sourceClassLabel: classLabel(association.classA),
   targetClass: ObjectClassName.make(association.classB),
+  targetClassLabel: classLabel(association.classB),
   sourceRole: NonEmptyString.make(association.nameA),
   targetRole: NonEmptyString.make(association.nameB),
   relationClass: ObjectClassName.make(core.class.Relation),

--- a/src/huly/operations/generic-associations.ts
+++ b/src/huly/operations/generic-associations.ts
@@ -16,11 +16,12 @@ import type {
   ListAssociationsResult,
   ListRelationsParams,
   ListRelationsResult,
+  ListRelationsWarning as ListRelationsWarningType,
   RelationDirection,
   RelationSummary,
   ResolvedObjectSummary
 } from "../../domain/schemas/generic-associations.js"
-import { DefaultRelationDirection } from "../../domain/schemas/generic-associations.js"
+import { DefaultRelationDirection, ListRelationsWarning } from "../../domain/schemas/generic-associations.js"
 import {
   AssociationId,
   DocId,
@@ -87,9 +88,19 @@ type RelationAssociationPair = {
   readonly association: HulyAssociation
 }
 
+type AssociationDiscoveryResult = {
+  readonly associations: Array<HulyAssociation>
+  readonly limitReached: boolean
+}
+
+type ListRelationsWarnings = readonly [ListRelationsWarningType, ...Array<ListRelationsWarningType>]
+
 const WRITE_UNSUPPORTED_REASON = "no generic association relation write path has been live-validated for this workspace"
 // Broad association scans use this local guardrail, not an SDK page size. Keep it at the public max result cap.
 const ASSOCIATION_DISCOVERY_LIMIT = 200
+const ASSOCIATION_DISCOVERY_LIMIT_WARNING: ListRelationsWarningType = ListRelationsWarning.make(
+  `Association discovery reached the local ${ASSOCIATION_DISCOVERY_LIMIT}-association cap for at least one endpoint orientation. Huly did not indicate whether more matching associations exist, so list_relations may omit older matching associations; pass a specific association from list_associations to avoid this discovery cap.`
+)
 const ASSOCIATION_LOOKUP_AMBIGUITY_LIMIT = 2
 
 const MUTATION_ASSOCIATION_FILTERS: AssociationFilters = {
@@ -697,18 +708,28 @@ const findVisibleAssociationsForEndpoints = (
   source: ResolvedObjectSummary | undefined,
   target: ResolvedObjectSummary | undefined,
   direction: RelationDirection
-): Effect.Effect<Array<HulyAssociation>, HulyClientError> =>
+): Effect.Effect<AssociationDiscoveryResult, HulyClientError> =>
   Effect.gen(function*() {
+    const discoveryResults = yield* Effect.forEach(
+      associationEndpointQueries(source, target, direction),
+      (query): Effect.Effect<AssociationDiscoveryResult, HulyClientError> =>
+        Effect.gen(function*() {
+          const associations = yield* client.findAll<HulyAssociation>(
+            core.class.Association,
+            hulyQuery(query),
+            {
+              limit: ASSOCIATION_DISCOVERY_LIMIT,
+              sort: { modifiedOn: SortingOrder.Descending }
+            }
+          )
+          return {
+            associations,
+            limitReached: associations.length >= ASSOCIATION_DISCOVERY_LIMIT
+          }
+        })
+    )
     const byId = new Map<Ref<HulyAssociation>, HulyAssociation>()
-    for (const query of associationEndpointQueries(source, target, direction)) {
-      const associations = yield* client.findAll<HulyAssociation>(
-        core.class.Association,
-        hulyQuery(query),
-        {
-          limit: ASSOCIATION_DISCOVERY_LIMIT,
-          sort: { modifiedOn: SortingOrder.Descending }
-        }
-      )
+    for (const { associations } of discoveryResults) {
       for (const association of associations) {
         if (
           associationMatchesFilters(association, VISIBLE_ASSOCIATION_FILTERS)
@@ -718,7 +739,10 @@ const findVisibleAssociationsForEndpoints = (
         }
       }
     }
-    return [...byId.values()]
+    return {
+      associations: [...byId.values()],
+      limitReached: discoveryResults.some((result) => result.limitReached)
+    }
   })
 
 const findRelationsForAssociation = (
@@ -836,9 +860,12 @@ const listRelationsWithoutAssociation = (
   target: ResolvedObjectSummary | undefined,
   direction: RelationDirection,
   limit: number
-): Effect.Effect<Array<RelationSummary>, HulyClientError> =>
+): Effect.Effect<
+  { readonly summaries: Array<RelationSummary>; readonly warnings?: ListRelationsWarnings },
+  HulyClientError
+> =>
   Effect.gen(function*() {
-    const associations = yield* findVisibleAssociationsForEndpoints(client, source, target, direction)
+    const { associations, limitReached } = yield* findVisibleAssociationsForEndpoints(client, source, target, direction)
     const associationsById = new Map(associations.map((association) => [association._id, association]))
     const relations = yield* findRelationsForAssociationIdsAndEndpoints(
       client,
@@ -856,7 +883,8 @@ const listRelationsWithoutAssociation = (
       return [{ relation, association }]
     })
 
-    return yield* relationsToSummaries(client, pairs.slice(0, limit))
+    const summaries = yield* relationsToSummaries(client, pairs.slice(0, limit))
+    return limitReached ? { summaries, warnings: [ASSOCIATION_DISCOVERY_LIMIT_WARNING] } : { summaries }
   })
 
 export const listRelations = (
@@ -874,11 +902,12 @@ export const listRelations = (
       const target = params.target === undefined
         ? undefined
         : yield* resolveGenericObject(client, params.target, undefined, "target")
-      const summaries = yield* listRelationsWithoutAssociation(client, source, target, direction, limit)
+      const { summaries, warnings } = yield* listRelationsWithoutAssociation(client, source, target, direction, limit)
 
       return {
         relations: summaries,
-        total: summaries.length
+        total: summaries.length,
+        ...(warnings !== undefined ? { warnings } : {})
       }
     }
 

--- a/src/huly/operations/issues-read.ts
+++ b/src/huly/operations/issues-read.ts
@@ -10,6 +10,7 @@ import { Effect, Schema } from "effect"
 
 import type { GetIssueParams, Issue, IssueSummary, ListIssuesParams } from "../../domain/schemas.js"
 import { IssueSummarySchema, parseIssue } from "../../domain/schemas/issues.js"
+import { IssueId } from "../../domain/schemas/shared.js"
 import { normalizeForComparison } from "../../utils/normalize.js"
 import type { HulyClient, HulyClientError } from "../client.js"
 import type { ComponentNotFoundError, InvalidStatusError, ProjectNotFoundError } from "../errors.js"
@@ -185,6 +186,7 @@ export const listIssues = (
         : undefined
 
       return {
+        issueId: IssueId.make(issue._id),
         identifier: issue.identifier,
         title: issue.title,
         status: statusName,
@@ -261,6 +263,7 @@ export const getIssue = (
       : undefined
 
     return yield* parseIssue({
+      issueId: IssueId.make(issue._id),
       identifier: issue.identifier,
       title: issue.title,
       description,

--- a/src/huly/operations/notifications.ts
+++ b/src/huly/operations/notifications.ts
@@ -35,6 +35,7 @@ import type {
   UpdateNotificationProviderSettingResult
 } from "../../domain/schemas/notifications.js"
 import {
+  DocId,
   NotificationContextId,
   NotificationId,
   NotificationProviderId,
@@ -49,7 +50,7 @@ import { notification } from "../huly-plugins.js"
 
 const toDocNotifyContextSummary = (ctx: HulyDocNotifyContext): DocNotifyContextSummary => ({
   id: NotificationContextId.make(ctx._id),
-  objectId: ctx.objectId,
+  objectId: DocId.make(ctx.objectId),
   objectClass: ObjectClassName.make(ctx.objectClass),
   isPinned: ctx.isPinned,
   hidden: ctx.hidden,
@@ -96,6 +97,9 @@ type MarkAllNotificationsReadError = HulyClientError
 type ArchiveAllNotificationsError = HulyClientError
 
 // --- Helpers ---
+
+const optionalDocId = (value: string | undefined): DocId | undefined =>
+  value === undefined ? undefined : DocId.make(value)
 
 const findNotification = (
   notificationId: string
@@ -176,7 +180,7 @@ export const listNotifications = (
       id: NotificationId.make(n._id),
       isViewed: n.isViewed,
       archived: n.archived,
-      objectId: n.objectId,
+      objectId: optionalDocId(n.objectId),
       objectClass: ObjectClassName.make(n.objectClass),
       title: n.title,
       body: n.body,
@@ -200,7 +204,7 @@ export const getNotification = (
       id: NotificationId.make(notif._id),
       isViewed: notif.isViewed,
       archived: notif.archived,
-      objectId: notif.objectId,
+      objectId: optionalDocId(notif.objectId),
       objectClass: ObjectClassName.make(notif.objectClass),
       docNotifyContextId: NotificationContextId.make(notif.docNotifyContext),
       title: notif.title,

--- a/src/huly/operations/organization-channel-providers.ts
+++ b/src/huly/operations/organization-channel-providers.ts
@@ -1,0 +1,62 @@
+import type { OrganizationChannelProvider } from "../../domain/schemas/contacts.js"
+import { contact } from "../huly-plugins.js"
+
+const CHANNEL_PROVIDER_REFS_BY_SDK_KEY = {
+  Email: contact.channelProvider.Email,
+  Phone: contact.channelProvider.Phone,
+  LinkedIn: contact.channelProvider.LinkedIn,
+  Twitter: contact.channelProvider.Twitter,
+  Telegram: contact.channelProvider.Telegram,
+  GitHub: contact.channelProvider.GitHub,
+  Facebook: contact.channelProvider.Facebook,
+  Homepage: contact.channelProvider.Homepage,
+  Whatsapp: contact.channelProvider.Whatsapp,
+  Skype: contact.channelProvider.Skype,
+  Profile: contact.channelProvider.Profile,
+  Viber: contact.channelProvider.Viber
+} satisfies Record<
+  keyof typeof contact.channelProvider,
+  typeof contact.channelProvider[keyof typeof contact.channelProvider]
+>
+
+const CHANNEL_PROVIDER_BY_SDK_KEY = {
+  Email: "email",
+  Phone: "phone",
+  LinkedIn: "linkedin",
+  Twitter: "twitter",
+  Telegram: "telegram",
+  GitHub: "github",
+  Facebook: "facebook",
+  Homepage: "homepage",
+  Whatsapp: "whatsapp",
+  Skype: "skype",
+  Profile: "profile",
+  Viber: "viber"
+} satisfies Record<keyof typeof contact.channelProvider, OrganizationChannelProvider>
+
+const CHANNEL_PROVIDERS = {
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Email]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Email,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Phone]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Phone,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.LinkedIn]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.LinkedIn,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Twitter]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Twitter,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Telegram]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Telegram,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.GitHub]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.GitHub,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Facebook]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Facebook,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Homepage]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Homepage,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Whatsapp]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Whatsapp,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Skype]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Skype,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Profile]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Profile,
+  [CHANNEL_PROVIDER_BY_SDK_KEY.Viber]: CHANNEL_PROVIDER_REFS_BY_SDK_KEY.Viber
+} satisfies Record<OrganizationChannelProvider, typeof contact.channelProvider[keyof typeof contact.channelProvider]>
+
+type MappedChannelProvider = typeof CHANNEL_PROVIDER_BY_SDK_KEY[keyof typeof CHANNEL_PROVIDER_BY_SDK_KEY]
+type ExactChannelProviderMapping = [OrganizationChannelProvider] extends [MappedChannelProvider]
+  ? [MappedChannelProvider] extends [OrganizationChannelProvider] ? true : never
+  : never
+
+const exactChannelProviderMapping = <T extends true>(value: T): T => value
+exactChannelProviderMapping<ExactChannelProviderMapping>(true)
+
+export const toChannelProviderRef = (
+  provider: OrganizationChannelProvider
+): typeof CHANNEL_PROVIDERS[typeof provider] => CHANNEL_PROVIDERS[provider]

--- a/src/huly/operations/organizations.ts
+++ b/src/huly/operations/organizations.ts
@@ -31,16 +31,12 @@ import type {
 } from "../../domain/schemas/contacts.js"
 import { Email, OrganizationId, PersonId, PersonName } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
-import {
-  InvalidContactProviderError,
-  OrganizationIdentifierAmbiguousError,
-  OrganizationNotFoundError,
-  PersonNotFoundError
-} from "../errors.js"
+import { OrganizationIdentifierAmbiguousError, OrganizationNotFoundError, PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { leadClassIds } from "../lead-plugin.js"
 import { buildContactUrlFromConfig } from "../url-builders.js"
 import { batchGetEmailsForPersons, findPersonByEmail, findPersonById } from "./contacts-shared.js"
+import { toChannelProviderRef } from "./organization-channel-providers.js"
 import { clampLimit } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
@@ -51,7 +47,6 @@ type UpdateOrganizationError = HulyClientError | OrganizationIdentifierAmbiguous
 type DeleteOrganizationError = HulyClientError | OrganizationIdentifierAmbiguousError | OrganizationNotFoundError
 type AddOrganizationChannelError =
   | HulyClientError
-  | InvalidContactProviderError
   | OrganizationIdentifierAmbiguousError
   | OrganizationNotFoundError
 type AddOrganizationMemberError =
@@ -345,18 +340,6 @@ export const makeOrganizationCustomer = (
     return { id: OrganizationId.make(org._id), applied: true }
   })
 
-// Maps user-friendly names to Huly contact.channelProvider refs.
-const CHANNEL_PROVIDERS: Partial<Record<string, typeof contact.channelProvider.Email>> = {
-  email: contact.channelProvider.Email,
-  phone: contact.channelProvider.Phone,
-  linkedin: contact.channelProvider.LinkedIn,
-  twitter: contact.channelProvider.Twitter,
-  github: contact.channelProvider.GitHub,
-  facebook: contact.channelProvider.Facebook,
-  telegram: contact.channelProvider.Telegram,
-  homepage: contact.channelProvider.Homepage
-}
-
 export const addOrganizationChannel = (
   params: AddOrganizationChannelParams
 ): Effect.Effect<{ id: OrganizationId; added: boolean }, AddOrganizationChannelError, HulyClient> =>
@@ -367,11 +350,7 @@ export const addOrganizationChannel = (
       return yield* new OrganizationNotFoundError({ identifier: params.organizationId })
     }
 
-    const providerKey = params.provider.toLowerCase()
-    const providerRef = CHANNEL_PROVIDERS[providerKey] ?? undefined
-    if (providerRef === undefined) {
-      return yield* new InvalidContactProviderError({ provider: params.provider })
-    }
+    const providerRef = toChannelProviderRef(params.provider)
 
     yield* client.addCollection(
       contact.class.Channel,

--- a/src/huly/operations/processes.ts
+++ b/src/huly/operations/processes.ts
@@ -21,7 +21,8 @@ import {
   ProcessDetailSchema,
   ProcessExecutionId,
   ProcessId,
-  ProcessStateId
+  ProcessStateId,
+  ProcessTransitionId
 } from "../../domain/schemas.js"
 import { CardId, MasterTagId } from "../../domain/schemas/shared.js"
 import { normalizeForComparison } from "../../utils/normalize.js"
@@ -169,7 +170,7 @@ const transitionSummary = (
   transition: HulyProcessTransition,
   titles: ReadonlyMap<Ref<HulyProcessState>, string>
 ): ProcessTransitionSummary => ({
-  id: transition._id,
+  id: ProcessTransitionId.make(transition._id),
   fromStateId: transition.from === null ? undefined : ProcessStateId.make(transition.from),
   fromStateTitle: transition.from === null ? undefined : titles.get(transition.from),
   toStateId: ProcessStateId.make(transition.to),

--- a/src/huly/operations/sdk-boundary.ts
+++ b/src/huly/operations/sdk-boundary.ts
@@ -1,4 +1,4 @@
-import type { Doc, PersonUuid, Ref } from "@hcengineering/core"
+import type { Class, Doc, PersonUuid, Ref } from "@hcengineering/core"
 import { Effect } from "effect"
 
 import type { NonEmptyString } from "../../domain/schemas/shared.js"
@@ -8,6 +8,12 @@ import { InvalidPersonUuidError } from "../errors.js"
 // Our domain uses Effect Schema brands. No type-safe bridge exists; this is the boundary cast.
 // eslint-disable-next-line no-restricted-syntax -- see above
 export const toRef = <T extends Doc>(id: NonEmptyString | Ref<T>): Ref<T> => id as Ref<T>
+
+// Huly class references are also branded strings. Dynamic generic-association
+// operations receive class IDs from association metadata, so this is the
+// centralized SDK boundary for converting validated class strings back to refs.
+// eslint-disable-next-line no-restricted-syntax -- see above
+export const toClassRef = <T extends Doc>(id: string | Ref<Class<T>>): Ref<Class<T>> => id as Ref<Class<T>>
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 

--- a/src/huly/operations/task-management.ts
+++ b/src/huly/operations/task-management.ts
@@ -42,33 +42,44 @@ import { toRef } from "./sdk-boundary.js"
 
 type TaskManagementError = HulyClientError | HulyConnectionError | HulyError
 
-const CATEGORY_TO_REF = {
-  backlog: task.statusCategory.UnStarted,
-  todo: task.statusCategory.ToDo,
-  active: task.statusCategory.Active,
-  done: task.statusCategory.Won,
-  canceled: task.statusCategory.Lost
-} as const satisfies Record<CreateStatusCategoryValue, Ref<StatusCategory>>
+const STATUS_CATEGORY_BY_SDK_KEY = {
+  UnStarted: { value: "backlog", ref: task.statusCategory.UnStarted, name: "Backlog" },
+  ToDo: { value: "todo", ref: task.statusCategory.ToDo, name: "Todo" },
+  Active: { value: "active", ref: task.statusCategory.Active, name: "Active" },
+  Won: { value: "done", ref: task.statusCategory.Won, name: "Done" },
+  Lost: { value: "canceled", ref: task.statusCategory.Lost, name: "Canceled" }
+} satisfies Record<
+  keyof typeof task.statusCategory,
+  { readonly value: CreateStatusCategoryValue; readonly ref: Ref<StatusCategory>; readonly name: string }
+>
 
-const CATEGORY_ENTRIES: ReadonlyArray<readonly [StatusCategoryValue, Ref<StatusCategory>]> = [
-  ["backlog", task.statusCategory.UnStarted],
-  ["todo", task.statusCategory.ToDo],
-  ["active", task.statusCategory.Active],
-  ["done", task.statusCategory.Won],
-  ["canceled", task.statusCategory.Lost]
-]
+type MappedStatusCategory = typeof STATUS_CATEGORY_BY_SDK_KEY[keyof typeof STATUS_CATEGORY_BY_SDK_KEY]["value"]
+type ExactStatusCategoryMapping = [CreateStatusCategoryValue] extends [MappedStatusCategory]
+  ? [MappedStatusCategory] extends [CreateStatusCategoryValue] ? true : never
+  : never
+
+const exactStatusCategoryMapping = <T extends true>(value: T): T => value
+exactStatusCategoryMapping<ExactStatusCategoryMapping>(true)
+
+const CATEGORY_TO_REF: Readonly<Record<CreateStatusCategoryValue, Ref<StatusCategory>>> = {
+  backlog: STATUS_CATEGORY_BY_SDK_KEY.UnStarted.ref,
+  todo: STATUS_CATEGORY_BY_SDK_KEY.ToDo.ref,
+  active: STATUS_CATEGORY_BY_SDK_KEY.Active.ref,
+  done: STATUS_CATEGORY_BY_SDK_KEY.Won.ref,
+  canceled: STATUS_CATEGORY_BY_SDK_KEY.Lost.ref
+}
 
 const REF_TO_CATEGORY = new Map<Ref<StatusCategory>, StatusCategoryValue>(
-  CATEGORY_ENTRIES.map(([value, ref]) => [ref, value])
+  Object.values(STATUS_CATEGORY_BY_SDK_KEY).map((entry) => [entry.ref, entry.value])
 )
 
-const STATUS_CATEGORIES: ReadonlyArray<StatusCategorySummary> = [
-  { value: "backlog", id: task.statusCategory.UnStarted, name: "Backlog" },
-  { value: "todo", id: task.statusCategory.ToDo, name: "Todo" },
-  { value: "active", id: task.statusCategory.Active, name: "Active" },
-  { value: "done", id: task.statusCategory.Won, name: "Done" },
-  { value: "canceled", id: task.statusCategory.Lost, name: "Canceled" }
-]
+const STATUS_CATEGORIES: ReadonlyArray<StatusCategorySummary> = Object.values(STATUS_CATEGORY_BY_SDK_KEY).map((
+  entry
+) => ({
+  value: entry.value,
+  id: entry.ref,
+  name: entry.name
+}))
 
 const WORKFLOW_WARNING = "This changes workspace-level tracker configuration for every project using this project type."
 

--- a/src/huly/operations/test-management-shared.ts
+++ b/src/huly/operations/test-management-shared.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax -- reverse enum maps: Object.entries loses numeric enum type, cast back is unavoidable */
 import type { MarkupRef } from "@hcengineering/api-client"
 import type { Person } from "@hcengineering/contact"
 import type { Class, Doc, Ref } from "@hcengineering/core"
@@ -55,9 +54,16 @@ const caseTypeToString: Record<TestCaseType, TestCaseTypeStr> = {
   [CaseType.Usability]: "usability"
 }
 
-const stringToCaseType: Record<string, TestCaseType> = Object.fromEntries(
-  Object.entries(caseTypeToString).map(([k, v]) => [v, Number(k) as TestCaseType])
-)
+const stringToCaseTypeExact = {
+  functional: CaseType.Functional,
+  performance: CaseType.Performance,
+  regression: CaseType.Regression,
+  security: CaseType.Security,
+  smoke: CaseType.Smoke,
+  usability: CaseType.Usability
+} satisfies Record<TestCaseTypeStr, TestCaseType>
+
+const stringToCaseType: Readonly<Record<string, TestCaseType>> = stringToCaseTypeExact
 
 export const testCaseTypeToString = (t: TestCaseType): TestCaseTypeStr => caseTypeToString[t]
 export const stringToTestCaseType = (s: string): TestCaseType | undefined => stringToCaseType[s.toLowerCase()]
@@ -69,9 +75,14 @@ const casePriorityToString: Record<TestCasePriority, TestCasePriorityStr> = {
   [CasePriority.Urgent]: "urgent"
 }
 
-const stringToCasePriority: Record<string, TestCasePriority> = Object.fromEntries(
-  Object.entries(casePriorityToString).map(([k, v]) => [v, Number(k) as TestCasePriority])
-)
+const stringToCasePriorityExact = {
+  low: CasePriority.Low,
+  medium: CasePriority.Medium,
+  high: CasePriority.High,
+  urgent: CasePriority.Urgent
+} satisfies Record<TestCasePriorityStr, TestCasePriority>
+
+const stringToCasePriority: Readonly<Record<string, TestCasePriority>> = stringToCasePriorityExact
 
 export const testCasePriorityToString = (p: TestCasePriority): TestCasePriorityStr => casePriorityToString[p]
 export const stringToTestCasePriority = (s: string): TestCasePriority | undefined =>
@@ -85,9 +96,15 @@ const caseStatusToString: Record<TestCaseStatus, TestCaseStatusStr> = {
   [CaseStatus.Rejected]: "rejected"
 }
 
-const stringToCaseStatus: Record<string, TestCaseStatus> = Object.fromEntries(
-  Object.entries(caseStatusToString).map(([k, v]) => [v, Number(k) as TestCaseStatus])
-)
+const stringToCaseStatusExact = {
+  draft: CaseStatus.Draft,
+  "ready-for-review": CaseStatus.ReadyForReview,
+  "fix-review-comments": CaseStatus.FixReviewComments,
+  approved: CaseStatus.Approved,
+  rejected: CaseStatus.Rejected
+} satisfies Record<TestCaseStatusStr, TestCaseStatus>
+
+const stringToCaseStatus: Readonly<Record<string, TestCaseStatus>> = stringToCaseStatusExact
 
 export const testCaseStatusToString = (s: TestCaseStatus): TestCaseStatusStr => caseStatusToString[s]
 export const stringToTestCaseStatus = (s: string): TestCaseStatus | undefined => stringToCaseStatus[s.toLowerCase()]
@@ -99,9 +116,14 @@ const runStatusToString: Record<TestRunStatus, TestRunStatusStr> = {
   [RunStatus.Failed]: "failed"
 }
 
-const stringToRunStatus: Record<string, TestRunStatus> = Object.fromEntries(
-  Object.entries(runStatusToString).map(([k, v]) => [v, Number(k) as TestRunStatus])
-)
+const stringToRunStatusExact = {
+  untested: RunStatus.Untested,
+  blocked: RunStatus.Blocked,
+  passed: RunStatus.Passed,
+  failed: RunStatus.Failed
+} satisfies Record<TestRunStatusStr, TestRunStatus>
+
+const stringToRunStatus: Readonly<Record<string, TestRunStatus>> = stringToRunStatusExact
 
 export const testRunStatusToString = (s: TestRunStatus): TestRunStatusStr => runStatusToString[s]
 export const stringToTestRunStatus = (s: string): TestRunStatus | undefined => stringToRunStatus[s.toLowerCase()]

--- a/src/huly/operations/workspace.ts
+++ b/src/huly/operations/workspace.ts
@@ -55,6 +55,14 @@ const accountRoleMap: Record<AccountRole, HulyAccountRole> = {
   ADMIN: HulyAccountRole.Admin
 }
 
+type MappedAccountRole = typeof accountRoleMap[keyof typeof accountRoleMap]
+type ExactAccountRoleMapping = [HulyAccountRole] extends [MappedAccountRole]
+  ? [MappedAccountRole] extends [HulyAccountRole] ? true : never
+  : never
+
+const exactAccountRoleMapping = <T extends true>(value: T): T => value
+exactAccountRoleMapping<ExactAccountRoleMapping>(true)
+
 const toHulyAccountRole = (role: AccountRole): HulyAccountRole => accountRoleMap[role]
 
 type ListWorkspaceMembersError = WorkspaceClientError

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -120,7 +120,16 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "ProcessMasterTagAmbiguousError",
   "ProcessMasterTagNotFoundError",
   "ProcessCardIdentifierAmbiguousError",
-  "ProcessCardNotFoundError"
+  "ProcessCardNotFoundError",
+  "AssociationNotFoundError",
+  "AssociationIdentifierAmbiguousError",
+  "RelationNotFoundError",
+  "RelationIdentifierAmbiguousError",
+  "RelationMutationUnsupportedError",
+  "RelationEndpointClassMismatchError",
+  "GenericObjectIdentifierAmbiguousError",
+  "GenericObjectLocatorInvalidError",
+  "GenericObjectNotFoundError"
 ])
 
 const INTERNAL_ERROR_PREFIX: Partial<Record<HulyDomainError["_tag"], string>> = {

--- a/src/mcp/tools/generic-associations.ts
+++ b/src/mcp/tools/generic-associations.ts
@@ -1,0 +1,84 @@
+import {
+  createRelationParamsJsonSchema,
+  CreateRelationResultSchema,
+  deleteRelationParamsJsonSchema,
+  DeleteRelationResultSchema,
+  listAssociationsParamsJsonSchema,
+  ListAssociationsResultSchema,
+  listRelationsParamsJsonSchema,
+  ListRelationsResultSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams
+} from "../../domain/schemas/generic-associations.js"
+import {
+  createRelation,
+  deleteRelation,
+  listAssociations,
+  listRelations
+} from "../../huly/operations/generic-associations.js"
+import { createEncodedToolHandler, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "associations" as const
+
+export const genericAssociationTools: ReadonlyArray<RegisteredTool> = [
+  {
+    name: "list_associations",
+    description:
+      "List Huly association definitions: class-level typed links that define which document classes may be related. Use this before create_relation to discover association IDs, source/target classes, and whether relation writes are supported.",
+    category: CATEGORY,
+    inputSchema: listAssociationsParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "list_associations",
+      parseListAssociationsParams,
+      listAssociations,
+      ListAssociationsResultSchema
+    )
+  },
+  {
+    name: "list_relations",
+    description:
+      "List concrete Huly relation instances under an association, optionally filtered by source and target documents. Requires at least one filter to avoid broad workspace scans.",
+    category: CATEGORY,
+    inputSchema: listRelationsParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "list_relations",
+      parseListRelationsParams,
+      listRelations,
+      ListRelationsResultSchema
+    )
+  },
+  {
+    name: "create_relation",
+    description:
+      "Idempotently create one concrete relation between two resolved documents. Only succeeds for associations where list_associations reports canCreateRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated.",
+    category: CATEGORY,
+    inputSchema: createRelationParamsJsonSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    },
+    handler: createEncodedToolHandler(
+      "create_relation",
+      parseCreateRelationParams,
+      createRelation,
+      CreateRelationResultSchema
+    )
+  },
+  {
+    name: "delete_relation",
+    description:
+      "Idempotently delete one concrete relation by relation ID or by exact association/source/target triple. Only succeeds for associations where list_associations reports canDeleteRelation=true; otherwise it fails clearly. This build currently reports no generic associations as writable until a write allowlist is live-validated.",
+    category: CATEGORY,
+    inputSchema: deleteRelationParamsJsonSchema,
+    handler: createEncodedToolHandler(
+      "delete_relation",
+      parseDeleteRelationParams,
+      deleteRelation,
+      DeleteRelationResultSchema
+    )
+  }
+]

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -12,6 +12,7 @@ import { contactTools } from "./contacts.js"
 import { customFieldTools } from "./custom-fields.js"
 import { deletionTools } from "./deletion.js"
 import { documentTools } from "./documents.js"
+import { genericAssociationTools } from "./generic-associations.js"
 import { issueTools } from "./issues.js"
 import { labelTools } from "./labels.js"
 import { leadTools } from "./leads.js"
@@ -39,6 +40,7 @@ const allTools: ReadonlyArray<RegisteredTool> = [
   ...deletionTools,
   ...milestoneTools,
   ...documentTools,
+  ...genericAssociationTools,
   ...storageTools,
   ...attachmentTools,
   ...contactTools,

--- a/test/domain/schemas.generic-associations.test.ts
+++ b/test/domain/schemas.generic-associations.test.ts
@@ -4,6 +4,7 @@ import { expect } from "vitest"
 
 import {
   deleteRelationParamsJsonSchema,
+  listRelationsParamsJsonSchema,
   parseCreateRelationParams,
   parseDeleteRelationParams,
   parseListAssociationsParams,
@@ -30,6 +31,23 @@ describe("generic association schemas", () => {
     Effect.gen(function*() {
       const error = yield* Effect.flip(parseListRelationsParams({}))
       expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("emits JSON schema filter alternatives for list_relations", () =>
+    Effect.gen(function*() {
+      expect(listRelationsParamsJsonSchema).toMatchObject({
+        type: "object",
+        properties: {
+          association: expect.any(Object),
+          source: expect.any(Object),
+          target: expect.any(Object)
+        },
+        anyOf: [
+          { required: ["association"] },
+          { required: ["source"] },
+          { required: ["target"] }
+        ]
+      })
     }))
 
   it.effect("parses raw, issue, and document locators", () =>

--- a/test/domain/schemas.generic-associations.test.ts
+++ b/test/domain/schemas.generic-associations.test.ts
@@ -70,16 +70,54 @@ describe("generic association schemas", () => {
       expect(error._tag).toBe("ParseError")
     }))
 
+  it.effect("rejects mixed delete modes", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseDeleteRelationParams({
+        relation: "rel-1",
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" },
+        target: { kind: "raw", id: "doc-2", class: "document:class:Document" }
+      }))
+      expect(error._tag).toBe("ParseError")
+    }))
+
   it.effect("accepts delete by relation ID", () =>
     Effect.gen(function*() {
       const parsed = yield* parseDeleteRelationParams({ relation: "rel-1" })
+      if (!("relation" in parsed)) {
+        throw new Error("expected relation-id delete params")
+      }
       expect(parsed.relation).toBe("rel-1")
+    }))
+
+  it.effect("accepts delete by association/source/target triple", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseDeleteRelationParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" },
+        target: { kind: "raw", id: "doc-2", class: "document:class:Document" }
+      })
+
+      if (!("association" in parsed)) {
+        throw new Error("expected triple delete params")
+      }
+      expect(parsed.association).toBe("links")
+      expect(parsed.source.kind).toBe("raw")
+      expect(parsed.target.kind).toBe("raw")
     }))
 
   it.effect("emits JSON schema for delete_relation", () =>
     Effect.gen(function*() {
       expect(deleteRelationParamsJsonSchema).toMatchObject({
-        type: "object"
+        type: "object",
+        anyOf: [
+          {
+            required: ["relation"]
+          },
+          {
+            required: ["association", "source", "target"]
+          }
+        ]
       })
     }))
 })

--- a/test/domain/schemas.generic-associations.test.ts
+++ b/test/domain/schemas.generic-associations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import {
+  deleteRelationParamsJsonSchema,
+  parseCreateRelationParams,
+  parseDeleteRelationParams,
+  parseListAssociationsParams,
+  parseListRelationsParams
+} from "../../src/domain/schemas/generic-associations.js"
+
+describe("generic association schemas", () => {
+  it.effect("parses list_associations filters", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseListAssociationsParams({
+        association: "issue-links",
+        sourceClass: "tracker:class:Issue",
+        writableOnly: true,
+        limit: 10
+      })
+
+      expect(parsed.association).toBe("issue-links")
+      expect(parsed.sourceClass).toBe("tracker:class:Issue")
+      expect(parsed.writableOnly).toBe(true)
+      expect(parsed.limit).toBe(10)
+    }))
+
+  it.effect("requires a filter for list_relations", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseListRelationsParams({}))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("parses raw, issue, and document locators", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseListRelationsParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" },
+        target: { kind: "issue", issue: "HULY-1" },
+        direction: "either"
+      })
+
+      expect(parsed.source?.kind).toBe("raw")
+      expect(parsed.target?.kind).toBe("issue")
+
+      const documentParsed = yield* parseCreateRelationParams({
+        association: "links",
+        source: { kind: "document", document: "Spec", teamspace: "Engineering" },
+        target: { kind: "raw", id: "doc-2", class: "document:class:Document" }
+      })
+      expect(documentParsed.source.kind).toBe("document")
+    }))
+
+  it.effect("rejects mixed locator shapes", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseListRelationsParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", issue: "HULY-1" }
+      }))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("rejects partial delete triples", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(parseDeleteRelationParams({
+        association: "links",
+        source: { kind: "raw", id: "doc-1", class: "document:class:Document" }
+      }))
+      expect(error._tag).toBe("ParseError")
+    }))
+
+  it.effect("accepts delete by relation ID", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseDeleteRelationParams({ relation: "rel-1" })
+      expect(parsed.relation).toBe("rel-1")
+    }))
+
+  it.effect("emits JSON schema for delete_relation", () =>
+    Effect.gen(function*() {
+      expect(deleteRelationParamsJsonSchema).toMatchObject({
+        type: "object"
+      })
+    }))
+})

--- a/test/domain/schemas.test.ts
+++ b/test/domain/schemas.test.ts
@@ -194,11 +194,13 @@ describe("Domain Schemas", () => {
     it.effect("parses minimal issue summary", () =>
       Effect.gen(function*() {
         const result = yield* parseIssueSummary({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           status: "Open"
         })
         expect(result).toEqual({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           status: "Open"
@@ -209,6 +211,7 @@ describe("Domain Schemas", () => {
     it.effect("parses with all optional fields", () =>
       Effect.gen(function*() {
         const result = yield* parseIssueSummary({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           status: "Open",
@@ -227,6 +230,7 @@ describe("Domain Schemas", () => {
     it.effect("parses minimal issue", () =>
       Effect.gen(function*() {
         const result = yield* parseIssue({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           status: "Open",
@@ -242,6 +246,7 @@ describe("Domain Schemas", () => {
     it.effect("parses full issue", () =>
       Effect.gen(function*() {
         const result = yield* parseIssue({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           description: "# Description\n\nFix the bug",
@@ -275,6 +280,7 @@ describe("Domain Schemas", () => {
     it.effect("handles null dueDate", () =>
       Effect.gen(function*() {
         const result = yield* parseIssue({
+          issueId: "issue-123",
           identifier: "HULY-123",
           title: "Fix bug",
           status: "Open",

--- a/test/helpers/brands.ts
+++ b/test/helpers/brands.ts
@@ -15,6 +15,7 @@ import type {
   AccountId,
   AccountUuid,
   ActivityMessageId,
+  AssociationId,
   AttachmentId,
   BlobId,
   ChannelId,
@@ -26,7 +27,9 @@ import type {
   ComponentIdentifier,
   ComponentLabel,
   ContactProvider,
+  CustomFieldId,
   DirectMessageIdentifier,
+  DocId,
   DocumentId,
   DocumentIdentifier,
   Email,
@@ -88,6 +91,8 @@ import type {
 export const personId = (s: string) => s as PersonId
 export const organizationId = (s: string) => s as OrganizationId
 export const issueId = (s: string) => s as IssueId
+export const associationBrandId = (s: string) => s as AssociationId
+export const docId = (s: string) => s as DocId
 export const componentBrandId = (s: string) => s as ComponentId
 export const milestoneId = (s: string) => s as MilestoneId
 export const issueTemplateChildId = (s: string) => s as IssueTemplateChildId
@@ -109,6 +114,7 @@ export const commentBrandId = (s: string) => s as CommentId
 export const timeSpendReportId = (s: string) => s as TimeSpendReportId
 export const tagElementId = (s: string) => s as TagElementId
 export const tagCategoryId = (s: string) => s as TagCategoryId
+export const customFieldId = (s: string) => s as CustomFieldId
 
 // Tier 2: Human-Readable Identifiers
 export const projectIdentifier = (s: string) => s as ProjectIdentifier
@@ -179,6 +185,7 @@ export type {
   AccountId,
   AccountUuid,
   ActivityMessageId,
+  AssociationId,
   AttachmentId,
   BlobId,
   ChannelId,
@@ -190,7 +197,9 @@ export type {
   ComponentIdentifier,
   ComponentLabel,
   ContactProvider,
+  CustomFieldId,
   DirectMessageIdentifier,
+  DocId,
   DocumentId,
   DocumentIdentifier,
   Email,

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@effect/vitest"
 import { Effect, Schema } from "effect"
 import { expect } from "vitest"
-import { RelationId } from "../../src/domain/schemas/shared.js"
+import { AssociationId, DocId, ObjectClassName, RelationId } from "../../src/domain/schemas/shared.js"
 import {
   ActivityMessageNotFoundError,
   AssociationIdentifierAmbiguousError,
@@ -894,7 +894,7 @@ describe("Huly Errors", () => {
           matchError(
             new AssociationIdentifierAmbiguousError({
               identifier: "links",
-              candidates: [{ id: "assoc-1" }, { id: "assoc-2" }]
+              candidates: [{ id: AssociationId.make("assoc-1") }, { id: AssociationId.make("assoc-2") }]
             })
           )
         ).toBe("association-ambiguous:links:2")
@@ -924,7 +924,11 @@ describe("Huly Errors", () => {
             new GenericObjectIdentifierAmbiguousError({
               field: "source",
               identifier: "Spec",
-              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+              candidates: [{
+                id: DocId.make("doc-1"),
+                class: ObjectClassName.make("document:class:Document"),
+                display: "Spec"
+              }]
             })
           )
         ).toBe("generic-object-ambiguous:source:1")

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -1,8 +1,11 @@
 import { describe, it } from "@effect/vitest"
 import { Effect, Schema } from "effect"
 import { expect } from "vitest"
+import { RelationId } from "../../src/domain/schemas/shared.js"
 import {
   ActivityMessageNotFoundError,
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   AttachmentNotFoundError,
   BYTES_PER_MB,
   CalendarNotAccessibleError,
@@ -21,6 +24,9 @@ import {
   FileTooLargeError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   type HulyDomainError,
@@ -47,6 +53,10 @@ import {
   ProjectNotFoundError,
   ReactionNotFoundError,
   RecurringEventNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError,
   SavedMessageNotFoundError,
   TagCategoryNotFoundError,
   TagNotFoundError,
@@ -777,6 +787,24 @@ describe("Huly Errors", () => {
               return `process-card-ambiguous:${error.identifier}:${error.candidates.length}`
             case "ProcessCardNotFoundError":
               return `process-card:${error.identifier}`
+            case "AssociationNotFoundError":
+              return `association:${error.identifier}`
+            case "AssociationIdentifierAmbiguousError":
+              return `association-ambiguous:${error.identifier}:${error.candidates.length}`
+            case "RelationNotFoundError":
+              return `relation:${error.identifier}`
+            case "RelationIdentifierAmbiguousError":
+              return `relation-ambiguous:${error.identifier}:${error.relationIds.length}`
+            case "RelationMutationUnsupportedError":
+              return `relation-unsupported:${error.reason}`
+            case "RelationEndpointClassMismatchError":
+              return `relation-mismatch:${error.field}:${error.expectedClass}:${error.actualClass}`
+            case "GenericObjectIdentifierAmbiguousError":
+              return `generic-object-ambiguous:${error.field}:${error.candidates.length}`
+            case "GenericObjectLocatorInvalidError":
+              return `generic-object-invalid:${error.field}:${error.reason}`
+            case "GenericObjectNotFoundError":
+              return `generic-object-not-found:${error.field}:${error.identifier}:${error.class ?? ""}`
             case "CannotDirectMessageSelfError":
               return `dm-self:${error.identifier}`
             case "PersonNotAnEmployeeError":
@@ -861,6 +889,59 @@ describe("Huly Errors", () => {
             new LeadNotFoundError({ identifier: leadIdentifier("LEAD-1"), funnel: funnelIdentifier("funnel-1") })
           )
         ).toBe("lead:LEAD-1")
+        expect(matchError(new AssociationNotFoundError({ identifier: "blocks" }))).toBe("association:blocks")
+        expect(
+          matchError(
+            new AssociationIdentifierAmbiguousError({
+              identifier: "links",
+              candidates: [{ id: "assoc-1" }, { id: "assoc-2" }]
+            })
+          )
+        ).toBe("association-ambiguous:links:2")
+        expect(matchError(new RelationNotFoundError({ identifier: "rel-1" }))).toBe("relation:rel-1")
+        expect(
+          matchError(
+            new RelationIdentifierAmbiguousError({
+              identifier: "triple",
+              relationIds: [RelationId.make("rel-1"), RelationId.make("rel-2")]
+            })
+          )
+        ).toBe("relation-ambiguous:triple:2")
+        expect(
+          matchError(new RelationMutationUnsupportedError({ reason: "not validated" }))
+        ).toBe("relation-unsupported:not validated")
+        expect(
+          matchError(
+            new RelationEndpointClassMismatchError({
+              field: "source",
+              expectedClass: "tracker:class:Issue",
+              actualClass: "document:class:Document"
+            })
+          )
+        ).toBe("relation-mismatch:source:tracker:class:Issue:document:class:Document")
+        expect(
+          matchError(
+            new GenericObjectIdentifierAmbiguousError({
+              field: "source",
+              identifier: "Spec",
+              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+            })
+          )
+        ).toBe("generic-object-ambiguous:source:1")
+        expect(
+          matchError(
+            new GenericObjectLocatorInvalidError({ field: "source", reason: "raw object locator requires class" })
+          )
+        ).toBe("generic-object-invalid:source:raw object locator requires class")
+        expect(
+          matchError(
+            new GenericObjectNotFoundError({
+              field: "target",
+              identifier: "missing-doc",
+              class: "document:class:Document"
+            })
+          )
+        ).toBe("generic-object-not-found:target:missing-doc:document:class:Document")
         expect(matchError(new CannotDirectMessageSelfError({ identifier: "Self,User" }))).toBe("dm-self:Self,User")
         expect(matchError(new PersonNotAnEmployeeError({ identifier: "Ext,Contact" }))).toBe("not-employee:Ext,Contact")
       }))

--- a/test/huly/operations/activity.test.ts
+++ b/test/huly/operations/activity.test.ts
@@ -34,6 +34,7 @@ import {
 import {
   activityMessageId,
   channelIdentifier,
+  docId,
   documentIdentifier,
   emojiCode,
   issueIdentifier,
@@ -386,7 +387,7 @@ describe("listActivity", () => {
       const testLayer = createTestLayerWithMocks({ activityMessages: messages })
 
       const result = yield* listActivity({
-        objectId: "obj-1",
+        objectId: docId("obj-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -401,7 +402,7 @@ describe("listActivity", () => {
       const testLayer = createTestLayerWithMocks({ activityMessages: [] })
 
       const result = yield* listActivity({
-        objectId: "obj-1",
+        objectId: docId("obj-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -426,7 +427,7 @@ describe("listActivity", () => {
       const testLayer = createTestLayerWithMocks({ activityMessages: [msg] })
 
       const result = yield* listActivity({
-        objectId: "obj-1",
+        objectId: docId("obj-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -462,7 +463,7 @@ describe("listActivity", () => {
       const testLayer = createTestLayerWithMocks({ activityMessages: messages })
 
       const result = yield* listActivity({
-        objectId: "obj-1",
+        objectId: docId("obj-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 

--- a/test/huly/operations/attachments.test.ts
+++ b/test/huly/operations/attachments.test.ts
@@ -26,6 +26,7 @@ import {
 import { HulyStorageClient } from "../../../src/huly/storage.js"
 import {
   attachmentBrandId,
+  docId,
   documentIdentifier,
   issueIdentifier,
   mimeType,
@@ -269,7 +270,7 @@ describe("listAttachments", () => {
       const testLayer = createTestLayer({ attachments })
 
       const result = yield* listAttachments({
-        objectId: "parent-1",
+        objectId: docId("parent-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -284,7 +285,7 @@ describe("listAttachments", () => {
       const testLayer = createTestLayer({})
 
       const result = yield* listAttachments({
-        objectId: "parent-1",
+        objectId: docId("parent-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -305,7 +306,7 @@ describe("listAttachments", () => {
       const testLayer = createTestLayer({ attachments: [att] })
 
       const result = yield* listAttachments({
-        objectId: "parent-1",
+        objectId: docId("parent-1"),
         objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -383,7 +384,7 @@ describe("addAttachment", () => {
       const testLayer = createTestLayer({ captureAddCollection })
 
       const result = yield* addAttachment({
-        objectId: "parent-1",
+        objectId: docId("parent-1"),
         objectClass: objectClassName("tracker:class:Issue"),
         space: spaceBrandId("space-1"),
         filename: "test.txt",
@@ -408,7 +409,7 @@ describe("addAttachment", () => {
       const testLayer = createTestLayer({ captureAddCollection })
 
       yield* addAttachment({
-        objectId: "parent-1",
+        objectId: docId("parent-1"),
         objectClass: objectClassName("tracker:class:Issue"),
         space: spaceBrandId("space-1"),
         filename: "test.txt",
@@ -431,7 +432,7 @@ describe("addAttachment", () => {
         const testLayer = createTestLayer({ captureAddCollection })
 
         const result = yield* addAttachment({
-          objectId: "parent-1",
+          objectId: docId("parent-1"),
           objectClass: objectClassName("tracker:class:Issue"),
           space: spaceBrandId("space-1"),
           filename: "from-disk.txt",

--- a/test/huly/operations/contacts-organization.test.ts
+++ b/test/huly/operations/contacts-organization.test.ts
@@ -731,7 +731,7 @@ describe("Organization CRUD, Customer Mixin, Channels, and Membership", () => {
         expect(capture.attributes?.value).toBe("info@testcorp.com")
       }))
 
-    it.effect("adds linkedin channel (case-insensitive provider)", () =>
+    it.effect("adds linkedin channel", () =>
       Effect.gen(function*() {
         const org = createMockOrganization()
         const capture: MockConfig["captureAddCollection"] = {}
@@ -743,7 +743,7 @@ describe("Organization CRUD, Customer Mixin, Channels, and Membership", () => {
 
         const result = yield* addOrganizationChannel({
           organizationId: organizationId("org-1"),
-          provider: "LinkedIn",
+          provider: "linkedin",
           value: "https://linkedin.com/company/test"
         }).pipe(Effect.provide(testLayer))
 
@@ -751,21 +751,24 @@ describe("Organization CRUD, Customer Mixin, Channels, and Membership", () => {
         expect(capture.attributes?.provider).toBe(contact.channelProvider.LinkedIn)
       }))
 
-    it.effect("returns error for unknown provider", () =>
+    it.effect("adds whatsapp channel", () =>
       Effect.gen(function*() {
         const org = createMockOrganization()
+        const capture: MockConfig["captureAddCollection"] = {}
 
-        const testLayer = createTestLayer({ organizations: [org] })
+        const testLayer = createTestLayer({
+          organizations: [org],
+          captureAddCollection: capture
+        })
 
-        const error = yield* Effect.flip(
-          addOrganizationChannel({
-            organizationId: organizationId("org-1"),
-            provider: "fax",
-            value: "555-1234"
-          }).pipe(Effect.provide(testLayer))
-        )
+        const result = yield* addOrganizationChannel({
+          organizationId: organizationId("org-1"),
+          provider: "whatsapp",
+          value: "+15551234"
+        }).pipe(Effect.provide(testLayer))
 
-        expect(error._tag).toBe("InvalidContactProviderError")
+        expect(result.added).toBe(true)
+        expect(capture.attributes?.provider).toBe(contact.channelProvider.Whatsapp)
       }))
 
     it.effect("returns OrganizationNotFoundError when org not found", () =>

--- a/test/huly/operations/custom-fields.test.ts
+++ b/test/huly/operations/custom-fields.test.ts
@@ -8,6 +8,7 @@ import { ListCustomFieldsResultSchema } from "../../../src/domain/schemas/custom
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import { core } from "../../../src/huly/huly-plugins.js"
 import { getCustomFieldValues, listCustomFields, setCustomField } from "../../../src/huly/operations/custom-fields.js"
+import { customFieldId, docId, objectClassName } from "../../helpers/brands.js"
 
 const toFindResult = <T extends Doc>(docs: Array<T>): FindResult<T> => {
   const result = docs as FindResult<T>
@@ -224,8 +225,8 @@ describe("custom-fields operations", () => {
       const doc = makeDoc({ qaApproved: true })
 
       const result = yield* getCustomFieldValues({
-        objectId: "issue-1",
-        objectClass: "tracker:class:Issue"
+        objectId: docId("issue-1"),
+        objectClass: objectClassName("tracker:class:Issue")
       }).pipe(Effect.provide(createTestLayer({ attributes: [attr], doc })))
 
       expect(result).toEqual([
@@ -255,9 +256,9 @@ describe("custom-fields operations", () => {
       const captureUpdateMixin: { mixin?: string; attributes?: Record<string, unknown> } = {}
 
       const result = yield* setCustomField({
-        objectId: "issue-1",
-        objectClass: "tracker:class:Issue",
-        fieldId: "attr-bool",
+        objectId: docId("issue-1"),
+        objectClass: objectClassName("tracker:class:Issue"),
+        fieldId: customFieldId("attr-bool"),
         value: "true"
       }).pipe(
         Effect.provide(

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -31,7 +31,7 @@ import {
   listAssociations,
   listRelations
 } from "../../../src/huly/operations/generic-associations.js"
-import { documentIdentifier, issueIdentifier } from "../../helpers/brands.js"
+import { docId, documentIdentifier, issueIdentifier } from "../../helpers/brands.js"
 
 const person = "person-1" as PersonId
 const space = "space-1" as Ref<Space>
@@ -358,8 +358,8 @@ describe("listRelations", () => {
 
       const result = yield* listRelations({
         association: assocId,
-        source: { kind: "raw", id: "issue-1", class: issueClass },
-        target: { kind: "raw", id: "issue-2", class: issueClass }
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        target: { kind: "raw", id: docId("issue-2"), class: issueClass }
       }).pipe(
         Effect.provide(testLayer({
           associations: [assoc],
@@ -381,8 +381,8 @@ describe("listRelations", () => {
 
       const result = yield* listRelations({
         association: assocId,
-        source: { kind: "raw", id: "issue-2", class: issueClass },
-        target: { kind: "raw", id: "issue-1", class: issueClass },
+        source: { kind: "raw", id: docId("issue-2"), class: issueClass },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass },
         direction: "either"
       }).pipe(
         Effect.provide(testLayer({
@@ -413,8 +413,8 @@ describe("listRelations", () => {
 
       const result = yield* listRelations({
         association: assocId,
-        source: { kind: "raw", id: "doc-1", class: documentClass },
-        target: { kind: "raw", id: "issue-1", class: issueClass },
+        source: { kind: "raw", id: docId("doc-1"), class: documentClass },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass },
         direction: "target-to-source"
       }).pipe(
         Effect.provide(testLayer({
@@ -447,8 +447,8 @@ describe("listRelations", () => {
 
       const result = yield* listRelations({
         association: assocId,
-        source: { kind: "raw", id: "doc-1", class: documentClass },
-        target: { kind: "raw", id: "issue-1", class: issueClass },
+        source: { kind: "raw", id: docId("doc-1"), class: documentClass },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass },
         direction: "either"
       }).pipe(
         Effect.provide(testLayer({
@@ -476,7 +476,7 @@ describe("listRelations", () => {
       const rel = relation({})
 
       const result = yield* listRelations({
-        source: { kind: "raw", id: "issue-1", class: issueClass }
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass }
       }).pipe(
         Effect.provide(testLayer({
           associations: [documentAssociation, issueAssociation],
@@ -494,7 +494,7 @@ describe("listRelations", () => {
       const error = yield* Effect.flip(
         listRelations({
           association: assocId,
-          source: { kind: "raw", id: "doc-1", class: documentClass }
+          source: { kind: "raw", id: docId("doc-1"), class: documentClass }
         }).pipe(
           Effect.provide(testLayer({
             associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
@@ -510,7 +510,7 @@ describe("listRelations", () => {
     Effect.gen(function*() {
       const error = yield* Effect.flip(
         listRelations({
-          source: { kind: "raw", id: "issue-1" }
+          source: { kind: "raw", id: docId("issue-1") }
         }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
       )
 
@@ -522,7 +522,7 @@ describe("listRelations", () => {
       const error = yield* Effect.flip(
         listRelations({
           association: assocId,
-          source: { kind: "raw", id: "missing-issue", class: issueClass }
+          source: { kind: "raw", id: docId("missing-issue"), class: issueClass }
         }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
       )
 
@@ -558,8 +558,8 @@ describe("relation mutations", () => {
       const error = yield* Effect.flip(
         createRelation({
           association: assocId,
-          source: { kind: "raw", id: "issue-1", class: issueClass },
-          target: { kind: "raw", id: "issue-2", class: issueClass }
+          source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+          target: { kind: "raw", id: docId("issue-2"), class: issueClass }
         }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
       )
 
@@ -571,8 +571,8 @@ describe("relation mutations", () => {
       const error = yield* Effect.flip(
         deleteRelation({
           association: assocId,
-          source: { kind: "raw", id: "issue-1", class: issueClass },
-          target: { kind: "raw", id: "issue-2", class: issueClass }
+          source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+          target: { kind: "raw", id: docId("issue-2"), class: issueClass }
         }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
       )
 

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -8,14 +8,14 @@ import type {
   Relation as HulyRelation,
   Space
 } from "@hcengineering/core"
-import { toFindResult } from "@hcengineering/core"
+import { SortingOrder, toFindResult } from "@hcengineering/core"
 import type { Document as HulyDocument } from "@hcengineering/document"
 import type { Issue as HulyIssue } from "@hcengineering/tracker"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
 import { AssociationIdentifier } from "../../../src/domain/schemas/generic-associations.js"
-import { ObjectClassName } from "../../../src/domain/schemas/shared.js"
+import { MAX_LIMIT, ObjectClassName } from "../../../src/domain/schemas/shared.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import {
   AssociationIdentifierAmbiguousError,
@@ -122,15 +122,21 @@ const matchesQuery = (doc: Doc, query: Record<string, unknown>): boolean =>
     return Reflect.get(doc, key) === value
   })
 
+const getProperty = (value: unknown, key: string): unknown =>
+  typeof value === "object" && value !== null ? Reflect.get(value, key) : undefined
+
 const resultFor = <T extends Doc>(
   docs: ReadonlyArray<T>,
   query: unknown,
   options: unknown
 ): FindResult<T> => {
   const q = query as Record<string, unknown>
-  const opts = options as { limit?: number } | undefined
+  const opts = options as { limit?: number; sort?: { modifiedOn?: SortingOrder } } | undefined
   const matches = docs.filter((doc) => matchesQuery(doc, q))
-  return toFindResult(matches.slice(0, opts?.limit), matches.length)
+  const sorted = opts?.sort?.modifiedOn === SortingOrder.Descending
+    ? [...matches].sort((left, right) => right.modifiedOn - left.modifiedOn)
+    : matches
+  return toFindResult(sorted.slice(0, opts?.limit), matches.length)
 }
 
 const testLayer = (data: TestData, onFindAll?: FindAllObserver) => {
@@ -484,6 +490,64 @@ describe("listRelations", () => {
       expect(result.relations[0].target.display).toBe("Spec")
     }))
 
+  it.effect("matches omitted asymmetric associations in either direction", () =>
+    Effect.gen(function*() {
+      const issueToDocument = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document,
+        nameA: "issue",
+        nameB: "document",
+        type: "1:N"
+      })
+      const rel = relation({
+        docA: "issue-1" as Ref<Doc>,
+        docB: "doc-1" as Ref<Doc>
+      })
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("doc-1"), class: documentClass },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [issueToDocument],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1")],
+          documents: [documentDoc("doc-1", "Spec")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("Spec")
+    }))
+
+  it.effect("deduplicates omitted same-class association discovery in either direction", () =>
+    Effect.gen(function*() {
+      const findAllRequests: Array<Parameters<FindAllObserver>[0]> = []
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        target: { kind: "raw", id: docId("issue-2"), class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }, (request) => {
+          findAllRequests.push(request)
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(findAllRequests.filter((request) => request._class === core.class.Association)).toHaveLength(1)
+      expect(findAllRequests.filter((request) => request._class === core.class.Relation)).toHaveLength(2)
+    }))
+
   it.effect("skips incompatible associations when association is omitted", () =>
     Effect.gen(function*() {
       const documentAssociation = association({
@@ -506,6 +570,145 @@ describe("listRelations", () => {
 
       expect(result.total).toBe(1)
       expect(result.relations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("does not fan out relation queries by discovered associations when association is omitted", () =>
+    Effect.gen(function*() {
+      const findAllRequests: Array<Parameters<FindAllObserver>[0]> = []
+      const associations = Array.from({ length: 20 }, (_, index) =>
+        association({
+          _id: `assoc-extra-${index}` as Ref<HulyAssociation>,
+          classA: tracker.class.Issue,
+          classB: tracker.class.Issue
+        }))
+      const issueAssociation = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [...associations, issueAssociation],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }, (request) => {
+          findAllRequests.push(request)
+        }))
+      )
+
+      const associationRequests = findAllRequests.filter((request) => request._class === core.class.Association)
+      const relationRequests = findAllRequests.filter((request) => request._class === core.class.Relation)
+      const issueRequests = findAllRequests.filter((request) => request._class === tracker.class.Issue)
+      const associationFilter = getProperty(relationRequests[0]?.query, "association")
+
+      expect(result.total).toBe(1)
+      expect(relationRequests).toHaveLength(1)
+      expect(associationRequests).toHaveLength(1)
+      expect(issueRequests).toHaveLength(1)
+      expect(getProperty(associationRequests[0]?.query, "classA")).toBe(tracker.class.Issue)
+      expect(getProperty(associationRequests[0]?.query, "classB")).toBeUndefined()
+      expect(getProperty(associationFilter, "$in")).toContain("assoc-1")
+    }))
+
+  it.effect("applies the relation limit after filtering hidden associations when association is omitted", () =>
+    Effect.gen(function*() {
+      const systemAssociation = association({
+        _id: "assoc-system" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: core.class.Doc
+      })
+      const visibleAssociation = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const hiddenRelation = relation({
+        _id: "rel-hidden" as Ref<HulyRelation>,
+        association: "assoc-system" as Ref<HulyAssociation>,
+        docB: "core-doc-1" as Ref<Doc>,
+        modifiedOn: 300
+      })
+      const visibleRelation = relation({
+        _id: "rel-visible" as Ref<HulyRelation>,
+        association: "assoc-1" as Ref<HulyAssociation>,
+        modifiedOn: 100
+      })
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        limit: 1
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [systemAssociation, visibleAssociation],
+          relations: [hiddenRelation, visibleRelation],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("discovers newest compatible associations before applying the association window", () =>
+    Effect.gen(function*() {
+      const olderAssociations = Array.from({ length: MAX_LIMIT }, (_, index) =>
+        association({
+          _id: `assoc-old-${index}` as Ref<HulyAssociation>,
+          modifiedOn: index
+        }))
+      const visibleAssociation = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        modifiedOn: MAX_LIMIT + 1
+      })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        limit: 1
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [...olderAssociations, visibleAssociation],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("chunks endpoint hydration by class instead of hydrating per relation", () =>
+    Effect.gen(function*() {
+      const findAllRequests: Array<Parameters<FindAllObserver>[0]> = []
+      const relations = Array.from({ length: MAX_LIMIT }, (_, index) =>
+        relation({
+          _id: `rel-${index}` as Ref<HulyRelation>,
+          docA: "issue-0" as Ref<Doc>,
+          docB: `issue-${index + 1}` as Ref<Doc>,
+          modifiedOn: 300 - index
+        }))
+      const issues = Array.from({ length: MAX_LIMIT + 1 }, (_, index) => issue(`issue-${index}`, `HULY-${index}`))
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: docId("issue-0"), class: issueClass },
+        limit: MAX_LIMIT
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
+          relations,
+          issues
+        }, (request) => {
+          findAllRequests.push(request)
+        }))
+      )
+
+      const issueHydrationRequests = findAllRequests.filter((request) => request._class === tracker.class.Issue)
+      const chunkSizes = issueHydrationRequests.map((request) => {
+        const ids = getProperty(getProperty(request.query, "_id"), "$in")
+        return Array.isArray(ids) ? ids.length : 0
+      })
+
+      expect(result.total).toBe(MAX_LIMIT)
+      expect(issueHydrationRequests).toHaveLength(2)
+      expect(chunkSizes.sort((left, right) => left - right)).toEqual([1, MAX_LIMIT])
+      expect(findAllRequests.filter((request) => request._class === core.class.Relation)).toHaveLength(1)
     }))
 
   it.effect("fails when a locator resolves to the wrong endpoint class", () =>

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -217,6 +217,25 @@ describe("listAssociations", () => {
       expect(result.total).toBe(1)
     }))
 
+  it.effect("maps SDK association type to public cardinality", () =>
+    Effect.gen(function*() {
+      const result = yield* listAssociations({}).pipe(
+        Effect.provide(testLayer({
+          associations: [
+            association({ _id: "assoc-1-1" as Ref<HulyAssociation>, type: "1:1" }),
+            association({ _id: "assoc-1-n" as Ref<HulyAssociation>, type: "1:N" }),
+            association({ _id: "assoc-n-n" as Ref<HulyAssociation>, type: "N:N" })
+          ]
+        }))
+      )
+
+      expect(result.associations.map((item) => item.cardinality)).toEqual([
+        "one-to-one",
+        "one-to-many",
+        "many-to-many"
+      ])
+    }))
+
   it.effect("returns no writable associations until a write allowlist exists", () =>
     Effect.gen(function*() {
       const result = yield* listAssociations({ writableOnly: true }).pipe(

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -197,6 +197,8 @@ describe("listAssociations", () => {
       )
 
       expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-visible"])
+      expect(result.associations[0].sourceClassLabel).toBe("Issue")
+      expect(result.associations[0].targetClassLabel).toBe("Issue")
       expect(result.associations[0].canListRelations).toBe(true)
       expect(result.associations[0].canCreateRelation).toBe(false)
     }))
@@ -327,6 +329,8 @@ describe("listAssociations", () => {
       )
 
       expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+      expect(result.associations[0].sourceClassLabel).toBe("Document")
+      expect(result.associations[0].targetClassLabel).toBe("Document")
     }))
 
   it.effect("fails on ambiguous association names", () =>

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -1,0 +1,581 @@
+import { describe, it } from "@effect/vitest"
+import type {
+  Association as HulyAssociation,
+  Doc,
+  FindResult,
+  PersonId,
+  Ref,
+  Relation as HulyRelation,
+  Space
+} from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import type { Document as HulyDocument } from "@hcengineering/document"
+import type { Issue as HulyIssue } from "@hcengineering/tracker"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import { AssociationIdentifier } from "../../../src/domain/schemas/generic-associations.js"
+import { ObjectClassName } from "../../../src/domain/schemas/shared.js"
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import {
+  AssociationIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationMutationUnsupportedError
+} from "../../../src/huly/errors.js"
+import { core, documentPlugin, tracker } from "../../../src/huly/huly-plugins.js"
+import {
+  createRelation,
+  deleteRelation,
+  listAssociations,
+  listRelations
+} from "../../../src/huly/operations/generic-associations.js"
+import { documentIdentifier, issueIdentifier } from "../../helpers/brands.js"
+
+const person = "person-1" as PersonId
+const space = "space-1" as Ref<Space>
+const assocId = AssociationIdentifier.make("assoc-1")
+const relatesAssociation = AssociationIdentifier.make("relates")
+const issueClass = ObjectClassName.make(tracker.class.Issue)
+const documentClass = ObjectClassName.make(documentPlugin.class.Document)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const association = (overrides: Partial<HulyAssociation>): HulyAssociation => ({
+  _id: "assoc-1" as Ref<HulyAssociation>,
+  _class: core.class.Association,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  classA: tracker.class.Issue,
+  classB: tracker.class.Issue,
+  nameA: "relates",
+  nameB: "relates",
+  type: "N:N",
+  ...overrides
+} as HulyAssociation)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const relation = (overrides: Partial<HulyRelation>): HulyRelation => ({
+  _id: "rel-1" as Ref<HulyRelation>,
+  _class: core.class.Relation,
+  space,
+  modifiedBy: person,
+  modifiedOn: 200,
+  createdBy: person,
+  createdOn: 200,
+  docA: "issue-1" as Ref<Doc>,
+  docB: "issue-2" as Ref<Doc>,
+  association: "assoc-1" as Ref<HulyAssociation>,
+  ...overrides
+} as HulyRelation)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const issue = (id: string, identifier: string): HulyIssue => ({
+  _id: id as Ref<HulyIssue>,
+  _class: tracker.class.Issue,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  title: identifier,
+  identifier,
+  number: 1
+} as HulyIssue)
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const documentDoc = (id: string, title: string): HulyDocument => ({
+  _id: id as Ref<HulyDocument>,
+  _class: documentPlugin.class.Document,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  title
+} as HulyDocument)
+
+interface TestData {
+  readonly associations?: ReadonlyArray<HulyAssociation>
+  readonly relations?: ReadonlyArray<HulyRelation>
+  readonly issues?: ReadonlyArray<HulyIssue>
+  readonly documents?: ReadonlyArray<HulyDocument>
+}
+
+type FindAllObserver = (
+  request: {
+    readonly _class: unknown
+    readonly query: unknown
+    readonly options: unknown
+  }
+) => void
+
+const matchesQuery = (doc: Doc, query: Record<string, unknown>): boolean =>
+  Object.entries(query).every(([key, value]) => {
+    if (typeof value === "object" && value !== null && "$in" in value) {
+      const values = Reflect.get(value, "$in")
+      return Array.isArray(values) && values.includes(Reflect.get(doc, key))
+    }
+    return Reflect.get(doc, key) === value
+  })
+
+const resultFor = <T extends Doc>(
+  docs: ReadonlyArray<T>,
+  query: unknown,
+  options: unknown
+): FindResult<T> => {
+  const q = query as Record<string, unknown>
+  const opts = options as { limit?: number } | undefined
+  const matches = docs.filter((doc) => matchesQuery(doc, q))
+  return toFindResult(matches.slice(0, opts?.limit), matches.length)
+}
+
+const testLayer = (data: TestData, onFindAll?: FindAllObserver) => {
+  const associations = data.associations ?? []
+  const relations = data.relations ?? []
+  const issues = data.issues ?? []
+  const documents = data.documents ?? []
+
+  const findAll: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown, options: unknown) => {
+    onFindAll?.({ _class, query, options })
+    if (_class === core.class.Association) {
+      return Effect.succeed(resultFor(associations, query, options))
+    }
+    if (_class === core.class.Relation) {
+      return Effect.succeed(resultFor(relations, query, options))
+    }
+    if (_class === tracker.class.Issue) {
+      return Effect.succeed(resultFor(issues, query, options))
+    }
+    if (_class === documentPlugin.class.Document) {
+      return Effect.succeed(resultFor(documents, query, options))
+    }
+    return Effect.succeed(toFindResult([]))
+  }) as HulyClientOperations["findAll"]
+
+  const findOne: HulyClientOperations["findOne"] = ((_class: unknown, query: unknown) => {
+    const q = query as Record<string, unknown>
+    if (_class === core.class.Association) {
+      return Effect.succeed(associations.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === tracker.class.Issue) {
+      return Effect.succeed(issues.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === documentPlugin.class.Document) {
+      return Effect.succeed(documents.find((doc) => matchesQuery(doc, q)))
+    }
+    if (_class === core.class.Relation) {
+      return Effect.succeed(relations.find((doc) => matchesQuery(doc, q)))
+    }
+    return Effect.succeed(undefined)
+  }) as HulyClientOperations["findOne"]
+
+  return HulyClient.testLayer({ findAll, findOne })
+}
+
+describe("listAssociations", () => {
+  it.effect("lists visible associations and hides core system associations by default", () =>
+    Effect.gen(function*() {
+      const visible = association({ _id: "assoc-visible" as Ref<HulyAssociation> })
+      const system = association({
+        _id: "assoc-system" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+
+      const result = yield* listAssociations({}).pipe(
+        Effect.provide(testLayer({ associations: [visible, system] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-visible"])
+      expect(result.associations[0].canListRelations).toBe(true)
+      expect(result.associations[0].canCreateRelation).toBe(false)
+    }))
+
+  it.effect("applies limit after hiding system associations", () =>
+    Effect.gen(function*() {
+      const system1 = association({
+        _id: "assoc-system-1" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const system2 = association({
+        _id: "assoc-system-2" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const visible = association({ _id: "assoc-visible" as Ref<HulyAssociation> })
+
+      const result = yield* listAssociations({ limit: 1 }).pipe(
+        Effect.provide(testLayer({ associations: [system1, system2, visible] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-visible"])
+      expect(result.total).toBe(1)
+    }))
+
+  it.effect("returns no writable associations until a write allowlist exists", () =>
+    Effect.gen(function*() {
+      const result = yield* listAssociations({ writableOnly: true }).pipe(
+        Effect.provide(testLayer({ associations: [association({})] }))
+      )
+
+      expect(result.associations).toEqual([])
+      expect(result.total).toBe(0)
+    }))
+
+  it.effect("resolves a selected association before applying writableOnly filtering", () =>
+    Effect.gen(function*() {
+      const result = yield* listAssociations({ association: assocId, writableOnly: true }).pipe(
+        Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] }))
+      )
+
+      expect(result.associations).toEqual([])
+      expect(result.total).toBe(0)
+    }))
+
+  it.effect("resolves a selected association ID beyond the discovery window", () =>
+    Effect.gen(function*() {
+      const nonMatches = Array.from({ length: 205 }, (_, index) =>
+        association({
+          _id: `assoc-other-${index}` as Ref<HulyAssociation>,
+          nameA: `other-${index}`,
+          nameB: `other-${index}`
+        }))
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        nameA: "outside-window",
+        nameB: "outside-window"
+      })
+
+      const result = yield* listAssociations({ association: AssociationIdentifier.make("assoc-target") }).pipe(
+        Effect.provide(testLayer({ associations: [...nonMatches, target] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("resolves a selected association name beyond the discovery window", () =>
+    Effect.gen(function*() {
+      const nonMatches = Array.from({ length: 205 }, (_, index) =>
+        association({
+          _id: `assoc-other-${index}` as Ref<HulyAssociation>,
+          nameA: `other-${index}`,
+          nameB: `other-${index}`
+        }))
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        nameA: "outside-window",
+        nameB: "outside-window"
+      })
+
+      const result = yield* listAssociations({ association: AssociationIdentifier.make("outside-window") }).pipe(
+        Effect.provide(testLayer({ associations: [...nonMatches, target] }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("applies class filters before limiting selected association name lookups", () =>
+    Effect.gen(function*() {
+      const target = association({
+        _id: "assoc-target" as Ref<HulyAssociation>,
+        classA: documentPlugin.class.Document,
+        classB: documentPlugin.class.Document
+      })
+
+      const result = yield* listAssociations({
+        association: relatesAssociation,
+        sourceClass: documentClass,
+        targetClass: documentClass
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [
+            association({ _id: "assoc-issue-1" as Ref<HulyAssociation> }),
+            association({ _id: "assoc-issue-2" as Ref<HulyAssociation> }),
+            target
+          ]
+        }))
+      )
+
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-target"])
+    }))
+
+  it.effect("fails on ambiguous association names", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listAssociations({ association: relatesAssociation }).pipe(
+          Effect.provide(testLayer({
+            associations: [
+              association({ _id: "assoc-1" as Ref<HulyAssociation> }),
+              association({ _id: "assoc-2" as Ref<HulyAssociation> })
+            ]
+          }))
+        )
+      )
+
+      expect(error).toBeInstanceOf(AssociationIdentifierAmbiguousError)
+    }))
+
+  it.effect("caps exact-name lookup queries while detecting ambiguity", () =>
+    Effect.gen(function*() {
+      const lookupLimits: Array<number | undefined> = []
+      const error = yield* Effect.flip(
+        listAssociations({ association: relatesAssociation }).pipe(
+          Effect.provide(testLayer(
+            {
+              associations: [
+                association({ _id: "assoc-1" as Ref<HulyAssociation> }),
+                association({ _id: "assoc-2" as Ref<HulyAssociation> }),
+                association({ _id: "assoc-3" as Ref<HulyAssociation> })
+              ]
+            },
+            ({ _class, options }) => {
+              if (_class === core.class.Association) {
+                const limit = typeof options === "object" && options !== null
+                  ? Reflect.get(options, "limit")
+                  : undefined
+                lookupLimits.push(typeof limit === "number" ? limit : undefined)
+              }
+            }
+          ))
+        )
+      )
+
+      expect(error).toBeInstanceOf(AssociationIdentifierAmbiguousError)
+      expect(lookupLimits).toEqual([2, 2])
+    }))
+})
+
+describe("listRelations", () => {
+  it.effect("lists relation instances with resolved endpoint display", () =>
+    Effect.gen(function*() {
+      const assoc = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "issue-1", class: issueClass },
+        target: { kind: "raw", id: "issue-2", class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [assoc],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("HULY-2")
+    }))
+
+  it.effect("matches symmetric associations in either direction", () =>
+    Effect.gen(function*() {
+      const assoc = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "issue-2", class: issueClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [assoc],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+    }))
+
+  it.effect("validates reversed endpoints against asymmetric association classes", () =>
+    Effect.gen(function*() {
+      const issueToDocument = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document,
+        nameA: "issue",
+        nameB: "document",
+        type: "1:N"
+      })
+      const rel = relation({
+        docA: "issue-1" as Ref<Doc>,
+        docB: "doc-1" as Ref<Doc>
+      })
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "doc-1", class: documentClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "target-to-source"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [issueToDocument],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1")],
+          documents: [documentDoc("doc-1", "Spec")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("Spec")
+    }))
+
+  it.effect("matches asymmetric associations in either direction", () =>
+    Effect.gen(function*() {
+      const issueToDocument = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document,
+        nameA: "issue",
+        nameB: "document",
+        type: "1:N"
+      })
+      const rel = relation({
+        docA: "issue-1" as Ref<Doc>,
+        docB: "doc-1" as Ref<Doc>
+      })
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: "doc-1", class: documentClass },
+        target: { kind: "raw", id: "issue-1", class: issueClass },
+        direction: "either"
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [issueToDocument],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1")],
+          documents: [documentDoc("doc-1", "Spec")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].relationId).toBe("rel-1")
+      expect(result.relations[0].source.display).toBe("HULY-1")
+      expect(result.relations[0].target.display).toBe("Spec")
+    }))
+
+  it.effect("skips incompatible associations when association is omitted", () =>
+    Effect.gen(function*() {
+      const documentAssociation = association({
+        _id: "assoc-doc" as Ref<HulyAssociation>,
+        classA: documentPlugin.class.Document,
+        classB: documentPlugin.class.Document
+      })
+      const issueAssociation = association({ _id: "assoc-1" as Ref<HulyAssociation> })
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: "issue-1", class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: [documentAssociation, issueAssociation],
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.relations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("fails when a locator resolves to the wrong endpoint class", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          association: assocId,
+          source: { kind: "raw", id: "doc-1", class: documentClass }
+        }).pipe(
+          Effect.provide(testLayer({
+            associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
+            documents: [documentDoc("doc-1", "Spec")]
+          }))
+        )
+      )
+
+      expect(error).toBeInstanceOf(RelationEndpointClassMismatchError)
+    }))
+
+  it.effect("fails with typed invalid locator error for raw locators without a known class", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "raw", id: "issue-1" }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectLocatorInvalidError)
+    }))
+
+  it.effect("fails with typed not found error for missing raw objects", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          association: assocId,
+          source: { kind: "raw", id: "missing-issue", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
+    }))
+
+  it.effect("fails with typed invalid locator error for issue locators without project or full key", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "issue", issue: issueIdentifier("123") }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectLocatorInvalidError)
+    }))
+
+  it.effect("fails with typed not found error for missing documents without teamspace", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "document", document: documentIdentifier("Missing Spec") }
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
+    }))
+})
+
+describe("relation mutations", () => {
+  it.effect("createRelation fails clearly while writes are unsupported", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        createRelation({
+          association: assocId,
+          source: { kind: "raw", id: "issue-1", class: issueClass },
+          target: { kind: "raw", id: "issue-2", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(RelationMutationUnsupportedError)
+    }))
+
+  it.effect("deleteRelation rejects validated association deletes while writes are unsupported", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        deleteRelation({
+          association: assocId,
+          source: { kind: "raw", id: "issue-1", class: issueClass },
+          target: { kind: "raw", id: "issue-2", class: issueClass }
+        }).pipe(Effect.provide(testLayer({ associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })] })))
+      )
+
+      expect(error).toBeInstanceOf(RelationMutationUnsupportedError)
+    }))
+})

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -673,6 +673,54 @@ describe("listRelations", () => {
       expect(result.relations[0].associationId).toBe("assoc-1")
     }))
 
+  it.effect("warns when omitted-association discovery reaches the association cap", () =>
+    Effect.gen(function*() {
+      const cappedAssociations = Array.from({ length: MAX_LIMIT }, (_, index) =>
+        association({
+          _id: `assoc-${index}` as Ref<HulyAssociation>,
+          modifiedOn: MAX_LIMIT - index
+        }))
+      const rel = relation({ association: "assoc-0" as Ref<HulyAssociation> })
+
+      const result = yield* listRelations({
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: cappedAssociations,
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings?.[0]).toContain(`${MAX_LIMIT}-association cap`)
+    }))
+
+  it.effect("does not warn when an explicit association is provided", () =>
+    Effect.gen(function*() {
+      const cappedAssociations = Array.from({ length: MAX_LIMIT }, (_, index) =>
+        association({
+          _id: `assoc-${index}` as Ref<HulyAssociation>,
+          modifiedOn: MAX_LIMIT - index
+        }))
+      const rel = relation({})
+
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass }
+      }).pipe(
+        Effect.provide(testLayer({
+          associations: cappedAssociations,
+          relations: [rel],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        }))
+      )
+
+      expect(result.total).toBe(1)
+      expect(result.warnings).toBeUndefined()
+    }))
+
   it.effect("chunks endpoint hydration by class instead of hydrating per relation", () =>
     Effect.gen(function*() {
       const findAllRequests: Array<Parameters<FindAllObserver>[0]> = []

--- a/test/huly/operations/issues.test.ts
+++ b/test/huly/operations/issues.test.ts
@@ -33,6 +33,7 @@ import { addLabel, createIssue, getIssue, listIssues, updateIssue } from "../../
 
 import { contact, core, tags, task, tracker } from "../../../src/huly/huly-plugins.js"
 import { colorCode, email, issueIdentifier, projectIdentifier, statusName } from "../../helpers/brands.js"
+import { docRef } from "../../helpers/huly-sdk.js"
 
 // Helper to create properly typed FindResult for tests
 // FindResult<T> = T[] & { total: number; lookupMap?: Record<string, Doc> }
@@ -486,8 +487,8 @@ describe("listIssues", () => {
         const project = makeProject({ identifier: "TEST" })
         // Input: older issue first (opposite of expected output order)
         const issues = [
-          makeIssue({ _id: "issue-2" as Ref<HulyIssue>, identifier: "TEST-2", title: "Issue 2", modifiedOn: 1000 }),
-          makeIssue({ _id: "issue-1" as Ref<HulyIssue>, identifier: "TEST-1", title: "Issue 1", modifiedOn: 2000 })
+          makeIssue({ _id: docRef<HulyIssue>("issue-2"), identifier: "TEST-2", title: "Issue 2", modifiedOn: 1000 }),
+          makeIssue({ _id: docRef<HulyIssue>("issue-1"), identifier: "TEST-1", title: "Issue 1", modifiedOn: 2000 })
         ]
         const statuses = [
           makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })

--- a/test/huly/operations/issues.test.ts
+++ b/test/huly/operations/issues.test.ts
@@ -486,8 +486,8 @@ describe("listIssues", () => {
         const project = makeProject({ identifier: "TEST" })
         // Input: older issue first (opposite of expected output order)
         const issues = [
-          makeIssue({ identifier: "TEST-2", title: "Issue 2", modifiedOn: 1000 }),
-          makeIssue({ identifier: "TEST-1", title: "Issue 1", modifiedOn: 2000 })
+          makeIssue({ _id: "issue-2" as Ref<HulyIssue>, identifier: "TEST-2", title: "Issue 2", modifiedOn: 1000 }),
+          makeIssue({ _id: "issue-1" as Ref<HulyIssue>, identifier: "TEST-1", title: "Issue 1", modifiedOn: 2000 })
         ]
         const statuses = [
           makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })
@@ -503,7 +503,9 @@ describe("listIssues", () => {
 
         expect(result).toHaveLength(2)
         // Expect sorted by modifiedOn descending (newer first)
+        expect(result[0].issueId).toBe("issue-1")
         expect(result[0].identifier).toBe("TEST-1")
+        expect(result[1].issueId).toBe("issue-2")
         expect(result[1].identifier).toBe("TEST-2")
       }))
 
@@ -837,6 +839,7 @@ describe("getIssue", () => {
           .pipe(Effect.provide(testLayer))
 
         expect(result.identifier).toBe("TEST-1")
+        expect(result.issueId).toBe("issue-1")
         expect(result.title).toBe("Test Issue")
         expect(result.status).toBe("Open")
         expect(result.project).toBe("TEST")

--- a/test/huly/operations/notifications.test.ts
+++ b/test/huly/operations/notifications.test.ts
@@ -29,6 +29,7 @@ import {
   updateNotificationProviderSetting
 } from "../../../src/huly/operations/notifications.js"
 import {
+  docId,
   notificationBrandId,
   notificationContextId,
   notificationProviderId,
@@ -597,7 +598,7 @@ describe("getNotificationContext", () => {
       const testLayer = createTestLayerWithMocks({ contexts: [ctx] })
 
       const result = yield* getNotificationContext({
-        objectId: "obj-1",
+        objectId: docId("obj-1"),
         objectClass: objectClassName("tracker.class.Issue")
       }).pipe(Effect.provide(testLayer))
 
@@ -617,7 +618,7 @@ describe("getNotificationContext", () => {
       const testLayer = createTestLayerWithMocks({ contexts: [] })
 
       const result = yield* getNotificationContext({
-        objectId: "nonexistent",
+        objectId: docId("nonexistent"),
         objectClass: objectClassName("tracker.class.Issue")
       }).pipe(Effect.provide(testLayer))
 

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -3,7 +3,15 @@ import type { ParseResult } from "effect"
 import { Cause, Effect, Schema } from "effect"
 import { expect } from "vitest"
 import { ProcessId } from "../../src/domain/schemas/processes.js"
-import { AssociationId, CardId, MasterTagId, NonEmptyString, RelationId } from "../../src/domain/schemas/shared.js"
+import {
+  AssociationId,
+  CardId,
+  DocId,
+  MasterTagId,
+  NonEmptyString,
+  ObjectClassName,
+  RelationId
+} from "../../src/domain/schemas/shared.js"
 import {
   AssociationIdentifierAmbiguousError,
   AssociationNotFoundError,
@@ -295,7 +303,7 @@ describe("Error Mapping to MCP", () => {
             new AssociationNotFoundError({ identifier: "relates" }),
             new AssociationIdentifierAmbiguousError({
               identifier: "relates",
-              candidates: [{ id: "assoc-1", name: "relates" }]
+              candidates: [{ id: AssociationId.make("assoc-1"), name: "relates" }]
             }),
             new RelationNotFoundError({ identifier: "rel-1" }),
             new RelationIdentifierAmbiguousError({
@@ -314,7 +322,11 @@ describe("Error Mapping to MCP", () => {
             new GenericObjectIdentifierAmbiguousError({
               field: "target",
               identifier: "Spec",
-              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+              candidates: [{
+                id: DocId.make("doc-1"),
+                class: ObjectClassName.make("document:class:Document"),
+                display: "Spec"
+              }]
             }),
             new GenericObjectLocatorInvalidError({
               field: "source",

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -3,8 +3,10 @@ import type { ParseResult } from "effect"
 import { Cause, Effect, Schema } from "effect"
 import { expect } from "vitest"
 import { ProcessId } from "../../src/domain/schemas/processes.js"
-import { CardId, MasterTagId, NonEmptyString } from "../../src/domain/schemas/shared.js"
+import { AssociationId, CardId, MasterTagId, NonEmptyString, RelationId } from "../../src/domain/schemas/shared.js"
 import {
+  AssociationIdentifierAmbiguousError,
+  AssociationNotFoundError,
   CalendarNotAccessibleError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
@@ -12,6 +14,9 @@ import {
   FileNotFoundError,
   FileUploadError,
   FunnelNotFoundError,
+  GenericObjectIdentifierAmbiguousError,
+  GenericObjectLocatorInvalidError,
+  GenericObjectNotFoundError,
   HulyAuthError,
   HulyConnectionError,
   HulyError,
@@ -30,7 +35,11 @@ import {
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
   ProcessNotFoundError,
-  ProjectNotFoundError
+  ProjectNotFoundError,
+  RelationEndpointClassMismatchError,
+  RelationIdentifierAmbiguousError,
+  RelationMutationUnsupportedError,
+  RelationNotFoundError
 } from "../../src/huly/errors.js"
 import {
   createSuccessResponse,
@@ -268,6 +277,54 @@ describe("Error Mapping to MCP", () => {
               candidates: [cardCandidate]
             }),
             new ProcessCardNotFoundError({ identifier: "Missing Card" })
+          ]
+
+          for (const error of errors) {
+            const response = mapDomainErrorToMcp(error)
+
+            expect(response.isError).toBe(true)
+            expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+            expect(response._meta.errorTag).toBeUndefined()
+            expect(response.content[0].text).toBe(error.message)
+          }
+        }))
+
+      it.effect("maps generic association and relation lookup errors with descriptive messages", () =>
+        Effect.gen(function*() {
+          const errors = [
+            new AssociationNotFoundError({ identifier: "relates" }),
+            new AssociationIdentifierAmbiguousError({
+              identifier: "relates",
+              candidates: [{ id: "assoc-1", name: "relates" }]
+            }),
+            new RelationNotFoundError({ identifier: "rel-1" }),
+            new RelationIdentifierAmbiguousError({
+              identifier: "assoc-1/source/target",
+              relationIds: [RelationId.make("rel-1")]
+            }),
+            new RelationMutationUnsupportedError({
+              associationId: AssociationId.make("assoc-1"),
+              reason: "not validated"
+            }),
+            new RelationEndpointClassMismatchError({
+              field: "source",
+              expectedClass: "tracker:class:Issue",
+              actualClass: "document:class:Document"
+            }),
+            new GenericObjectIdentifierAmbiguousError({
+              field: "target",
+              identifier: "Spec",
+              candidates: [{ id: "doc-1", class: "document:class:Document", display: "Spec" }]
+            }),
+            new GenericObjectLocatorInvalidError({
+              field: "source",
+              reason: "raw object locator requires class"
+            }),
+            new GenericObjectNotFoundError({
+              field: "target",
+              identifier: "missing-doc",
+              class: "document:class:Document"
+            })
           ]
 
           for (const error of errors) {

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -42,6 +42,7 @@ describe("CATEGORY_NAMES", () => {
       expect(CATEGORY_NAMES.has("documents")).toBe(true)
       expect(CATEGORY_NAMES.has("comments")).toBe(true)
       expect(CATEGORY_NAMES.has("task-management")).toBe(true)
+      expect(CATEGORY_NAMES.has("associations")).toBe(true)
       expect(CATEGORY_NAMES.size).toBeGreaterThan(5)
     }))
 })
@@ -110,6 +111,22 @@ describe("createFilteredRegistry", () => {
         expect(tool.category).toBe("task-management")
       }
     }))
+
+  it.effect("filters to association tools", () =>
+    Effect.gen(function*() {
+      const filtered = createFilteredRegistry(new Set(["associations"]))
+      const toolNames = filtered.definitions.map((tool) => tool.name)
+
+      expect(toolNames).toEqual([
+        "list_associations",
+        "list_relations",
+        "create_relation",
+        "delete_relation"
+      ])
+      for (const tool of filtered.definitions) {
+        expect(tool.category).toBe("associations")
+      }
+    }))
 })
 
 describe("handleToolCall", () => {
@@ -135,6 +152,7 @@ describe("TOOL_DEFINITIONS", () => {
       expect(keys.length).toBeGreaterThan(0)
       expect(keys.length).toBe(toolRegistry.tools.size)
       expect(keys).toContain("create_issue_status")
+      expect(keys).toContain("list_associations")
     }))
 
   it.effect("entries match toolRegistry", () =>

--- a/test/mcp/tools/generic-associations.test.ts
+++ b/test/mcp/tools/generic-associations.test.ts
@@ -106,4 +106,21 @@ describe("genericAssociationTools", () => {
         openWorldHint: false
       })
     }))
+
+  it.effect("delete_relation input schema stays list_tools compatible while describing both delete modes", () =>
+    Effect.gen(function*() {
+      const tool = findTool("delete_relation")
+
+      expect(tool.inputSchema).toMatchObject({
+        type: "object",
+        anyOf: [
+          {
+            required: ["relation"]
+          },
+          {
+            required: ["association", "source", "target"]
+          }
+        ]
+      })
+    }))
 })

--- a/test/mcp/tools/generic-associations.test.ts
+++ b/test/mcp/tools/generic-associations.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "@effect/vitest"
+import type { AccountUuid, Association as HulyAssociation, PersonId, Ref, Space } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import type { HulyClientOperations } from "../../../src/huly/client.js"
+import { core, tracker } from "../../../src/huly/huly-plugins.js"
+import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import type { HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
+import { genericAssociationTools } from "../../../src/mcp/tools/generic-associations.js"
+
+const person = "person-1" as PersonId
+const space = "space-1" as Ref<Space>
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- SDK fixture builder
+const makeAssociation = (): HulyAssociation => ({
+  _id: "assoc-1" as Ref<HulyAssociation>,
+  _class: core.class.Association,
+  space,
+  modifiedBy: person,
+  modifiedOn: 100,
+  createdBy: person,
+  createdOn: 100,
+  classA: tracker.class.Issue,
+  classB: tracker.class.Issue,
+  nameA: "relates",
+  nameB: "relates",
+  type: "N:N"
+} as HulyAssociation)
+
+const noopStorageClient: HulyStorageOperations = {
+  uploadFile: () => Effect.die(new Error("not implemented")),
+  getFileUrl: (blobId: string) => `https://test.huly.io/files?file=${blobId}`
+}
+
+const hulyClient: HulyClientOperations = {
+  getAccountUuid: () => "account-1" as AccountUuid,
+  getPrimarySocialId: () => person,
+  markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
+  findAll: ((_class: unknown) =>
+    _class === core.class.Association
+      ? Effect.succeed(toFindResult([makeAssociation()]))
+      : Effect.succeed(toFindResult([]))) as HulyClientOperations["findAll"],
+  findOne: () => Effect.succeed(undefined),
+  createDoc: () => Effect.die(new Error("not implemented")),
+  updateDoc: () => Effect.die(new Error("not implemented")),
+  addCollection: () => Effect.die(new Error("not implemented")),
+  removeDoc: () => Effect.die(new Error("not implemented")),
+  uploadMarkup: () => Effect.die(new Error("not implemented")),
+  fetchMarkup: () => Effect.succeed(""),
+  updateMarkup: () => Effect.die(new Error("not implemented")),
+  updateMixin: () => Effect.die(new Error("not implemented")),
+  createMixin: () => Effect.die(new Error("not implemented")),
+  searchFulltext: () => Effect.die(new Error("not implemented"))
+}
+
+const findTool = (name: string) => {
+  const tool = genericAssociationTools.find((candidate) => candidate.name === name)
+  if (tool === undefined) throw new Error(`Tool ${name} not found`)
+  return tool
+}
+
+describe("genericAssociationTools", () => {
+  it.effect("exports association tools in the associations category", () =>
+    Effect.gen(function*() {
+      expect(genericAssociationTools.map((tool) => tool.name)).toEqual([
+        "list_associations",
+        "list_relations",
+        "create_relation",
+        "delete_relation"
+      ])
+      for (const tool of genericAssociationTools) {
+        expect(tool.category).toBe("associations")
+      }
+    }))
+
+  it.effect("list_associations handler encodes successful output", () =>
+    Effect.gen(function*() {
+      const tool = findTool("list_associations")
+      const result = yield* Effect.promise(() => tool.handler({}, hulyClient, noopStorageClient))
+
+      expect(result.isError).toBeUndefined()
+      const parsed = JSON.parse(result.content[0].text) as { associations: Array<{ associationId: string }> }
+      expect(parsed.associations[0].associationId).toBe("assoc-1")
+    }))
+
+  it.effect("list_relations handler maps schema parse errors", () =>
+    Effect.gen(function*() {
+      const tool = findTool("list_relations")
+      const result = yield* Effect.promise(() => tool.handler({}, hulyClient, noopStorageClient))
+
+      expect(result.isError).toBe(true)
+    }))
+
+  it.effect("create_relation annotations mark the operation idempotent and non-destructive", () =>
+    Effect.gen(function*() {
+      const tool = findTool("create_relation")
+
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      })
+    }))
+})


### PR DESCRIPTION
## Summary
- add generic association/relation schemas, operations, and MCP tools
- expose read-side `list_associations` and `list_relations` with safe filtering and typed errors
- add guarded `create_relation` and `delete_relation` entrypoints that fail clearly until writable associations are live-validated
- add README/tool generation and integration script coverage

## Attribution / Prior Art
- Feature idea and product surface were inspired by [`dugynoo/huly-mcp`](https://github.com/dugynoo/huly-mcp).
- Implementation was produced from an independently written behavior spec and review loop; no external source code was copied into this branch.

## Validation
- `pnpm check-all`
- Review loop converged after 7 rounds with no actionable findings
- Pre-commit hook regenerated README tool docs, ran lint-staged, and ran gitleaks
- Not run: Docker/local-Huly integration, because `HULY_URL`/`.env.local`/`CLAUDE.local.md` are unavailable in this worktree