### PR TITLE
feat: Add process write tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-.reference/
+.reference
 dist/
 *.tsbuildinfo
 .ralph/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Code review agents must consult `.claude/review-rules.md` for project-specific q
 2. Run `effect-solutions show <topic>...` for relevant patterns (supports multiple topics)
 3. Search `.reference/effect/` for real implementations (run `effect-solutions setup` first)
 
-In secondary worktrees, `.reference/effect/` may exist only in the master checkout at `/workspace/typescript/hulymcp/.reference/effect/`. When working from another worktree, consult the master checkout's Effect reference rather than assuming the local worktree has its own copy.
+In secondary worktrees, `.reference/effect/` may exist only in the master checkout at `/workspace/typescript/hulymcp/.reference/effect/`. After creating a worktree, run `bash scripts/bootstrap-worktree.sh` to link ignored local resources (`node_modules`, `.reference`, `.env.local`, `CLAUDE.local.md`) from the master checkout when available. If `effect-solutions` is not on PATH, do not report that the Effect reference is missing until you have checked `/workspace/typescript/hulymcp/.reference/effect/`; search it directly with `rg` and read relevant files from there.
 
 Topics: quick-start, project-setup, tsconfig, basics, services-and-layers, data-modeling, error-handling, config, testing, cli.
 
@@ -95,7 +95,8 @@ Use short timeouts (5s) - MCP keeps connection open.
 
 ## Worktrees
 
-Worktrees symlink `node_modules` to the main tree. `.gitignore` must use `node_modules` (no trailing slash) — trailing slash only matches directories, not symlinks, so `git add .` will commit the symlink.
+Worktrees symlink `node_modules` and `.reference` to the main tree. `.gitignore` must use `node_modules` and `.reference` (no trailing slash) — trailing slash only matches directories, not symlinks, so `git add .` will commit the symlink.
+After creating a secondary worktree, run `bash scripts/bootstrap-worktree.sh` from that worktree. This links ignored local resources from `/workspace/typescript/hulymcp`, including `node_modules`, `.reference`, `.env.local`, and `CLAUDE.local.md`, so Effect and Huly reference material remains available outside the master checkout.
 
 Before deleting a worktree or branch, always check for uncommitted changes (`git status`) and unmerged commits (`git log <branch> --not master`) first. Never force-delete without verifying all work is integrated.
 

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -108,7 +108,7 @@ The full suite tests CRUD lifecycles with cleanup for all domains:
 | 16. Workspace | get_workspace_info, list_workspace_members | Read-only (management tools skipped) |
 | 17. Attachments | add_issue_attachment, list/get/pin/update/download/delete attachment | Full CRUD (upload_file standalone skipped — no blob delete) |
 | 18. Test Management | Full suite/case/plan/run/result lifecycle | Requires TM project in Huly UI |
-| 19. Processes | list_processes, get_process, list_process_executions | Read-only; get/filter cases run when the workspace has process definitions |
+| 19. Processes | list_processes, get_process, list_process_executions, start_process, cancel_execution | Read/write; write checks run only when the workspace has a process with an initial state and a matching safe card fixture, then cancel the created execution |
 
 ### Intentionally Skipped (22 fixed + up to 14 conditional)
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-m
 | `list_processes` | List read-only Huly Process workflow definitions. Optionally filter by the master tag/card type that workflows attach to. Returns process IDs, names, attached card type, automation flags, and state/transition counts. |
 | `get_process` | Get one Huly Process workflow definition by process ID or exact display name. If a name is ambiguous, the tool returns a typed error with candidate IDs instead of guessing. |
 | `list_process_executions` | List read-only Huly Process workflow executions. Supports filters by process ID/name, card/document ID/title, and status. Rows are enriched with process name, card title, and current state title when available. |
+| `start_process` | Start a new active Huly Process workflow execution on a card/document. Accepts process ID or exact process name, and card/document ID or exact title; ambiguous names or titles fail with candidate IDs. This is not idempotent: each successful call creates a new execution unless the process forbids parallel active executions for the same card, in which case the existing active execution ID is returned in a typed error. |
+| `cancel_execution` | Idempotently cancel one Huly Process execution by execution ID. Active executions are marked cancelled; already-cancelled executions succeed with cancelled=false; completed executions fail without changing history. |
 
 ### Tag-Categories
 

