### PR TITLE
fix(schemas): remove top-level anyOf/oneOf/allOf from input_schema (#66) — make-it-work, tests not updated

### DIFF
--- a/src/domain/schemas/activity.ts
+++ b/src/domain/schemas/activity.ts
@@ -227,55 +227,34 @@ const targetStringJsonSchema = (description: string): object => ({
   description
 })
 
+// NOTE (fork patch): top-level oneOf removed (Anthropic API rejects it).
+// All target fields optional at schema level; runtime Schema.filter on
+// ListActivityParamsSchema enforces the "choose exactly one mode" rule.
 export const listActivityParamsJsonSchema = {
   type: "object",
+  additionalProperties: false,
   description:
-    "Choose exactly one target mode for activity lookup: project+issueIdentifier, teamspace+document, channel, or objectId+objectClass.",
-  oneOf: [
-    {
-      title: "Issue activity target",
-      type: "object",
-      additionalProperties: false,
-      required: ["project", "issueIdentifier"],
-      properties: {
-        project: targetStringJsonSchema("Project identifier for issue activity, e.g. 'HULY'."),
-        issueIdentifier: targetStringJsonSchema("Issue identifier for issue activity, e.g. 'HULY-123' or '123'."),
-        limit: activityLimitJsonSchema
-      }
-    },
-    {
-      title: "Document activity target",
-      type: "object",
-      additionalProperties: false,
-      required: ["teamspace", "document"],
-      properties: {
-        teamspace: targetStringJsonSchema("Teamspace name or ID for document activity."),
-        document: targetStringJsonSchema("Document title or ID for document activity."),
-        limit: activityLimitJsonSchema
-      }
-    },
-    {
-      title: "Channel activity target",
-      type: "object",
-      additionalProperties: false,
-      required: ["channel"],
-      properties: {
-        channel: targetStringJsonSchema("Channel name or ID for channel activity."),
-        limit: activityLimitJsonSchema
-      }
-    },
-    {
-      title: "Raw Huly object activity target",
-      type: "object",
-      additionalProperties: false,
-      required: ["objectId", "objectClass"],
-      properties: {
-        objectId: targetStringJsonSchema("Internal Huly object ID to get activity for."),
-        objectClass: targetStringJsonSchema("Internal Huly object class for objectId, such as 'tracker:class:Issue'."),
-        limit: activityLimitJsonSchema
-      }
-    }
-  ]
+    "List activity for a Huly object. Choose exactly one target mode and provide all of its fields: "
+    + "(1) issue: project + issueIdentifier; "
+    + "(2) document: teamspace + document; "
+    + "(3) channel: channel; "
+    + "(4) raw: objectId + objectClass. Mixing modes is rejected at runtime.",
+  properties: {
+    project: targetStringJsonSchema("Project identifier for issue activity, e.g. 'HULY'. Use with issueIdentifier."),
+    issueIdentifier: targetStringJsonSchema(
+      "Issue identifier for issue activity, e.g. 'HULY-123' or '123'. Use with project."
+    ),
+    teamspace: targetStringJsonSchema("Teamspace name or ID for document activity. Use with document."),
+    document: targetStringJsonSchema("Document title or ID for document activity. Use with teamspace."),
+    channel: targetStringJsonSchema("Channel name or ID for channel activity."),
+    objectId: targetStringJsonSchema(
+      "Advanced: internal Huly object ID. Use with objectClass when no friendly identifiers exist."
+    ),
+    objectClass: targetStringJsonSchema(
+      "Advanced: internal Huly object class for objectId, such as 'tracker:class:Issue'."
+    ),
+    limit: activityLimitJsonSchema
+  }
 }
 export const addReactionParamsJsonSchema = JSONSchema.make(AddReactionParamsSchema)
 export const removeReactionParamsJsonSchema = JSONSchema.make(RemoveReactionParamsSchema)

--- a/src/domain/schemas/documents.ts
+++ b/src/domain/schemas/documents.ts
@@ -382,6 +382,9 @@ const editDocumentGeneratedProperties = isJsonSchemaRecord(editDocumentGenerated
 const editDocumentOldTextJsonSchema = isJsonSchemaRecord(editDocumentGeneratedProperties.old_text)
   ? editDocumentGeneratedProperties.old_text
   : {}
+// NOTE (fork patch): top-level anyOf/allOf removed (Anthropic API rejects them).
+// Cross-field rules (mutual exclusion + co-required + at-least-one) live in the
+// Schema.filter on EditDocumentParamsSchema and are reported as decode errors.
 export const editDocumentParamsJsonSchema = {
   ...editDocumentGeneratedJsonSchema,
   properties: {
@@ -390,30 +393,7 @@ export const editDocumentParamsJsonSchema = {
       ...editDocumentOldTextJsonSchema,
       pattern: "\\S"
     }
-  },
-  anyOf: [{ required: ["title"] }, { required: ["content"] }, { required: ["old_text", "new_text"] }],
-  allOf: [
-    {
-      not: {
-        anyOf: [
-          { required: ["content", "old_text"] },
-          { required: ["content", "new_text"] }
-        ]
-      }
-    },
-    {
-      if: { required: ["old_text"] },
-      then: { required: ["new_text"] }
-    },
-    {
-      if: { required: ["new_text"] },
-      then: { required: ["old_text"] }
-    },
-    {
-      if: { required: ["replace_all"] },
-      then: { required: ["old_text", "new_text"] }
-    }
-  ]
+  }
 }
 export const listInlineCommentsParamsJsonSchema = JSONSchema.make(ListInlineCommentsParamsSchema)
 export const deleteDocumentParamsJsonSchema = JSONSchema.make(DeleteDocumentParamsSchema)

--- a/src/domain/schemas/generic-associations.ts
+++ b/src/domain/schemas/generic-associations.ts
@@ -283,18 +283,36 @@ export const DeleteRelationResultSchema = Schema.Struct({
 export type DeleteRelationResult = Schema.Schema.Type<typeof DeleteRelationResultSchema>
 
 export const listAssociationsParamsJsonSchema = JSONSchema.make(ListAssociationsParamsSchema)
+// NOTE (fork patch): top-level anyOf removed (Anthropic API rejects it).
+// Constraint described in `description`; runtime parser enforces.
+const listRelationsBaseJsonSchema = JSONSchema.make(ListRelationsParamsBaseSchema) as Record<string, unknown>
+const listRelationsExistingDescription = typeof listRelationsBaseJsonSchema.description === "string"
+  ? listRelationsBaseJsonSchema.description
+  : ""
+const listRelationsConstraintMessage = "At least one of `association`, `source`, or `target` must be provided."
 export const listRelationsParamsJsonSchema = {
-  ...JSONSchema.make(ListRelationsParamsBaseSchema),
-  anyOf: [
-    { required: ["association"] },
-    { required: ["source"] },
-    { required: ["target"] }
-  ]
+  ...listRelationsBaseJsonSchema,
+  description: listRelationsExistingDescription.length > 0
+    ? `${listRelationsExistingDescription} ${listRelationsConstraintMessage}`
+    : listRelationsConstraintMessage
 }
 export const createRelationParamsJsonSchema = JSONSchema.make(CreateRelationParamsSchema)
+// NOTE (fork patch): top-level anyOf (from Schema.Union) removed —
+// Anthropic API rejects it. Flat object with all targeting fields optional;
+// runtime Union parser enforces "either relation, or association+source+target".
+const deleteRelationByIdJsonSchema = JSONSchema.make(DeleteRelationByIdParamsSchema) as Record<string, unknown>
+const deleteRelationByTripleJsonSchema = JSONSchema.make(DeleteRelationByTripleParamsSchema) as Record<string, unknown>
+const deleteRelationByIdProperties = (deleteRelationByIdJsonSchema.properties ?? {}) as Record<string, unknown>
+const deleteRelationByTripleProperties = (deleteRelationByTripleJsonSchema.properties ?? {}) as Record<string, unknown>
 export const deleteRelationParamsJsonSchema = {
-  ...JSONSchema.make(DeleteRelationParamsSchema),
-  type: "object"
+  type: "object",
+  description:
+    "Idempotently delete one concrete generic relation. Provide either `relation` (concrete _id), "
+    + "or the full triple `association` + `source` + `target`. Mixing modes is rejected at runtime.",
+  properties: {
+    ...deleteRelationByIdProperties,
+    ...deleteRelationByTripleProperties
+  }
 }
 
 const strictParseOptions = { onExcessProperty: "error" } as const

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -37,10 +37,17 @@ export const atLeastOneUpdateFieldMessage = (fields: ReadonlyArray<string>): str
 export const withAtLeastOneRequired = <K extends string>(
   schema: object,
   fields: ReadonlyArray<K>
-): object => ({
-  ...schema,
-  anyOf: fields.map((field) => ({ required: [field] }))
-})
+): object => {
+  // NOTE (fork patch): Anthropic API rejects top-level anyOf/oneOf/allOf in
+  // input_schema. Runtime enforcement lives in requireUpdateFields — the
+  // schema just needs to describe the constraint to the LLM.
+  const existing = (schema as { readonly description?: string }).description
+  const constraint = atLeastOneUpdateFieldMessage(fields.map((field) => String(field)))
+  const description = existing !== undefined && existing.length > 0
+    ? `${existing} ${constraint}`
+    : constraint
+  return { ...schema, description }
+}
 
 // === Tier 1: Huly Internal Refs (opaque IDs from _id) ===
 


### PR DESCRIPTION
## ⚠️ Disclaimers — please read first

- **Made with [Claude Code](https://claude.com/claude-code)** by a downstream user (`@firfi/huly-mcp` consumer) who was hitting #66.
- **This is a "make it work locally" patch, NOT production-ready.** I needed the MCP working in my Claude Code session today; rather than only patch locally I'm publishing it in case it saves you time.
- **Tests are NOT updated.** Several tests (`src/domain/schemas/contacts.test.ts`, `src/domain/schemas/calendar.test.ts`, `test/domain/schemas/milestones.test.ts`, and likely others in `test/`) assert on the exact `anyOf` arrays this PR removes. They will fail. I did not touch them on purpose — you'll have a stronger opinion than I do on whether the new assertions should check the `description` text, drop the schema-shape tests in favor of runtime-parser tests, or something else.
- **Treat this as a starting point / reference, not a mergeable PR.** Cherry-pick, rewrite, or ignore as you prefer.

Closes #66.

---

## Problem

Anthropic API rejects every `tools/list` from `@firfi/huly-mcp@0.15.0` once an affected tool enters the context:

```
API Error: 400 tools.N.custom.input_schema: input_schema does not
support oneOf, allOf, or anyOf at the top level
```

24 of 212 tools ship a top-level `anyOf`/`oneOf`/`allOf`. Breaks claude.ai web/desktop immediately; breaks Claude Code CLI once any affected tool gets lazy-loaded.

## Fix strategy

Same insight for all 4 patterns: **the runtime parser already enforces every cross-field rule** (via `Schema.filter`, `Schema.Union`, and `requireUpdateFields`). The JSON Schema sent to the LLM only needs to describe the shape and put the constraint in `description`. Runtime behavior unchanged — invalid inputs still error out the same way.

## Changes (4 files, ~80 lines)

| File | Pattern | What changed |
|---|---|---|
| `src/domain/schemas/shared.ts` | A — helper | `withAtLeastOneRequired` no longer emits `anyOf`; appends constraint to `description`. Fixes all 22 `update_*` tools in one shot. Runtime via `requireUpdateFields`. |
| `src/domain/schemas/generic-associations.ts` | A inline + B variant | `listRelationsParamsJsonSchema`: `anyOf` → description. `deleteRelationParamsJsonSchema`: flat object merging both Union branches' properties. Runtime via `Schema.Union` parser. |
| `src/domain/schemas/activity.ts` | B | `listActivityParamsJsonSchema`: `oneOf` of 4 target shapes → single object with all target fields optional + description listing valid combos. Runtime via existing `Schema.filter`. |
| `src/domain/schemas/documents.ts` | C | `editDocumentParamsJsonSchema`: dropped the full `anyOf` + `allOf` (`if`/`then`/`not`) block. All 5 cross-field rules already in the `Schema.filter` on `EditDocumentParamsSchema`. |

Search for `// NOTE (fork patch):` in the diff for inline rationale at each callsite.

## Verification

Built dist with `pnpm build`, captured `tools/list`, walked every `inputSchema`:

|  | before | after |
|---|---|---|
| top-level `oneOf`/`anyOf`/`allOf` | **24** | **0** |
| nested combinators (allowed by API) | 28 | 28 |

Pointed local Claude Code at `node /path/to/fork/dist/index.cjs` — original 400 gone, tools invoke normally, sending an empty `update_issue` still produces the expected `NoUpdateFieldsError` from the runtime guard.

## What I did NOT touch

- Tests (see disclaimer).
- `hasAtLeastOneDefined`, `atLeastOneUpdateFieldMessage`, `requireUpdateFields` — runtime path unchanged.
- Nested combinators inside `properties` (allowed by the API — 28 tools still use them).
- README / tool-usage docs (may want a sweep to mention the constraints now live in description + runtime, not in the JSON schema shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
