### PR TITLE
fix: strip inline-comment marks before markdown conversion

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -45,7 +45,7 @@ import { type Auth, HulyConfigService } from "../config/config.js"
 import { UrlString, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 import { concatLink } from "../utils/url.js"
 import { HulyAuthError, HulyConnectionError } from "./errors.js"
-import { type MarkupUrlConfig, testMarkupUrlConfig } from "./operations/markup.js"
+import { type MarkupUrlConfig, stripInlineCommentMarks, testMarkupUrlConfig } from "./operations/markup.js"
 import { HulySdk, type HulySdkDependencies } from "./sdk-deps.js"
 import { testWorkbenchUrlConfig, type WorkbenchUrlConfig } from "./url-builders.js"
 
@@ -168,8 +168,10 @@ function fromInternalMarkup(
       return markup
     case "html":
       return sdk.jsonToHTML(sdk.markupToJSON(markup))
-    case "markdown":
-      return sdk.markupToMarkdown(sdk.markupToJSON(markup), opts)
+    case "markdown": {
+      const json = stripInlineCommentMarks(sdk.markupToJSON(markup))
+      return sdk.markupToMarkdown(json, opts)
+    }
     default:
       absurd(format)
       throw new Error(`Invalid format: ${format}`)

--- a/src/huly/operations/markup.ts
+++ b/src/huly/operations/markup.ts
@@ -7,10 +7,31 @@
  * @module
  */
 import type { Markup } from "@hcengineering/core"
-import { jsonToMarkup, markupToJSON } from "@hcengineering/text"
+import type { MarkupNode } from "@hcengineering/text"
+import { jsonToMarkup, markupToJSON, traverseNode } from "@hcengineering/text"
 import { markdownToMarkup, markupToMarkdown } from "@hcengineering/text-markdown"
 
 import { type UrlString, UrlString as UrlStringSchema } from "../../domain/schemas/shared.js"
+
+const INLINE_COMMENT_MARK_TYPE = "inline-comment"
+
+/**
+ * Remove inline-comment marks before markdown serialization.
+ * @hcengineering/text-markdown has no serializer for this Huly-specific mark and throws otherwise.
+ * The highlighted text is preserved; use list_inline_comments for thread metadata.
+ */
+export const stripInlineCommentMarks = (root: MarkupNode): MarkupNode => {
+  traverseNode(root, (node) => {
+    if (node.marks !== undefined && node.marks.length > 0) {
+      const filtered = node.marks.filter((mark) => String(mark.type) !== INLINE_COMMENT_MARK_TYPE)
+      if (filtered.length !== node.marks.length) {
+        node.marks = filtered
+      }
+    }
+    return true
+  })
+  return root
+}
 
 // SDK: jsonToMarkup return type doesn't match Markup; cast contained here.
 const jsonAsMarkup: (json: ReturnType<typeof markdownToMarkup>) => Markup = jsonToMarkup
@@ -27,7 +48,7 @@ export const testMarkupUrlConfig: MarkupUrlConfig = {
 }
 
 export const markupToMarkdownString = (markup: Markup, urls: MarkupUrlConfig): string => {
-  const json = markupToJSON(markup)
+  const json = stripInlineCommentMarks(markupToJSON(markup))
   return markupToMarkdown(json, urls)
 }
 

--- a/test/huly/client.test.ts
+++ b/test/huly/client.test.ts
@@ -90,7 +90,13 @@ const testSdk: HulySdkDependencies = {
   jsonToHTML: mockFn().mockImplementation((json: unknown) => `<html>${JSON.stringify(json)}</html>`),
   jsonToMarkup: mockFn().mockImplementation((json: unknown) => `markup:${JSON.stringify(json)}`),
   markdownToMarkup: mockFn().mockImplementation((md: string) => ({ type: "md-parsed", content: md })),
-  markupToJSON: mockFn().mockImplementation((markup: string) => ({ type: "markup-parsed", content: markup })),
+  markupToJSON: mockFn().mockImplementation((markup: string) => ({
+    type: "doc",
+    content: [{
+      type: "paragraph",
+      content: [{ type: "text", text: markup, marks: [] }]
+    }]
+  })),
   markupToMarkdown: mockFn().mockImplementation((_json: unknown, _opts: unknown) => "# Markdown output")
 }
 

--- a/test/huly/operations/markup.test.ts
+++ b/test/huly/operations/markup.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "@effect/vitest"
+import type { MarkupMark, MarkupNode } from "@hcengineering/text"
+import { jsonToMarkup } from "@hcengineering/text"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+import {
+  markupToMarkdownString,
+  stripInlineCommentMarks,
+  testMarkupUrlConfig
+} from "../../../src/huly/operations/markup.js"
+
+const makeMarkupDoc = (...content: Array<MarkupNode>): MarkupNode => ({
+  type: "doc" as MarkupNode["type"],
+  content
+})
+
+const makeParagraph = (...content: Array<MarkupNode>): MarkupNode => ({
+  type: "paragraph" as MarkupNode["type"],
+  content
+})
+
+const makeText = (text: string, marks?: Array<{ type: string; attrs?: Record<string, unknown> }>): MarkupNode => {
+  const node: MarkupNode = { type: "text" as MarkupNode["type"], text }
+  if (marks !== undefined) {
+    node.marks = marks as Array<MarkupMark>
+  }
+  return node
+}
+
+describe("stripInlineCommentMarks", () => {
+  it.effect("removes inline-comment marks while preserving text", () =>
+    Effect.gen(function*() {
+      const root = makeMarkupDoc(
+        makeParagraph(
+          makeText("highlighted ", [{ type: "inline-comment", attrs: { thread: "thread-1" } }]),
+          makeText("plain")
+        )
+      )
+
+      stripInlineCommentMarks(root)
+
+      const paragraph = root.content?.[0]
+      const highlighted = paragraph?.content?.[0]
+      const plain = paragraph?.content?.[1]
+
+      expect(highlighted?.text).toBe("highlighted ")
+      expect(highlighted?.marks ?? []).toEqual([])
+      expect(plain?.text).toBe("plain")
+    }))
+})
+
+describe("markupToMarkdownString", () => {
+  it.effect("serializes text with inline-comment marks without error", () =>
+    Effect.gen(function*() {
+      const root = makeMarkupDoc(
+        makeParagraph(
+          makeText("Tiêu chí 6: Thông báo lỗi", [{ type: "inline-comment", attrs: { thread: "thread-1" } }])
+        )
+      )
+      const markup = jsonToMarkup(root)
+
+      const markdown = markupToMarkdownString(markup, testMarkupUrlConfig)
+
+      expect(markdown).toContain("Tiêu chí 6: Thông báo lỗi")
+    }))
+})


### PR DESCRIPTION
## Summary

- Fix `get_document` (and all `fetchMarkup` markdown paths) failing with `No info for mark inline-comment` when document content contains Huly inline comments
- Strip `inline-comment` ProseMirror marks before `@hcengineering/text-markdown` serialization while preserving the highlighted text
- Inline comment thread metadata remains available via the existing `list_inline_comments` tool

## Test plan

- [x] `pnpm check-all` passes (2130 tests)
- [x] New unit tests in `test/huly/operations/markup.test.ts` for mark stripping and markdown serialization
- [x] Live `get_document` against a document with inline comments (teamspace `Product Owner`, doc `6a100d4f8cc535985f7d2678`) returns full markdown content


Made with [Cursor](https://cursor.com)