--- a/scripts/bootstrap-worktree.sh
+++ b/scripts/bootstrap-worktree.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Link ignored local resources from the canonical checkout into a secondary worktree.
+# Usage: bash scripts/bootstrap-worktree.sh [/path/to/master-checkout]
+set -euo pipefail
+
+MASTER_CHECKOUT="${1:-/workspace/typescript/hulymcp}"
+
+if [ ! -d "$MASTER_CHECKOUT" ]; then
+  echo "ERROR: master checkout not found: $MASTER_CHECKOUT" >&2
+  exit 1
+fi
+
+link_if_missing() {
+  local name="$1"
+  local source="$MASTER_CHECKOUT/$name"
+
+  if [ ! -e "$source" ]; then
+    echo "SKIP: $name (missing in $MASTER_CHECKOUT)"
+    return 0
+  fi
+
+  if [ -e "$name" ] || [ -L "$name" ]; then
+    echo "OK: $name already exists"
+    return 0
+  fi
+
+  ln -s "$source" "$name"
+  echo "LINK: $name -> $source"
+}
+
+link_if_missing "node_modules"
+link_if_missing ".reference"
+link_if_missing ".env.local"
+link_if_missing "CLAUDE.local.md"

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1545,16 +1545,67 @@ run_test "list_process_executions" \
 PROCESSES_TEXT=$(run_capture_only \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_processes","arguments":{}},"id":2}')
 PROCESS_ID=$(echo "$PROCESSES_TEXT" | jq -r '.processes[0].id // empty' 2>/dev/null)
+PROCESS_DETAIL_TEXT=""
 
 if [ -n "$PROCESS_ID" ]; then
   echo "  Using process: $PROCESS_ID"
   run_test "get_process($PROCESS_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_process\",\"arguments\":{\"process\":\"$PROCESS_ID\"}},\"id\":2}"
+  PROCESS_DETAIL_TEXT=$(run_capture_only \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_process\",\"arguments\":{\"process\":\"$PROCESS_ID\"}},\"id\":2}")
   run_test "list_process_executions(process:$PROCESS_ID)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_process_executions\",\"arguments\":{\"process\":\"$PROCESS_ID\",\"limit\":5}},\"id\":2}"
 else
   skip_test "get_process" "no process definitions found in workspace"
   skip_test "list_process_executions(process)" "no process definitions found in workspace"
+fi
+
+PROCESS_INITIAL_STATE=$(echo "$PROCESS_DETAIL_TEXT" | jq -r '.initialStateId // empty' 2>/dev/null)
+PROCESS_TYPE=$(echo "$PROCESS_DETAIL_TEXT" | jq -r '.masterTagName // .masterTagId // empty' 2>/dev/null)
+PROCESS_PARALLEL_FORBIDDEN=$(echo "$PROCESS_DETAIL_TEXT" | jq -r '.parallelExecutionForbidden // false' 2>/dev/null)
+SAFE_CARD_ID=""
+
+if [ -n "$PROCESS_ID" ] && [ -n "$PROCESS_INITIAL_STATE" ] && [ -n "$PROCESS_TYPE" ]; then
+  CARD_SPACES_TEXT=$(run_capture_only \
+    '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_card_spaces","arguments":{"limit":20}},"id":2}')
+  CARD_SPACE_COUNT=$(echo "$CARD_SPACES_TEXT" | jq -r '.cardSpaces | length' 2>/dev/null)
+  i=0
+  while [ "$i" -lt "${CARD_SPACE_COUNT:-0}" ] && [ -z "$SAFE_CARD_ID" ]; do
+    CARD_SPACE_NAME=$(echo "$CARD_SPACES_TEXT" | jq -r ".cardSpaces[$i].name // empty" 2>/dev/null)
+    if [ -n "$CARD_SPACE_NAME" ]; then
+      CARD_SPACE_JSON=$(json_string "$CARD_SPACE_NAME")
+      PROCESS_TYPE_JSON=$(json_string "$PROCESS_TYPE")
+      CARDS_TEXT=$(run_capture_only \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_cards\",\"arguments\":{\"cardSpace\":$CARD_SPACE_JSON,\"type\":$PROCESS_TYPE_JSON,\"limit\":1}},\"id\":2}")
+      SAFE_CARD_ID=$(echo "$CARDS_TEXT" | jq -r '.cards[0].id // empty' 2>/dev/null)
+    fi
+    i=$((i + 1))
+  done
+fi
+
+if [ -n "$PROCESS_ID" ] && [ -n "$PROCESS_INITIAL_STATE" ] && [ -n "$SAFE_CARD_ID" ]; then
+  if [ "$PROCESS_PARALLEL_FORBIDDEN" = "true" ]; then
+    EXISTING_ACTIVE=$(run_capture_only \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_process_executions\",\"arguments\":{\"process\":\"$PROCESS_ID\",\"card\":\"$SAFE_CARD_ID\",\"status\":\"active\",\"limit\":1}},\"id\":2}" | jq -r '.executions[0].id // empty' 2>/dev/null)
+  else
+    EXISTING_ACTIVE=""
+  fi
+
+  if [ -n "$EXISTING_ACTIVE" ]; then
+    skip_test "start_process/cancel_execution" "safe card already has an active execution and process forbids parallel executions"
+  else
+    START_TEXT=$(run_capture "start_process($PROCESS_ID,$SAFE_CARD_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"start_process\",\"arguments\":{\"process\":\"$PROCESS_ID\",\"card\":\"$SAFE_CARD_ID\"}},\"id\":2}")
+    STARTED_EXECUTION_ID=$(echo "$START_TEXT" | jq -r '.executionId // empty' 2>/dev/null)
+    if [ -n "$STARTED_EXECUTION_ID" ]; then
+      run_test "cancel_execution($STARTED_EXECUTION_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"cancel_execution\",\"arguments\":{\"execution\":\"$STARTED_EXECUTION_ID\"}},\"id\":2}"
+    else
+      skip_test "cancel_execution(started)" "start_process did not return an execution ID"
+    fi
+  fi
+else
+  skip_test "start_process/cancel_execution" "requires a process with an initial state and a matching safe card fixture"
 fi
 echo ""
 

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -198,6 +198,11 @@ export {
 } from "./cards.js"
 
 export {
+  type CancelExecutionParams,
+  cancelExecutionParamsJsonSchema,
+  CancelExecutionParamsSchema,
+  type CancelExecutionResult,
+  CancelExecutionResultSchema,
   type GetProcessParams,
   getProcessParamsJsonSchema,
   GetProcessParamsSchema,
@@ -211,9 +216,11 @@ export {
   ListProcessesParamsSchema,
   type ListProcessesResult,
   ListProcessesResultSchema,
+  parseCancelExecutionParams,
   parseGetProcessParams,
   parseListExecutionsParams,
   parseListProcessesParams,
+  parseStartProcessParams,
   type ProcessCandidate,
   ProcessCandidateSchema,
   ProcessCardIdentifier,
@@ -234,7 +241,12 @@ export {
   ProcessSummarySchema,
   ProcessTransitionId,
   type ProcessTransitionSummary,
-  ProcessTransitionSummarySchema
+  ProcessTransitionSummarySchema,
+  type StartProcessParams,
+  startProcessParamsJsonSchema,
+  StartProcessParamsSchema,
+  type StartProcessResult,
+  StartProcessResultSchema
 } from "./processes.js"
 
 export {

--- a/src/domain/schemas/processes.ts
+++ b/src/domain/schemas/processes.ts
@@ -137,6 +137,32 @@ export const ListExecutionsParamsSchema = Schema.Struct({
 })
 export type ListExecutionsParams = Schema.Schema.Type<typeof ListExecutionsParamsSchema>
 
+export const StartProcessParamsSchema = Schema.Struct({
+  process: ProcessIdentifier.annotations({
+    description:
+      "Process/workflow ID or exact display name. Ambiguous names fail with candidate IDs instead of guessing."
+  }),
+  card: ProcessCardIdentifier.annotations({
+    description:
+      "Card/document ID or exact title to attach the new execution to. If a title matches multiple cards, the call fails with candidates."
+  })
+}).annotations({
+  title: "StartProcessParams",
+  description: "Parameters for starting a Huly Process workflow execution on a card/document."
+})
+export type StartProcessParams = Schema.Schema.Type<typeof StartProcessParamsSchema>
+
+export const CancelExecutionParamsSchema = Schema.Struct({
+  execution: ProcessExecutionId.annotations({
+    description:
+      "Process execution ID to cancel. Already-cancelled executions return cancelled=false; completed executions fail without mutation."
+  })
+}).annotations({
+  title: "CancelExecutionParams",
+  description: "Parameters for cancelling an active Huly Process workflow execution."
+})
+export type CancelExecutionParams = Schema.Schema.Type<typeof CancelExecutionParamsSchema>
+
 export const ListProcessesResultSchema = Schema.Struct({
   processes: Schema.Array(ProcessSummarySchema),
   total: Schema.NonNegativeInt
@@ -149,10 +175,33 @@ export const ListExecutionsResultSchema = Schema.Struct({
 })
 export type ListExecutionsResult = Schema.Schema.Type<typeof ListExecutionsResultSchema>
 
+export const StartProcessResultSchema = Schema.Struct({
+  executionId: ProcessExecutionId,
+  processId: ProcessId,
+  processName: Schema.optional(NonEmptyString),
+  cardId: CardId,
+  cardTitle: Schema.optional(NonEmptyString),
+  currentStateId: ProcessStateId,
+  currentStateTitle: Schema.optional(NonEmptyString),
+  status: Schema.Literal("active")
+})
+export type StartProcessResult = Schema.Schema.Type<typeof StartProcessResultSchema>
+
+export const CancelExecutionResultSchema = Schema.Struct({
+  executionId: ProcessExecutionId,
+  status: Schema.Literal("cancelled"),
+  cancelled: Schema.Boolean
+})
+export type CancelExecutionResult = Schema.Schema.Type<typeof CancelExecutionResultSchema>
+
 export const listProcessesParamsJsonSchema = JSONSchema.make(ListProcessesParamsSchema)
 export const getProcessParamsJsonSchema = JSONSchema.make(GetProcessParamsSchema)
 export const listExecutionsParamsJsonSchema = JSONSchema.make(ListExecutionsParamsSchema)
+export const startProcessParamsJsonSchema = JSONSchema.make(StartProcessParamsSchema)
+export const cancelExecutionParamsJsonSchema = JSONSchema.make(CancelExecutionParamsSchema)
 
 export const parseListProcessesParams = Schema.decodeUnknown(ListProcessesParamsSchema)
 export const parseGetProcessParams = Schema.decodeUnknown(GetProcessParamsSchema)
 export const parseListExecutionsParams = Schema.decodeUnknown(ListExecutionsParamsSchema)
+export const parseStartProcessParams = Schema.decodeUnknown(StartProcessParamsSchema)
+export const parseCancelExecutionParams = Schema.decodeUnknown(CancelExecutionParamsSchema)

--- a/src/huly/errors-processes.ts
+++ b/src/huly/errors-processes.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 
-import { ProcessCandidateSchema } from "../domain/schemas/processes.js"
+import { ProcessCandidateSchema, ProcessExecutionId, ProcessId } from "../domain/schemas/processes.js"
 import { CardId, MasterTagId, NonEmptyString } from "../domain/schemas/shared.js"
 
 const candidateList = (
@@ -90,5 +90,55 @@ export class ProcessCardNotFoundError extends Schema.TaggedError<ProcessCardNotF
 ) {
   override get message(): string {
     return `Card/document '${this.identifier}' not found`
+  }
+}
+
+export class ProcessInitialStateNotFoundError extends Schema.TaggedError<ProcessInitialStateNotFoundError>()(
+  "ProcessInitialStateNotFoundError",
+  {
+    processId: ProcessId,
+    processName: NonEmptyString
+  }
+) {
+  override get message(): string {
+    return `Process '${this.processName}' (${this.processId}) has no initial transition from null`
+  }
+}
+
+export class ProcessParallelExecutionForbiddenError
+  extends Schema.TaggedError<ProcessParallelExecutionForbiddenError>()(
+    "ProcessParallelExecutionForbiddenError",
+    {
+      processId: ProcessId,
+      cardId: CardId,
+      activeExecutionId: ProcessExecutionId
+    }
+  )
+{
+  override get message(): string {
+    return `Process '${this.processId}' already has active execution '${this.activeExecutionId}' for card '${this.cardId}'`
+  }
+}
+
+export class ProcessExecutionNotFoundError extends Schema.TaggedError<ProcessExecutionNotFoundError>()(
+  "ProcessExecutionNotFoundError",
+  {
+    executionId: ProcessExecutionId
+  }
+) {
+  override get message(): string {
+    return `Process execution '${this.executionId}' not found`
+  }
+}
+
+export class ProcessExecutionNotCancellableError extends Schema.TaggedError<ProcessExecutionNotCancellableError>()(
+  "ProcessExecutionNotCancellableError",
+  {
+    executionId: ProcessExecutionId,
+    status: Schema.Literal("done")
+  }
+) {
+  override get message(): string {
+    return `Process execution '${this.executionId}' is completed and cannot be cancelled`
   }
 }

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -76,10 +76,14 @@ import { NotificationContextNotFoundError, NotificationNotFoundError } from "./e
 import {
   ProcessCardIdentifierAmbiguousError,
   ProcessCardNotFoundError,
+  ProcessExecutionNotCancellableError,
+  ProcessExecutionNotFoundError,
   ProcessIdentifierAmbiguousError,
+  ProcessInitialStateNotFoundError,
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
-  ProcessNotFoundError
+  ProcessNotFoundError,
+  ProcessParallelExecutionForbiddenError
 } from "./errors-processes.js"
 import {
   TestCaseNotFoundError,
@@ -154,10 +158,14 @@ export {
   PersonNotFoundError,
   ProcessCardIdentifierAmbiguousError,
   ProcessCardNotFoundError,
+  ProcessExecutionNotCancellableError,
+  ProcessExecutionNotFoundError,
   ProcessIdentifierAmbiguousError,
+  ProcessInitialStateNotFoundError,
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
   ProcessNotFoundError,
+  ProcessParallelExecutionForbiddenError,
   ProjectNotFoundError,
   ReactionNotFoundError,
   RecurringEventNotFoundError,
@@ -250,6 +258,10 @@ export type HulyDomainError =
   | ProcessMasterTagNotFoundError
   | ProcessCardIdentifierAmbiguousError
   | ProcessCardNotFoundError
+  | ProcessInitialStateNotFoundError
+  | ProcessParallelExecutionForbiddenError
+  | ProcessExecutionNotFoundError
+  | ProcessExecutionNotCancellableError
   | AssociationNotFoundError
   | AssociationIdentifierAmbiguousError
   | RelationNotFoundError
@@ -331,6 +343,10 @@ export const HulyDomainError: Schema.Union<
     typeof ProcessMasterTagNotFoundError,
     typeof ProcessCardIdentifierAmbiguousError,
     typeof ProcessCardNotFoundError,
+    typeof ProcessInitialStateNotFoundError,
+    typeof ProcessParallelExecutionForbiddenError,
+    typeof ProcessExecutionNotFoundError,
+    typeof ProcessExecutionNotCancellableError,
     typeof AssociationNotFoundError,
     typeof AssociationIdentifierAmbiguousError,
     typeof RelationNotFoundError,
@@ -408,6 +424,10 @@ export const HulyDomainError: Schema.Union<
   ProcessMasterTagNotFoundError,
   ProcessCardIdentifierAmbiguousError,
   ProcessCardNotFoundError,
+  ProcessInitialStateNotFoundError,
+  ProcessParallelExecutionForbiddenError,
+  ProcessExecutionNotFoundError,
+  ProcessExecutionNotCancellableError,
   AssociationNotFoundError,
   AssociationIdentifierAmbiguousError,
   RelationNotFoundError,

--- a/src/huly/operations/processes.ts
+++ b/src/huly/operations/processes.ts
@@ -1,9 +1,12 @@
+/* eslint-disable max-lines -- Process read/write operations share resolver and enrichment helpers in one module */
 import type { Card, MasterTag, Tag } from "@hcengineering/card"
-import type { DocumentQuery, Ref } from "@hcengineering/core"
-import { SortingOrder } from "@hcengineering/core"
+import type { Data, DocumentQuery, DocumentUpdate, Ref, Space } from "@hcengineering/core"
+import { generateId, SortingOrder } from "@hcengineering/core"
 import { Effect, Schema } from "effect"
 
 import type {
+  CancelExecutionParams,
+  CancelExecutionResult,
   GetProcessParams,
   ListExecutionsParams,
   ListExecutionsResult,
@@ -13,16 +16,20 @@ import type {
   ProcessDetail,
   ProcessExecutionSummary,
   ProcessSummary,
-  ProcessTransitionSummary
+  ProcessTransitionSummary,
+  StartProcessParams,
+  StartProcessResult
 } from "../../domain/schemas.js"
 import {
+  CancelExecutionResultSchema,
   ListExecutionsResultSchema,
   ListProcessesResultSchema,
   ProcessDetailSchema,
   ProcessExecutionId,
   ProcessId,
   ProcessStateId,
-  ProcessTransitionId
+  ProcessTransitionId,
+  StartProcessResultSchema
 } from "../../domain/schemas.js"
 import { CardId, MasterTagId } from "../../domain/schemas/shared.js"
 import { normalizeForComparison } from "../../utils/normalize.js"
@@ -31,12 +38,16 @@ import {
   HulyConnectionError,
   ProcessCardIdentifierAmbiguousError,
   ProcessCardNotFoundError,
+  ProcessExecutionNotCancellableError,
+  ProcessExecutionNotFoundError,
   ProcessIdentifierAmbiguousError,
+  ProcessInitialStateNotFoundError,
   ProcessMasterTagAmbiguousError,
   ProcessMasterTagNotFoundError,
-  ProcessNotFoundError
+  ProcessNotFoundError,
+  ProcessParallelExecutionForbiddenError
 } from "../errors.js"
-import { cardPlugin } from "../huly-plugins.js"
+import { cardPlugin, core } from "../huly-plugins.js"
 import {
   type HulyProcessDefinition,
   type HulyProcessExecution,
@@ -56,6 +67,10 @@ type ProcessOperationError =
   | ProcessMasterTagAmbiguousError
   | ProcessCardIdentifierAmbiguousError
   | ProcessCardNotFoundError
+  | ProcessInitialStateNotFoundError
+  | ProcessParallelExecutionForbiddenError
+  | ProcessExecutionNotFoundError
+  | ProcessExecutionNotCancellableError
 
 interface MasterTagDisplay {
   readonly id: Ref<MasterTag | Tag>
@@ -179,11 +194,18 @@ const transitionSummary = (
   actionCount: transition.actions.length
 })
 
+const initialTransition = (
+  transitions: ReadonlyArray<HulyProcessTransition>
+): HulyProcessTransition | undefined =>
+  [...transitions].filter((transition) => transition.from === null).sort((a, b) =>
+    String(a.rank).localeCompare(String(b.rank))
+  )[0]
+
 const initialStateId = (
   transitions: ReadonlyArray<HulyProcessTransition>
 ): ProcessStateId | undefined => {
-  const initialTransition = transitions.find((transition) => transition.from === null)
-  return initialTransition === undefined ? undefined : ProcessStateId.make(initialTransition.to)
+  const transition = initialTransition(transitions)
+  return transition === undefined ? undefined : ProcessStateId.make(transition.to)
 }
 
 const processDetail = (data: ProcessDetailData): ProcessDetail => {
@@ -331,6 +353,41 @@ const executionSummary = (
   modifiedOn: execution.modifiedOn
 })
 
+const startProcessResult = (
+  executionId: Ref<HulyProcessExecution>,
+  process: HulyProcessDefinition,
+  card: Card,
+  currentState: HulyProcessState
+): StartProcessResult => ({
+  executionId: ProcessExecutionId.make(executionId),
+  processId: ProcessId.make(process._id),
+  processName: process.name,
+  cardId: CardId.make(card._id),
+  cardTitle: card.title,
+  currentStateId: ProcessStateId.make(currentState._id),
+  currentStateTitle: currentState.title,
+  status: "active"
+})
+
+const findExecutionOrFail = (
+  client: HulyClientOperations,
+  executionId: ProcessExecutionId
+): Effect.Effect<HulyProcessExecution, HulyClientError | ProcessExecutionNotFoundError> =>
+  client.findOne<HulyProcessExecution>(
+    processPlugin.class.Execution,
+    { _id: toRef<HulyProcessExecution>(executionId) }
+  ).pipe(
+    Effect.flatMap((execution) =>
+      execution === undefined
+        ? Effect.fail(
+          new ProcessExecutionNotFoundError({
+            executionId: ProcessExecutionId.make(executionId)
+          })
+        )
+        : Effect.succeed(execution)
+    )
+  )
+
 export const listProcesses = (
   params: ListProcessesParams
 ): Effect.Effect<ListProcessesResult, ProcessOperationError, HulyClient> =>
@@ -411,4 +468,127 @@ export const listExecutions = (
       total: executions.length
     }
     return yield* encodeOrConnectionError(ListExecutionsResultSchema, result, "listExecutions")
+  })
+
+export const startProcess = (
+  params: StartProcessParams
+): Effect.Effect<StartProcessResult, ProcessOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const process = yield* resolveProcess(client, params.process)
+    const cardId = yield* resolveCardFilter(client, params.card)
+    const card = yield* client.findOne<Card>(cardPlugin.class.Card, { _id: cardId })
+
+    if (card === undefined) {
+      return yield* Effect.fail(new ProcessCardNotFoundError({ identifier: params.card }))
+    }
+
+    const transitions = yield* client.findAll<HulyProcessTransition>(
+      processPlugin.class.Transition,
+      { process: process._id },
+      { sort: { rank: SortingOrder.Ascending } }
+    )
+    const transition = initialTransition(transitions)
+    if (transition === undefined) {
+      return yield* Effect.fail(
+        new ProcessInitialStateNotFoundError({
+          processId: ProcessId.make(process._id),
+          processName: process.name
+        })
+      )
+    }
+
+    const currentState = yield* client.findOne<HulyProcessState>(
+      processPlugin.class.State,
+      { _id: transition.to }
+    )
+    if (currentState === undefined) {
+      return yield* Effect.fail(
+        new ProcessInitialStateNotFoundError({
+          processId: ProcessId.make(process._id),
+          processName: process.name
+        })
+      )
+    }
+
+    if (process.parallelExecutionForbidden === true) {
+      const activeExecution = yield* client.findOne<HulyProcessExecution>(
+        processPlugin.class.Execution,
+        {
+          process: process._id,
+          card: card._id,
+          status: "active"
+        }
+      )
+      if (activeExecution !== undefined) {
+        return yield* Effect.fail(
+          new ProcessParallelExecutionForbiddenError({
+            processId: ProcessId.make(process._id),
+            cardId: CardId.make(card._id),
+            activeExecutionId: ProcessExecutionId.make(activeExecution._id)
+          })
+        )
+      }
+    }
+
+    const executionId: Ref<HulyProcessExecution> = generateId()
+    const executionData: Data<HulyProcessExecution> = {
+      process: process._id,
+      card: card._id,
+      currentState: currentState._id,
+      rollback: [],
+      context: {},
+      status: "active"
+    }
+
+    yield* client.createDoc(
+      processPlugin.class.Execution,
+      toRef<Space>(core.space.Workspace),
+      executionData,
+      executionId
+    )
+
+    const result = startProcessResult(executionId, process, card, currentState)
+    return yield* encodeOrConnectionError(StartProcessResultSchema, result, "startProcess")
+  })
+
+export const cancelExecution = (
+  params: CancelExecutionParams
+): Effect.Effect<CancelExecutionResult, ProcessOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const execution = yield* findExecutionOrFail(client, params.execution)
+
+    if (execution.status === "cancelled") {
+      const result: CancelExecutionResult = {
+        executionId: ProcessExecutionId.make(execution._id),
+        status: "cancelled",
+        cancelled: false
+      }
+      return yield* encodeOrConnectionError(CancelExecutionResultSchema, result, "cancelExecution")
+    }
+
+    if (execution.status === "done") {
+      return yield* Effect.fail(
+        new ProcessExecutionNotCancellableError({
+          executionId: ProcessExecutionId.make(execution._id),
+          status: "done"
+        })
+      )
+    }
+
+    const update: DocumentUpdate<HulyProcessExecution> = { status: "cancelled" }
+    yield* client.updateDoc(
+      processPlugin.class.Execution,
+      execution.space,
+      execution._id,
+      update
+    )
+
+    const result: CancelExecutionResult = {
+      executionId: ProcessExecutionId.make(execution._id),
+      status: "cancelled",
+      cancelled: true
+    }
+    return yield* encodeOrConnectionError(CancelExecutionResultSchema, result, "cancelExecution")
   })

--- a/src/mcp/tools/processes.ts
+++ b/src/mcp/tools/processes.ts
@@ -1,15 +1,27 @@
 import {
+  cancelExecutionParamsJsonSchema,
+  CancelExecutionResultSchema,
   getProcessParamsJsonSchema,
   listExecutionsParamsJsonSchema,
   ListExecutionsResultSchema,
   listProcessesParamsJsonSchema,
   ListProcessesResultSchema,
+  parseCancelExecutionParams,
   parseGetProcessParams,
   parseListExecutionsParams,
   parseListProcessesParams,
-  ProcessDetailSchema
+  parseStartProcessParams,
+  ProcessDetailSchema,
+  startProcessParamsJsonSchema,
+  StartProcessResultSchema
 } from "../../domain/schemas.js"
-import { getProcess, listExecutions, listProcesses } from "../../huly/operations/processes.js"
+import {
+  cancelExecution,
+  getProcess,
+  listExecutions,
+  listProcesses,
+  startProcess
+} from "../../huly/operations/processes.js"
 import { createEncodedToolHandler, type RegisteredTool } from "./registry.js"
 
 const CATEGORY = "processes" as const
@@ -52,6 +64,44 @@ export const processTools: ReadonlyArray<RegisteredTool> = [
       parseListExecutionsParams,
       listExecutions,
       ListExecutionsResultSchema
+    )
+  },
+  {
+    name: "start_process",
+    description:
+      "Start a new active Huly Process workflow execution on a card/document. Accepts process ID or exact process name, and card/document ID or exact title; ambiguous names or titles fail with candidate IDs. This is not idempotent: each successful call creates a new execution unless the process forbids parallel active executions for the same card, in which case the existing active execution ID is returned in a typed error.",
+    category: CATEGORY,
+    inputSchema: startProcessParamsJsonSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false
+    },
+    handler: createEncodedToolHandler(
+      "start_process",
+      parseStartProcessParams,
+      startProcess,
+      StartProcessResultSchema
+    )
+  },
+  {
+    name: "cancel_execution",
+    description:
+      "Idempotently cancel one Huly Process execution by execution ID. Active executions are marked cancelled; already-cancelled executions succeed with cancelled=false; completed executions fail without changing history.",
+    category: CATEGORY,
+    inputSchema: cancelExecutionParamsJsonSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    },
+    handler: createEncodedToolHandler(
+      "cancel_execution",
+      parseCancelExecutionParams,
+      cancelExecution,
+      CancelExecutionResultSchema
     )
   }
 ]

