### PR TITLE
[codex] fix client-compatible tool schemas

### DIFF
--- a/.changeset/client-compatible-tool-schemas.md
+++ b/.changeset/client-compatible-tool-schemas.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Advertise MCP tool schemas without root-level JSON Schema composition so bulk-loading clients can load all tools.

--- a/src/mcp/input-schema-compat.ts
+++ b/src/mcp/input-schema-compat.ts
@@ -1,0 +1,64 @@
+export interface McpInputSchema {
+  readonly type: "object"
+  readonly properties?: Record<string, unknown>
+  readonly required?: ReadonlyArray<string>
+  readonly $defs?: Record<string, unknown>
+  readonly [key: string]: unknown
+}
+
+type ObjectSchemaField = "properties" | "$defs"
+
+const ROOT_COMPOSITION_KEYS = new Set(["anyOf", "oneOf", "allOf"])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export const isObjectSchema = (schema: object): schema is McpInputSchema => "type" in schema && schema.type === "object"
+
+const mergeObjectFields = (
+  sources: ReadonlyArray<unknown>
+): Record<string, unknown> | undefined => {
+  const merged = sources.reduce<Record<string, unknown>>(
+    (acc, source) => isRecord(source) ? { ...source, ...acc } : acc,
+    {}
+  )
+  return Object.keys(merged).length > 0 ? merged : undefined
+}
+
+const rootCompositionBranches = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> =>
+  [...ROOT_COMPOSITION_KEYS].flatMap((key) => {
+    const branches = schema[key]
+    return Array.isArray(branches) ? branches.filter(isRecord) : []
+  })
+
+const schemaAndCompositionDescendants = (
+  schema: Record<string, unknown>
+): ReadonlyArray<Record<string, unknown>> => [
+  schema,
+  ...rootCompositionBranches(schema).flatMap(schemaAndCompositionDescendants)
+]
+
+const mergedSchemaField = (
+  schema: McpInputSchema,
+  field: ObjectSchemaField
+): Record<string, unknown> | undefined =>
+  mergeObjectFields(schemaAndCompositionDescendants(schema).map((branch) => branch[field]))
+
+/**
+ * Some tool clients reject root-level schema composition. Branch-only required
+ * constraints stay runtime-only because union branches represent alternatives.
+ */
+export const toClientCompatibleInputSchema = (schema: McpInputSchema): McpInputSchema => {
+  const rootFields = Object.fromEntries(
+    Object.entries(schema).filter(([key]) => key !== "type" && !ROOT_COMPOSITION_KEYS.has(key))
+  )
+  const properties = mergedSchemaField(schema, "properties")
+  const defs = mergedSchemaField(schema, "$defs")
+
+  return {
+    ...rootFields,
+    type: "object",
+    ...(properties === undefined ? {} : { properties }),
+    ...(defs === undefined ? {} : { $defs: defs })
+  } satisfies McpInputSchema
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,6 +21,7 @@ import { TelemetryService } from "../telemetry/telemetry.js"
 import { VERSION } from "../version.js"
 import type { McpToolResponse } from "./error-mapping.js"
 import { createSuccessResponse, createUnknownToolError, mapDomainErrorToMcp, toMcpResponse } from "./error-mapping.js"
+import { isObjectSchema, toClientCompatibleInputSchema } from "./input-schema-compat.js"
 import { defaultToolOutputSchema, versionToolOutputSchema } from "./tool-output-schema.js"
 import type { ToolRegistry } from "./tools/index.js"
 import { CATEGORY_NAMES, createFilteredRegistry, resolveAnnotations, toolRegistry } from "./tools/index.js"
@@ -71,15 +72,6 @@ const handleVersionTool = async (): Promise<McpToolResponse> => {
   const latest = await fetchLatestNpmVersion()
   return createSuccessResponse({ current: VERSION, latest })
 }
-
-interface McpInputSchema {
-  readonly type: "object"
-  readonly properties?: Record<string, unknown>
-  readonly required?: Array<string>
-  readonly [key: string]: unknown
-}
-
-const isObjectSchema = (schema: object): schema is McpInputSchema => "type" in schema && schema.type === "object"
 
 export type McpTransportType = "stdio" | "http"
 
@@ -201,7 +193,7 @@ const createMcpServer = (
           return [{
             name: tool.name,
             description: tool.description,
-            inputSchema: tool.inputSchema,
+            inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
             outputSchema: defaultToolOutputSchema,
             annotations: resolveAnnotations(tool)
           }]

--- a/test/mcp/input-schema-compat.test.ts
+++ b/test/mcp/input-schema-compat.test.ts
@@ -1,0 +1,74 @@
+import { describe } from "@effect/vitest"
+import { expect, it } from "vitest"
+
+import type { McpInputSchema } from "../../src/mcp/input-schema-compat.js"
+import { toClientCompatibleInputSchema } from "../../src/mcp/input-schema-compat.js"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const expectRecord = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error("Expected record")
+  }
+  return value
+}
+
+describe("toClientCompatibleInputSchema", () => {
+  it("removes root composition while keeping branch-required constraints runtime-only", () => {
+    const schema: McpInputSchema = {
+      type: "object",
+      required: ["project"],
+      properties: {
+        project: { type: "string" }
+      },
+      oneOf: [
+        {
+          required: ["issueIdentifier"],
+          properties: {
+            issueIdentifier: { type: "string" }
+          },
+          $defs: {
+            IssueIdentifier: { type: "string" }
+          },
+          anyOf: [
+            {
+              required: ["document"],
+              properties: {
+                document: { type: "string" }
+              },
+              $defs: {
+                DocumentIdentifier: { type: "string" }
+              }
+            }
+          ]
+        }
+      ],
+      allOf: [
+        {
+          properties: {
+            limit: { type: "integer" }
+          }
+        }
+      ]
+    }
+
+    const sanitized = toClientCompatibleInputSchema(schema)
+    const properties = expectRecord(sanitized.properties)
+    const defs = expectRecord(sanitized.$defs)
+
+    expect(sanitized.type).toBe("object")
+    expect(sanitized.oneOf).toBeUndefined()
+    expect(sanitized.anyOf).toBeUndefined()
+    expect(sanitized.allOf).toBeUndefined()
+    expect(sanitized.required).toEqual(["project"])
+    expect(sanitized.required).not.toContain("issueIdentifier")
+    expect(sanitized.required).not.toContain("document")
+    expect(properties.project).toBeDefined()
+    expect(properties.issueIdentifier).toBeDefined()
+    expect(properties.document).toBeDefined()
+    expect(properties.limit).toBeDefined()
+    expect(defs.IssueIdentifier).toBeDefined()
+    expect(defs.DocumentIdentifier).toBeDefined()
+  })
+})

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -207,6 +207,37 @@ const requiredModeSets = (tool: ToolDefinition): ReadonlyArray<string> => {
     : []
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const assertSchemaObject = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error("Expected schema object")
+  }
+  return value
+}
+
+interface ListedToolForTest {
+  readonly name: string
+  readonly inputSchema: unknown
+}
+
+const isListedToolForTest = (value: unknown): value is ListedToolForTest =>
+  isRecord(value) && typeof value.name === "string" && "inputSchema" in value
+
+const assertListToolsResponse = (value: unknown): { readonly tools: ReadonlyArray<ListedToolForTest> } => {
+  if (!isRecord(value)) {
+    throw new Error("Expected ListTools response object")
+  }
+
+  const tools = value.tools
+  if (!Array.isArray(tools) || !tools.every(isListedToolForTest)) {
+    throw new Error("Expected ListTools response with tool definitions")
+  }
+
+  return { tools }
+}
+
 // --- Test Helpers ---
 
 const createMockHulyClientLayer = (config: {
@@ -1593,6 +1624,54 @@ describe("McpServerService.layer operations", () => {
         expect(result.tools[0]).toHaveProperty("outputSchema")
         expect(result.tools.every((tool) => "outputSchema" in tool)).toBe(true)
         expect(firstListToolsCalled).toBe(true)
+
+        yield* cleanup(fiber)
+      }), { timeout: 5000 })
+
+    it.scoped("ListTools handler returns client-compatible root object schemas", () =>
+      Effect.gen(function*() {
+        capturedHandlers.clear()
+        const layers = Layer.mergeAll(
+          HulyClient.testLayer({}),
+          HulyStorageClient.testLayer({}),
+          WorkspaceClient.testLayer({}),
+          TelemetryService.testLayer()
+        )
+        const fiber = yield* buildAndRun(layers)
+
+        const listToolsHandler = capturedHandlers.get(ListToolsRequestSchema)
+        expect(listToolsHandler).toBeDefined()
+        if (typeof listToolsHandler !== "function") {
+          throw new Error("ListTools handler was not registered")
+        }
+
+        const result = assertListToolsResponse(yield* Effect.promise(() => Promise.resolve(listToolsHandler())))
+        const tools = new Map(result.tools.map((tool) => [tool.name, assertSchemaObject(tool.inputSchema)]))
+
+        for (const schema of tools.values()) {
+          expect(schema.type).toBe("object")
+          expect(schema.anyOf).toBeUndefined()
+          expect(schema.oneOf).toBeUndefined()
+          expect(schema.allOf).toBeUndefined()
+        }
+
+        const updateIssueSchema = assertSchemaObject(tools.get("update_issue"))
+        const updateIssueProperties = assertSchemaObject(updateIssueSchema.properties)
+        expect(updateIssueProperties.title).toBeDefined()
+        expect(updateIssueProperties.description).toBeDefined()
+        expect(updateIssueProperties.priority).toBeDefined()
+        expect(updateIssueProperties.assignee).toBeDefined()
+        expect(updateIssueProperties.status).toBeDefined()
+
+        const listActivitySchema = assertSchemaObject(tools.get("list_activity"))
+        const listActivityProperties = assertSchemaObject(listActivitySchema.properties)
+        expect(listActivityProperties.project).toBeDefined()
+        expect(listActivityProperties.issueIdentifier).toBeDefined()
+        expect(listActivityProperties.teamspace).toBeDefined()
+        expect(listActivityProperties.document).toBeDefined()
+        expect(listActivityProperties.channel).toBeDefined()
+        expect(listActivityProperties.objectId).toBeDefined()
+        expect(listActivityProperties.objectClass).toBeDefined()
 
         yield* cleanup(fiber)
       }), { timeout: 5000 })


### PR DESCRIPTION
Fixes #66.

Makes advertised MCP tool schemas client-compatible.