--- a/test/domain/schemas.test.ts
+++ b/test/domain/schemas.test.ts
@@ -3,6 +3,7 @@ import { Effect, Schema } from "effect"
 import { expect } from "vitest"
 import {
   addLabelParamsJsonSchema,
+  cancelExecutionParamsJsonSchema,
   createDocumentParamsJsonSchema,
   createIssueParamsJsonSchema,
   deleteDocumentParamsJsonSchema,
@@ -19,6 +20,7 @@ import {
   listTeamspacesParamsJsonSchema,
   logTimeParamsJsonSchema,
   parseAddLabelParams,
+  parseCancelExecutionParams,
   parseCreateDocumentParams,
   parseCreateIssueParams,
   parseDeleteDocumentParams,
@@ -35,9 +37,11 @@ import {
   parseListTimeSpendReportsParams,
   parseLogTimeParams,
   parseProject,
+  parseStartProcessParams,
   parseStartTimerParams,
   parseStopTimerParams,
   parseUpdateIssueParams,
+  startProcessParamsJsonSchema,
   startTimerParamsJsonSchema,
   stopTimerParamsJsonSchema,
   updateIssueParamsJsonSchema
@@ -165,6 +169,39 @@ describe("Domain Schemas", () => {
           name: "John Doe",
           email: "john@example.com"
         })
+      }))
+  })
+
+  describe("Process write schemas", () => {
+    it.effect("parses start_process params and exposes required JSON schema fields", () =>
+      Effect.gen(function*() {
+        const parsed = yield* parseStartProcessParams({
+          process: "Approval",
+          card: "Contract"
+        })
+        expect(parsed).toEqual({
+          process: "Approval",
+          card: "Contract"
+        })
+
+        const schema = startProcessParamsJsonSchema as JsonSchemaObject
+        expect(schema.required).toEqual(["process", "card"])
+        expect(schema.properties?.process).toBeDefined()
+        expect(schema.properties?.card).toBeDefined()
+      }))
+
+    it.effect("parses cancel_execution params and exposes required JSON schema fields", () =>
+      Effect.gen(function*() {
+        const parsed = yield* parseCancelExecutionParams({
+          execution: "execution-1"
+        })
+        expect(parsed).toEqual({
+          execution: "execution-1"
+        })
+
+        const schema = cancelExecutionParamsJsonSchema as JsonSchemaObject
+        expect(schema.required).toEqual(["execution"])
+        expect(schema.properties?.execution).toBeDefined()
       }))
   })
 

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -787,6 +787,14 @@ describe("Huly Errors", () => {
               return `process-card-ambiguous:${error.identifier}:${error.candidates.length}`
             case "ProcessCardNotFoundError":
               return `process-card:${error.identifier}`
+            case "ProcessInitialStateNotFoundError":
+              return `process-initial-state:${error.processId}`
+            case "ProcessParallelExecutionForbiddenError":
+              return `process-parallel-forbidden:${error.processId}:${error.cardId}:${error.activeExecutionId}`
+            case "ProcessExecutionNotFoundError":
+              return `process-execution:${error.executionId}`
+            case "ProcessExecutionNotCancellableError":
+              return `process-execution-not-cancellable:${error.executionId}:${error.status}`
             case "AssociationNotFoundError":
               return `association:${error.identifier}`
             case "AssociationIdentifierAmbiguousError":

--- a/test/huly/operations/processes.test.ts
+++ b/test/huly/operations/processes.test.ts
@@ -1,15 +1,26 @@
 import { describe, it } from "@effect/vitest"
 import type { Card, MasterTag } from "@hcengineering/card"
-import type { Class, Doc, DocumentQuery, PersonId, Ref } from "@hcengineering/core"
+import type { Class, Doc, DocumentQuery, PersonId, Ref, Space } from "@hcengineering/core"
 import { toFindResult } from "@hcengineering/core"
 import type { IntlString } from "@hcengineering/platform"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
-import { ProcessCardIdentifier, ProcessIdentifier, ProcessMasterTagIdentifier } from "../../../src/domain/schemas.js"
+import {
+  ProcessCardIdentifier,
+  ProcessExecutionId,
+  ProcessIdentifier,
+  ProcessMasterTagIdentifier
+} from "../../../src/domain/schemas.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import { cardPlugin, core } from "../../../src/huly/huly-plugins.js"
-import { getProcess, listExecutions, listProcesses } from "../../../src/huly/operations/processes.js"
+import {
+  cancelExecution,
+  getProcess,
+  listExecutions,
+  listProcesses,
+  startProcess
+} from "../../../src/huly/operations/processes.js"
 import {
   type HulyProcessDefinition,
   type HulyProcessExecution,
@@ -149,6 +160,18 @@ const createLayer = (config?: {
   readonly cards?: ReadonlyArray<Card>
   readonly masterTags?: ReadonlyArray<MasterTag>
   readonly total?: number
+  readonly captureCreateDoc?: {
+    class?: unknown
+    space?: unknown
+    attributes?: unknown
+    id?: string
+  }
+  readonly captureUpdateDoc?: {
+    class?: unknown
+    space?: unknown
+    objectId?: string
+    operations?: unknown
+  }
 }) => {
   const processes = config?.processes ?? [makeProcess()]
   const states = config?.states ?? [
@@ -200,9 +223,41 @@ const createLayer = (config?: {
     query: DocumentQuery<T>
   ) => findAllImpl<T>(_class, query).pipe(Effect.map((items) => items[0]))) as HulyClientOperations["findOne"]
 
+  const createDocImpl: HulyClientOperations["createDoc"] = ((
+    _class: unknown,
+    space: Ref<Space>,
+    attributes: unknown,
+    id?: unknown
+  ) => {
+    if (config?.captureCreateDoc !== undefined) {
+      config.captureCreateDoc.class = _class
+      config.captureCreateDoc.space = space
+      config.captureCreateDoc.attributes = attributes
+      config.captureCreateDoc.id = String(id)
+    }
+    return Effect.succeed((id ?? "execution-new") as Ref<Doc>)
+  }) as HulyClientOperations["createDoc"]
+
+  const updateDocImpl: HulyClientOperations["updateDoc"] = ((
+    _class: unknown,
+    space: Ref<Space>,
+    objectId: unknown,
+    operations: unknown
+  ) => {
+    if (config?.captureUpdateDoc !== undefined) {
+      config.captureUpdateDoc.class = _class
+      config.captureUpdateDoc.space = space
+      config.captureUpdateDoc.objectId = String(objectId)
+      config.captureUpdateDoc.operations = operations
+    }
+    return Effect.succeed({})
+  }) as HulyClientOperations["updateDoc"]
+
   return HulyClient.testLayer({
     findAll: findAllImpl,
-    findOne: findOneImpl
+    findOne: findOneImpl,
+    createDoc: createDocImpl,
+    updateDoc: updateDocImpl
   })
 }
 
@@ -425,6 +480,229 @@ describe("process operations", () => {
       expect(result._tag).toBe("Left")
       if (result._tag === "Left") {
         expect(result.left._tag).toBe("ProcessCardNotFoundError")
+      }
+    }))
+
+  it.effect("starts a process by process ID and card ID", () =>
+    Effect.gen(function*() {
+      const capture: {
+        class?: unknown
+        space?: unknown
+        attributes?: unknown
+        id?: string
+      } = {}
+      const result = yield* startProcess({
+        process: ProcessIdentifier.make(processId),
+        card: ProcessCardIdentifier.make(cardId)
+      }).pipe(Effect.provide(createLayer({ executions: [], captureCreateDoc: capture })))
+
+      expect(result).toMatchObject({
+        processId,
+        processName: "Approval",
+        cardId,
+        cardTitle: "Contract",
+        currentStateId: initStateId,
+        currentStateTitle: "Draft",
+        status: "active"
+      })
+      expect(result.executionId).toBe(capture.id)
+      expect(capture.class).toBe(processPlugin.class.Execution)
+      expect(capture.space).toBe(core.space.Workspace)
+      expect(capture.attributes).toEqual({
+        process: processId,
+        card: cardId,
+        currentState: initStateId,
+        rollback: [],
+        context: {},
+        status: "active"
+      })
+    }))
+
+  it.effect("starts a process by process name and card title", () =>
+    Effect.gen(function*() {
+      const result = yield* startProcess({
+        process: ProcessIdentifier.make("approval"),
+        card: ProcessCardIdentifier.make("Contract")
+      }).pipe(Effect.provide(createLayer({ executions: [] })))
+
+      expect(result.processId).toBe(processId)
+      expect(result.cardId).toBe(cardId)
+      expect(result.currentStateId).toBe(initStateId)
+    }))
+
+  it.effect("uses the lowest-rank null transition as the initial process state", () =>
+    Effect.gen(function*() {
+      const earliestStateId = "state-earliest" as Ref<HulyProcessState>
+      const capture: {
+        attributes?: unknown
+      } = {}
+      const result = yield* startProcess({
+        process: ProcessIdentifier.make(processId),
+        card: ProcessCardIdentifier.make(cardId)
+      }).pipe(Effect.provide(createLayer({
+        executions: [],
+        states: [
+          makeState({ _id: earliestStateId, title: "Earliest", rank: "0" }),
+          makeState()
+        ],
+        transitions: [
+          makeInitialTransition({ _id: "transition-late" as Ref<HulyProcessTransition>, to: initStateId, rank: "z" }),
+          makeInitialTransition({
+            _id: "transition-early" as Ref<HulyProcessTransition>,
+            to: earliestStateId,
+            rank: "a"
+          })
+        ],
+        captureCreateDoc: capture
+      })))
+
+      expect(result.currentStateId).toBe(earliestStateId)
+      expect(result.currentStateTitle).toBe("Earliest")
+      expect(capture.attributes).toMatchObject({ currentState: earliestStateId })
+    }))
+
+  it.effect("fails start_process when the process has no initial transition", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        startProcess({
+          process: ProcessIdentifier.make(processId),
+          card: ProcessCardIdentifier.make(cardId)
+        }).pipe(Effect.provide(createLayer({
+          transitions: [makeTransition()],
+          executions: []
+        })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessInitialStateNotFoundError")
+      }
+    }))
+
+  it.effect("fails start_process when parallel execution is forbidden and an active execution exists", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        startProcess({
+          process: ProcessIdentifier.make(processId),
+          card: ProcessCardIdentifier.make(cardId)
+        }).pipe(Effect.provide(createLayer({
+          processes: [makeProcess({ parallelExecutionForbidden: true })],
+          executions: [makeExecution({ currentState: initStateId, status: "active" })]
+        })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessParallelExecutionForbiddenError")
+        expect(result.left.message).toContain("execution-1")
+      }
+    }))
+
+  it.effect("fails start_process for ambiguous card titles", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        startProcess({
+          process: ProcessIdentifier.make(processId),
+          card: ProcessCardIdentifier.make("Contract")
+        }).pipe(Effect.provide(createLayer({
+          executions: [],
+          cards: [
+            makeCard(),
+            makeCard({ _id: "card-2" as Ref<Card> })
+          ]
+        })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessCardIdentifierAmbiguousError")
+      }
+    }))
+
+  it.effect("fails start_process for missing card titles", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        startProcess({
+          process: ProcessIdentifier.make(processId),
+          card: ProcessCardIdentifier.make("Missing Contract")
+        }).pipe(Effect.provide(createLayer({ executions: [] })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessCardNotFoundError")
+      }
+    }))
+
+  it.effect("cancels an active execution", () =>
+    Effect.gen(function*() {
+      const capture: {
+        class?: unknown
+        space?: unknown
+        objectId?: string
+        operations?: unknown
+      } = {}
+      const result = yield* cancelExecution({
+        execution: ProcessExecutionId.make("execution-1")
+      }).pipe(Effect.provide(createLayer({ captureUpdateDoc: capture })))
+
+      expect(result).toEqual({
+        executionId: "execution-1",
+        status: "cancelled",
+        cancelled: true
+      })
+      expect(capture.class).toBe(processPlugin.class.Execution)
+      expect(capture.objectId).toBe("execution-1")
+      expect(capture.operations).toEqual({ status: "cancelled" })
+    }))
+
+  it.effect("returns cancelled=false for already-cancelled executions without updating", () =>
+    Effect.gen(function*() {
+      const capture: {
+        operations?: unknown
+      } = {}
+      const result = yield* cancelExecution({
+        execution: ProcessExecutionId.make("execution-1")
+      }).pipe(Effect.provide(createLayer({
+        executions: [makeExecution({ status: "cancelled" })],
+        captureUpdateDoc: capture
+      })))
+
+      expect(result).toEqual({
+        executionId: "execution-1",
+        status: "cancelled",
+        cancelled: false
+      })
+      expect(capture.operations).toBeUndefined()
+    }))
+
+  it.effect("fails cancel_execution for missing executions", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        cancelExecution({
+          execution: ProcessExecutionId.make("execution-missing")
+        }).pipe(Effect.provide(createLayer({ executions: [] })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessExecutionNotFoundError")
+      }
+    }))
+
+  it.effect("fails cancel_execution for completed executions", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.either(
+        cancelExecution({
+          execution: ProcessExecutionId.make("execution-1")
+        }).pipe(Effect.provide(createLayer({
+          executions: [makeExecution({ status: "done" })]
+        })))
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left._tag).toBe("ProcessExecutionNotCancellableError")
       }
     }))
 })

--- a/test/huly/operations/processes.test.ts
+++ b/test/huly/operations/processes.test.ts
@@ -48,6 +48,20 @@ const asCard = (value: unknown): Card => value as Card
 const asMasterTag = (value: unknown): MasterTag => value as MasterTag
 const asIntlString = (value: string): IntlString => value as IntlString
 
+interface CreateDocCall {
+  readonly class: unknown
+  readonly space: Ref<Space>
+  readonly attributes: unknown
+  readonly id?: string
+}
+
+interface UpdateDocCall {
+  readonly class: unknown
+  readonly space: Ref<Space>
+  readonly objectId: string
+  readonly operations: unknown
+}
+
 const makeProcess = (overrides?: Partial<HulyProcessDefinition>): HulyProcessDefinition =>
   asProcess({
     _id: processId,
@@ -160,18 +174,8 @@ const createLayer = (config?: {
   readonly cards?: ReadonlyArray<Card>
   readonly masterTags?: ReadonlyArray<MasterTag>
   readonly total?: number
-  readonly captureCreateDoc?: {
-    class?: unknown
-    space?: unknown
-    attributes?: unknown
-    id?: string
-  }
-  readonly captureUpdateDoc?: {
-    class?: unknown
-    space?: unknown
-    objectId?: string
-    operations?: unknown
-  }
+  readonly createDocCalls?: Array<CreateDocCall>
+  readonly updateDocCalls?: Array<UpdateDocCall>
 }) => {
   const processes = config?.processes ?? [makeProcess()]
   const states = config?.states ?? [
@@ -229,12 +233,20 @@ const createLayer = (config?: {
     attributes: unknown,
     id?: unknown
   ) => {
-    if (config?.captureCreateDoc !== undefined) {
-      config.captureCreateDoc.class = _class
-      config.captureCreateDoc.space = space
-      config.captureCreateDoc.attributes = attributes
-      config.captureCreateDoc.id = String(id)
-    }
+    config?.createDocCalls?.push(
+      id === undefined
+        ? {
+          class: _class,
+          space,
+          attributes
+        }
+        : {
+          class: _class,
+          space,
+          attributes,
+          id: String(id)
+        }
+    )
     return Effect.succeed((id ?? "execution-new") as Ref<Doc>)
   }) as HulyClientOperations["createDoc"]
 
@@ -244,12 +256,12 @@ const createLayer = (config?: {
     objectId: unknown,
     operations: unknown
   ) => {
-    if (config?.captureUpdateDoc !== undefined) {
-      config.captureUpdateDoc.class = _class
-      config.captureUpdateDoc.space = space
-      config.captureUpdateDoc.objectId = String(objectId)
-      config.captureUpdateDoc.operations = operations
-    }
+    config?.updateDocCalls?.push({
+      class: _class,
+      space,
+      objectId: String(objectId),
+      operations
+    })
     return Effect.succeed({})
   }) as HulyClientOperations["updateDoc"]
 
@@ -485,16 +497,11 @@ describe("process operations", () => {
 
   it.effect("starts a process by process ID and card ID", () =>
     Effect.gen(function*() {
-      const capture: {
-        class?: unknown
-        space?: unknown
-        attributes?: unknown
-        id?: string
-      } = {}
+      const createDocCalls: Array<CreateDocCall> = []
       const result = yield* startProcess({
         process: ProcessIdentifier.make(processId),
         card: ProcessCardIdentifier.make(cardId)
-      }).pipe(Effect.provide(createLayer({ executions: [], captureCreateDoc: capture })))
+      }).pipe(Effect.provide(createLayer({ executions: [], createDocCalls })))
 
       expect(result).toMatchObject({
         processId,
@@ -505,10 +512,11 @@ describe("process operations", () => {
         currentStateTitle: "Draft",
         status: "active"
       })
-      expect(result.executionId).toBe(capture.id)
-      expect(capture.class).toBe(processPlugin.class.Execution)
-      expect(capture.space).toBe(core.space.Workspace)
-      expect(capture.attributes).toEqual({
+      const [createdExecution] = createDocCalls
+      expect(result.executionId).toBe(createdExecution.id)
+      expect(createdExecution.class).toBe(processPlugin.class.Execution)
+      expect(createdExecution.space).toBe(core.space.Workspace)
+      expect(createdExecution.attributes).toEqual({
         process: processId,
         card: cardId,
         currentState: initStateId,
@@ -533,9 +541,7 @@ describe("process operations", () => {
   it.effect("uses the lowest-rank null transition as the initial process state", () =>
     Effect.gen(function*() {
       const earliestStateId = "state-earliest" as Ref<HulyProcessState>
-      const capture: {
-        attributes?: unknown
-      } = {}
+      const createDocCalls: Array<CreateDocCall> = []
       const result = yield* startProcess({
         process: ProcessIdentifier.make(processId),
         card: ProcessCardIdentifier.make(cardId)
@@ -553,12 +559,12 @@ describe("process operations", () => {
             rank: "a"
           })
         ],
-        captureCreateDoc: capture
+        createDocCalls
       })))
 
       expect(result.currentStateId).toBe(earliestStateId)
       expect(result.currentStateTitle).toBe("Earliest")
-      expect(capture.attributes).toMatchObject({ currentState: earliestStateId })
+      expect(createDocCalls[0].attributes).toMatchObject({ currentState: earliestStateId })
     }))
 
   it.effect("fails start_process when the process has no initial transition", () =>
@@ -636,36 +642,30 @@ describe("process operations", () => {
 
   it.effect("cancels an active execution", () =>
     Effect.gen(function*() {
-      const capture: {
-        class?: unknown
-        space?: unknown
-        objectId?: string
-        operations?: unknown
-      } = {}
+      const updateDocCalls: Array<UpdateDocCall> = []
       const result = yield* cancelExecution({
         execution: ProcessExecutionId.make("execution-1")
-      }).pipe(Effect.provide(createLayer({ captureUpdateDoc: capture })))
+      }).pipe(Effect.provide(createLayer({ updateDocCalls })))
 
       expect(result).toEqual({
         executionId: "execution-1",
         status: "cancelled",
         cancelled: true
       })
-      expect(capture.class).toBe(processPlugin.class.Execution)
-      expect(capture.objectId).toBe("execution-1")
-      expect(capture.operations).toEqual({ status: "cancelled" })
+      const [updatedExecution] = updateDocCalls
+      expect(updatedExecution.class).toBe(processPlugin.class.Execution)
+      expect(updatedExecution.objectId).toBe("execution-1")
+      expect(updatedExecution.operations).toEqual({ status: "cancelled" })
     }))
 
   it.effect("returns cancelled=false for already-cancelled executions without updating", () =>
     Effect.gen(function*() {
-      const capture: {
-        operations?: unknown
-      } = {}
+      const updateDocCalls: Array<UpdateDocCall> = []
       const result = yield* cancelExecution({
         execution: ProcessExecutionId.make("execution-1")
       }).pipe(Effect.provide(createLayer({
         executions: [makeExecution({ status: "cancelled" })],
-        captureUpdateDoc: capture
+        updateDocCalls
       })))
 
       expect(result).toEqual({
@@ -673,7 +673,7 @@ describe("process operations", () => {
         status: "cancelled",
         cancelled: false
       })
-      expect(capture.operations).toBeUndefined()
+      expect(updateDocCalls).toEqual([])
     }))
 
   it.effect("fails cancel_execution for missing executions", () =>

--- a/test/mcp/tools/processes.test.ts
+++ b/test/mcp/tools/processes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import { processTools } from "../../../src/mcp/tools/processes.js"
+
+const findTool = (name: string) => {
+  const tool = processTools.find((candidate) => candidate.name === name)
+  if (tool === undefined) throw new Error(`Tool ${name} not found`)
+  return tool
+}
+
+describe("processTools", () => {
+  it.effect("exports process read and write tools in the processes category", () =>
+    Effect.gen(function*() {
+      expect(processTools.map((tool) => tool.name)).toEqual([
+        "list_processes",
+        "get_process",
+        "list_process_executions",
+        "start_process",
+        "cancel_execution"
+      ])
+      for (const tool of processTools) {
+        expect(tool.category).toBe("processes")
+      }
+    }))
+
+  it.effect("start_process schema and annotations describe a non-idempotent write", () =>
+    Effect.gen(function*() {
+      const tool = findTool("start_process")
+
+      expect(tool.inputSchema).toMatchObject({
+        type: "object",
+        required: ["process", "card"]
+      })
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false
+      })
+    }))
+
+  it.effect("cancel_execution schema and annotations describe an idempotent write", () =>
+    Effect.gen(function*() {
+      const tool = findTool("cancel_execution")
+
+      expect(tool.inputSchema).toMatchObject({
+        type: "object",
+        required: ["execution"]
+      })
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      })
+    }))
+})


### PR DESCRIPTION
## Summary
- add `start_process` and `cancel_execution` tools with schemas, typed errors, and operation tests
- update process integration coverage and docs
- add worktree bootstrap docs/script for local Effect reference access

## Verification
- `pnpm check-all`
- full integration: 177 passed, 0 failed, 38 skipped
