### PR TITLE
add property-based test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
+    "fast-check": "^4.8.0",
     "husky": "^9.1.7",
     "jscpd": "^4.0.8",
     "lint-staged": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       eslint-plugin-sort-destructure-keys:
         specifier: ^2.0.0
         version: 2.0.0(eslint@9.39.2)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -2478,6 +2481,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3544,6 +3551,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -6790,6 +6800,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -7967,6 +7981,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@8.4.0: {}
 
   qs@6.15.2:
     dependencies:

--- a/src/domain/schemas/attachments.ts
+++ b/src/domain/schemas/attachments.ts
@@ -6,6 +6,7 @@ import {
   AttachmentId,
   DocId,
   DocumentIdentifier,
+  hasAtLeastOneDefined,
   IssueIdentifier,
   LimitParam,
   MimeType,
@@ -140,7 +141,13 @@ export const UpdateAttachmentParamsSchema = Schema.Struct({
   pinned: Schema.optional(Schema.Boolean.annotations({
     description: "Pin or unpin the attachment"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_ATTACHMENT_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_ATTACHMENT_FIELDS)
+  )
+).annotations({
   title: "UpdateAttachmentParams",
   description: `Parameters for updating an attachment. ${atLeastOneUpdateFieldMessage(UPDATE_ATTACHMENT_FIELDS)}`
 })

--- a/src/domain/schemas/calendar.test.ts
+++ b/src/domain/schemas/calendar.test.ts
@@ -216,11 +216,11 @@ describe("Calendar Schemas", () => {
   })
 
   describe("UpdateEventParamsSchema", () => {
-    it("accepts only eventId and advertises update-field requirement in JSON Schema", () => {
+    it("rejects only eventId and advertises update-field requirement in JSON Schema", () => {
       const result = Schema.decodeUnknownEither(UpdateEventParamsSchema)({
         eventId: "evt-123"
       })
-      expect(Either.isRight(result)).toBe(true)
+      expect(Either.isLeft(result)).toBe(true)
 
       const jsonSchema = expectJsonSchemaObject(updateEventParamsJsonSchema)
       expect(jsonSchema.anyOf).toEqual(

--- a/src/domain/schemas/calendar.ts
+++ b/src/domain/schemas/calendar.ts
@@ -7,6 +7,7 @@ import {
   EmptyParamsSchema,
   enumValuesDescription,
   EventId,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   Timestamp,
@@ -295,7 +296,11 @@ export const UpdateEventParamsSchema = Schema.Struct({
   visibility: Schema.optional(VisibilitySchema.annotations({
     description: "New event visibility"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_EVENT_FIELDS) ? undefined : atLeastOneUpdateFieldMessage(UPDATE_EVENT_FIELDS)
+  )
+).annotations({
   title: "UpdateEventParams",
   description: `Parameters for updating an event. ${atLeastOneUpdateFieldMessage(UPDATE_EVENT_FIELDS)}`
 })

--- a/src/domain/schemas/cards.ts
+++ b/src/domain/schemas/cards.ts
@@ -5,6 +5,7 @@ import {
   atLeastOneUpdateFieldMessage,
   CardIdentifier,
   CardSpaceIdentifier,
+  hasAtLeastOneDefined,
   LimitParam,
   MasterTagIdentifier,
   NonEmptyString,
@@ -174,7 +175,11 @@ export const UpdateCardParamsSchema = Schema.Struct({
   content: Schema.optional(Schema.String.annotations({
     description: "New card content (markdown supported)"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_CARD_FIELDS) ? undefined : atLeastOneUpdateFieldMessage(UPDATE_CARD_FIELDS)
+  )
+).annotations({
   title: "UpdateCardParams",
   description: `Parameters for updating a card. ${atLeastOneUpdateFieldMessage(UPDATE_CARD_FIELDS)}`
 })

--- a/src/domain/schemas/channels.ts
+++ b/src/domain/schemas/channels.ts
@@ -4,6 +4,7 @@ import type { AccountUuid, ChannelId, ChannelName, PersonName } from "./shared.j
 import {
   atLeastOneUpdateFieldMessage,
   ChannelIdentifier,
+  hasAtLeastOneDefined,
   LimitParam,
   MessageId,
   NonEmptyString,
@@ -140,7 +141,13 @@ export const UpdateChannelParamsSchema = Schema.Struct({
   topic: Schema.optional(Schema.String.annotations({
     description: "New channel topic"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_CHANNEL_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_CHANNEL_FIELDS)
+  )
+).annotations({
   title: "UpdateChannelParams",
   description: `Parameters for updating a channel. ${atLeastOneUpdateFieldMessage(UPDATE_CHANNEL_FIELDS)}`
 })

--- a/src/domain/schemas/components.ts
+++ b/src/domain/schemas/components.ts
@@ -5,6 +5,7 @@ import {
   ComponentId,
   ComponentIdentifier,
   ComponentLabel,
+  hasAtLeastOneDefined,
   IssueIdentifier,
   LimitParam,
   NonEmptyString,
@@ -116,7 +117,13 @@ export const UpdateComponentParamsSchema = Schema.Struct({
       description: "New lead person email or display name (null to unassign)"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_COMPONENT_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_COMPONENT_FIELDS)
+  )
+).annotations({
   title: "UpdateComponentParams",
   description: `Parameters for updating a component. ${atLeastOneUpdateFieldMessage(UPDATE_COMPONENT_FIELDS)}`
 })

--- a/src/domain/schemas/contacts.test.ts
+++ b/src/domain/schemas/contacts.test.ts
@@ -180,11 +180,11 @@ describe("Contact Schemas", () => {
   })
 
   describe("UpdatePersonParamsSchema", () => {
-    it("accepts personId only and advertises update-field requirement in JSON Schema", () => {
+    it("rejects personId only and advertises update-field requirement in JSON Schema", () => {
       const result = Schema.decodeUnknownEither(UpdatePersonParamsSchema)({
         personId: "abc123"
       })
-      expect(result._tag).toBe("Right")
+      expect(result._tag).toBe("Left")
 
       const jsonSchema = expectJsonSchemaObject(updatePersonParamsJsonSchema)
       expect(jsonSchema.anyOf).toEqual(

--- a/src/domain/schemas/contacts.ts
+++ b/src/domain/schemas/contacts.ts
@@ -5,6 +5,7 @@ import {
   atLeastOneUpdateFieldMessage,
   Email,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   LimitParam,
   MemberReference,
   NonEmptyString,
@@ -12,7 +13,6 @@ import {
   withAtLeastOneRequired
 } from "./shared.js"
 
-// No codec needed — internal type, not used for runtime validation
 export interface PersonSummary {
   readonly id: PersonId
   readonly name: PersonName
@@ -145,6 +145,7 @@ export const UPDATE_PERSON_FIELDS: ReadonlyArray<"firstName" | "lastName" | "cit
   "lastName",
   "city"
 ]
+const updatePersonFieldMessage = atLeastOneUpdateFieldMessage(UPDATE_PERSON_FIELDS)
 
 export const UpdatePersonParamsSchema = Schema.Struct({
   personId: PersonId.annotations({
@@ -161,13 +162,14 @@ export const UpdatePersonParamsSchema = Schema.Struct({
       description: "New city (null to clear)"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) => hasAtLeastOneDefined(params, UPDATE_PERSON_FIELDS) ? undefined : updatePersonFieldMessage)
+).annotations({
   title: "UpdatePersonParams",
-  description: `Parameters for updating a person. ${atLeastOneUpdateFieldMessage(UPDATE_PERSON_FIELDS)}`
+  description: `Parameters for updating a person. ${updatePersonFieldMessage}`
 })
 
 export type UpdatePersonParams = Schema.Schema.Type<typeof UpdatePersonParamsSchema>
-
 export const DeletePersonParamsSchema = Schema.Struct({
   personId: PersonId.annotations({
     description: "Person ID"
@@ -237,6 +239,7 @@ export const UPDATE_ORGANIZATION_FIELDS: ReadonlyArray<"name" | "city" | "descri
   "city",
   "description"
 ]
+const updateOrganizationFieldMessage = atLeastOneUpdateFieldMessage(UPDATE_ORGANIZATION_FIELDS)
 
 export const UpdateOrganizationParamsSchema = Schema.Struct({
   identifier: NonEmptyString.annotations({
@@ -255,11 +258,14 @@ export const UpdateOrganizationParamsSchema = Schema.Struct({
       description: "New description/notes (null to clear). Supports multi-line plain text."
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_ORGANIZATION_FIELDS) ? undefined : updateOrganizationFieldMessage
+  )
+).annotations({
   title: "UpdateOrganizationParams",
-  description: `Update fields on an existing organization. Only provided fields are modified. ${
-    atLeastOneUpdateFieldMessage(UPDATE_ORGANIZATION_FIELDS)
-  }`
+  description:
+    `Update fields on an existing organization. Only provided fields are modified. ${updateOrganizationFieldMessage}`
 })
 
 export type UpdateOrganizationParams = Schema.Schema.Type<typeof UpdateOrganizationParamsSchema>

--- a/src/domain/schemas/documents.ts
+++ b/src/domain/schemas/documents.ts
@@ -4,6 +4,7 @@ import type { DocumentId, TeamspaceId, UrlString } from "./shared.js"
 import {
   atLeastOneUpdateFieldMessage,
   DocumentIdentifier,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   TeamspaceIdentifier,
@@ -284,7 +285,13 @@ export const UpdateTeamspaceParamsSchema = Schema.Struct({
   archived: Schema.optional(Schema.Boolean.annotations({
     description: "Set archived status"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEAMSPACE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEAMSPACE_FIELDS)
+  )
+).annotations({
   title: "UpdateTeamspaceParams",
   description: `Parameters for updating a teamspace. ${atLeastOneUpdateFieldMessage(UPDATE_TEAMSPACE_FIELDS)}`
 })

--- a/src/domain/schemas/issue-templates.ts
+++ b/src/domain/schemas/issue-templates.ts
@@ -6,6 +6,7 @@ import {
   atLeastOneUpdateFieldMessage,
   ComponentIdentifier,
   ComponentLabel,
+  hasAtLeastOneDefined,
   IssueTemplateChildId,
   IssueTemplateId,
   LimitParam,
@@ -231,7 +232,13 @@ export const UpdateIssueTemplateParamsSchema = Schema.Struct({
   estimation: Schema.optional(PositiveNumber.annotations({
     description: "New default estimation in minutes"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_ISSUE_TEMPLATE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_ISSUE_TEMPLATE_FIELDS)
+  )
+).annotations({
   title: "UpdateIssueTemplateParams",
   description: `Parameters for updating an issue template. ${
     atLeastOneUpdateFieldMessage(UPDATE_ISSUE_TEMPLATE_FIELDS)

--- a/src/domain/schemas/issues.ts
+++ b/src/domain/schemas/issues.ts
@@ -7,6 +7,7 @@ import {
   ComponentIdentifier,
   Email,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   IssueId,
   IssueIdentifier,
   LimitParam,
@@ -302,7 +303,11 @@ export const UpdateIssueParamsSchema = Schema.Struct({
       description: "Time estimation in minutes, or null to clear"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_ISSUE_FIELDS) ? undefined : atLeastOneUpdateFieldMessage(UPDATE_ISSUE_FIELDS)
+  )
+).annotations({
   title: "UpdateIssueParams",
   description: `Parameters for updating an issue. ${atLeastOneUpdateFieldMessage(UPDATE_ISSUE_FIELDS)}`
 })

--- a/src/domain/schemas/labels.ts
+++ b/src/domain/schemas/labels.ts
@@ -3,6 +3,7 @@ import { JSONSchema, Schema } from "effect"
 import {
   atLeastOneUpdateFieldMessage,
   ColorCode,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   TagCategoryIdentifier,
@@ -82,7 +83,11 @@ export const UpdateLabelParamsSchema = Schema.Struct({
   description: Schema.optional(Schema.String.annotations({
     description: "New label description"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_LABEL_FIELDS) ? undefined : atLeastOneUpdateFieldMessage(UPDATE_LABEL_FIELDS)
+  )
+).annotations({
   title: "UpdateLabelParams",
   description: `Parameters for updating a label definition. ${atLeastOneUpdateFieldMessage(UPDATE_LABEL_FIELDS)}`
 })

--- a/src/domain/schemas/milestones.ts
+++ b/src/domain/schemas/milestones.ts
@@ -3,6 +3,7 @@ import { JSONSchema, Schema } from "effect"
 import {
   atLeastOneUpdateFieldMessage,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   IssueIdentifier,
   LimitParam,
   MilestoneId,
@@ -128,7 +129,13 @@ export const UpdateMilestoneParamsSchema = Schema.Struct({
   status: Schema.optional(MilestoneStatusSchema.annotations({
     description: "New milestone status"
   }))
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_MILESTONE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_MILESTONE_FIELDS)
+  )
+).annotations({
   title: "UpdateMilestoneParams",
   description: `Parameters for updating a milestone. ${atLeastOneUpdateFieldMessage(UPDATE_MILESTONE_FIELDS)}`
 })

--- a/src/domain/schemas/projects.ts
+++ b/src/domain/schemas/projects.ts
@@ -2,6 +2,7 @@ import { JSONSchema, Schema } from "effect"
 
 import {
   atLeastOneUpdateFieldMessage,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   ProjectIdentifier,
@@ -82,7 +83,13 @@ export const UpdateProjectParamsSchema = Schema.Struct({
   description: Schema.optional(
     Schema.NullOr(Schema.String).annotations({ description: "New description (null to clear)" })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_PROJECT_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_PROJECT_FIELDS)
+  )
+).annotations({
   title: "UpdateProjectParams",
   description: `Parameters for updating a project. ${atLeastOneUpdateFieldMessage(UPDATE_PROJECT_FIELDS)}`
 })

--- a/src/domain/schemas/tag-categories.ts
+++ b/src/domain/schemas/tag-categories.ts
@@ -2,6 +2,7 @@ import { JSONSchema, Schema } from "effect"
 
 import {
   atLeastOneUpdateFieldMessage,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   TagCategoryId,
@@ -75,7 +76,13 @@ export const UpdateTagCategoryParamsSchema = Schema.Struct({
       description: "New default flag"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TAG_CATEGORY_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TAG_CATEGORY_FIELDS)
+  )
+).annotations({
   title: "UpdateTagCategoryParams",
   description: `Parameters for updating a tag category. ${atLeastOneUpdateFieldMessage(UPDATE_TAG_CATEGORY_FIELDS)}`
 })

--- a/src/domain/schemas/tags.ts
+++ b/src/domain/schemas/tags.ts
@@ -5,6 +5,7 @@ import {
   atLeastOneUpdateFieldMessage,
   ColorCode,
   DocId,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   ObjectClassName,
@@ -162,7 +163,11 @@ export const UpdateTagParamsSchema = Schema.Struct({
     description: "Tag ID or exact title. Title lookup is scoped to targetClass."
   }),
   ...UpdateTagFieldSchema.fields
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TAG_FIELDS) ? undefined : atLeastOneUpdateFieldMessage(UPDATE_TAG_FIELDS)
+  )
+).annotations({
   title: "UpdateTagParams",
   description: `Update a generic Huly tag definition. ${atLeastOneUpdateFieldMessage(UPDATE_TAG_FIELDS)}`
 })

--- a/src/domain/schemas/test-management-core.ts
+++ b/src/domain/schemas/test-management-core.ts
@@ -4,6 +4,7 @@ import type { TestCaseId, TestProjectId, TestSuiteId } from "./shared.js"
 import {
   atLeastOneUpdateFieldMessage,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   TestCaseIdentifier,
@@ -163,7 +164,13 @@ export const UpdateTestSuiteParamsSchema = Schema.Struct({
       description: "New suite description (null to clear)"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEST_SUITE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEST_SUITE_FIELDS)
+  )
+).annotations({
   title: "UpdateTestSuiteParams",
   description: `Parameters for updating a test suite. Only provided fields are modified. ${
     atLeastOneUpdateFieldMessage(UPDATE_TEST_SUITE_FIELDS)
@@ -309,7 +316,13 @@ export const UpdateTestCaseParamsSchema = Schema.Struct({
       description: "New assignee name or email (null to unassign)"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEST_CASE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEST_CASE_FIELDS)
+  )
+).annotations({
   title: "UpdateTestCaseParams",
   description: `Parameters for updating a test case. Only provided fields are modified. ${
     atLeastOneUpdateFieldMessage(UPDATE_TEST_CASE_FIELDS)

--- a/src/domain/schemas/test-management-plans.ts
+++ b/src/domain/schemas/test-management-plans.ts
@@ -4,6 +4,7 @@ import type { TestPlanId, TestPlanItemId, TestResultId, TestRunId } from "./shar
 import {
   atLeastOneUpdateFieldMessage,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   TestCaseIdentifier,
@@ -92,7 +93,13 @@ export const UpdateTestPlanParamsSchema = Schema.Struct({
   plan: planField,
   name: Schema.optional(nameField),
   description: Schema.optional(descNullField)
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEST_PLAN_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEST_PLAN_FIELDS)
+  )
+).annotations({
   title: "UpdateTestPlanParams",
   description: `Update a test plan. ${atLeastOneUpdateFieldMessage(UPDATE_TEST_PLAN_FIELDS)}`
 })
@@ -189,7 +196,13 @@ export const UpdateTestRunParamsSchema = Schema.Struct({
       description: "Due date (ms timestamp), or null to clear"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEST_RUN_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEST_RUN_FIELDS)
+  )
+).annotations({
   title: "UpdateTestRunParams",
   description: `Update a test run. ${atLeastOneUpdateFieldMessage(UPDATE_TEST_RUN_FIELDS)}`
 })
@@ -268,7 +281,13 @@ export const UpdateTestResultParamsSchema = Schema.Struct({
     Schema.NullOr(NonEmptyString).annotations({ description: "Assignee email or name, or null to unassign" })
   ),
   description: Schema.optional(descNullField)
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_TEST_RESULT_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_TEST_RESULT_FIELDS)
+  )
+).annotations({
   title: "UpdateTestResultParams",
   description: `Update a test result. ${atLeastOneUpdateFieldMessage(UPDATE_TEST_RESULT_FIELDS)}`
 })

--- a/src/domain/schemas/workspace.ts
+++ b/src/domain/schemas/workspace.ts
@@ -7,6 +7,7 @@ import {
   Email,
   EmptyParamsSchema,
   enumValuesDescription,
+  hasAtLeastOneDefined,
   LimitParam,
   NonEmptyString,
   PersonUuid,
@@ -174,7 +175,13 @@ export const UpdateUserProfileParamsSchema = Schema.Struct({
       description: "Whether profile is public"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_USER_PROFILE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_USER_PROFILE_FIELDS)
+  )
+).annotations({
   title: "UpdateUserProfileParams",
   description: `Parameters for updating user profile. ${atLeastOneUpdateFieldMessage(UPDATE_USER_PROFILE_FIELDS)}`
 })
@@ -197,7 +204,13 @@ export const UpdateGuestSettingsParamsSchema = Schema.Struct({
       description: "Allow guest sign-up"
     })
   )
-}).annotations({
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_GUEST_SETTINGS_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_GUEST_SETTINGS_FIELDS)
+  )
+).annotations({
   title: "UpdateGuestSettingsParams",
   description: `Parameters for updating guest settings. ${atLeastOneUpdateFieldMessage(UPDATE_GUEST_SETTINGS_FIELDS)}`
 })

--- a/src/huly/errors-files.ts
+++ b/src/huly/errors-files.ts
@@ -6,6 +6,8 @@
 import { Schema } from "effect"
 
 export const BYTES_PER_MB = 1024 * 1024
+export const MAX_FILE_SIZE_MB = 100
+export const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * BYTES_PER_MB
 
 /**
  * File upload error - storage operation failed.

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -46,7 +46,9 @@ import {
   FileTooLargeError,
   FileUploadError,
   InvalidContentTypeError,
-  InvalidFileDataError
+  InvalidFileDataError,
+  MAX_FILE_SIZE,
+  MAX_FILE_SIZE_MB
 } from "./errors-files.js"
 import {
   AssociationConflictError,
@@ -159,6 +161,8 @@ export {
   IssueTemplateNotFoundError,
   LeadNotFoundError,
   MasterTagNotFoundError,
+  MAX_FILE_SIZE,
+  MAX_FILE_SIZE_MB,
   MessageNotFoundError,
   MilestoneNotFoundError,
   NotificationContextNotFoundError,

--- a/src/huly/operations/issues-shared.ts
+++ b/src/huly/operations/issues-shared.ts
@@ -80,8 +80,8 @@ export const uniqueStatusRefs = (refs: ReadonlyArray<Ref<Status>>): Array<Ref<St
     []
   )
 
-export const uniqueStatusDocs = (statuses: Iterable<Status>): Array<Status> =>
-  Array.from(statuses).reduce<Array<Status>>(
+export const uniqueStatusDocs = <T extends Pick<Status, "_id">>(statuses: Iterable<T>): Array<T> =>
+  Array.from(statuses).reduce<Array<T>>(
     (unique, status) => unique.some((existing) => existing._id === status._id) ? unique : [...unique, status],
     []
   )

--- a/src/huly/operations/sdk-discovery-mappers.ts
+++ b/src/huly/operations/sdk-discovery-mappers.ts
@@ -86,7 +86,21 @@ export const directAncestorRefs = (cls: MetadataClassDoc): ReadonlyArray<DirectA
     : Array.isArray(cls.extends)
     ? cls.extends
     : [cls.extends]
-  return [...extended, ...(cls.implements ?? [])]
+  return [...extended, ...(cls.implements ?? [])].reduce<{
+    readonly refs: ReadonlyArray<DirectAncestorRef>
+    readonly seen: ReadonlySet<string>
+  }>(
+    (state, ref) => {
+      const key = String(ref)
+      return state.seen.has(key)
+        ? state
+        : {
+          refs: [...state.refs, ref],
+          seen: new Set([...state.seen, key])
+        }
+    },
+    { refs: [], seen: new Set([String(cls._id)]) }
+  ).refs
 }
 
 const directAncestorIds = (cls: MetadataClassDoc): ReadonlyArray<ObjectClassName> =>

--- a/src/huly/operations/tags-shared.ts
+++ b/src/huly/operations/tags-shared.ts
@@ -65,8 +65,13 @@ const toTagReferenceRef: (tagReference: string) => Ref<TagReference> = toRef
 const toSpaceRef: (space: string) => Ref<Space> = toRef
 const toDocRef: (doc: string) => Ref<Doc> = toRef
 
-export const normalizeColorCode = (color: number): ColorCode =>
-  ColorCode.make(Number.isFinite(color) ? Math.max(0, Math.trunc(color)) : 0)
+export const normalizeColorCode = (color: number): ColorCode => {
+  if (!Number.isFinite(color)) {
+    return ColorCode.make(0)
+  }
+
+  return ColorCode.make(Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.trunc(color))))
+}
 
 export const toResolvedTagElement = (tag: HulyTagElement, created: boolean): ResolvedTagElement => ({
   id: tag._id,
@@ -92,7 +97,9 @@ const createdResolvedTagElement = (
   created: true
 })
 
-export const toAttachedTagSummary = (tagRef: TagReference): AttachedTagSummary => {
+export const toAttachedTagSummary = (
+  tagRef: Pick<TagReference, "_id" | "tag" | "title" | "color" | "weight">
+): AttachedTagSummary => {
   const summary = {
     id: TagReferenceId.make(tagRef._id),
     tag: TagElementId.make(tagRef.tag),

--- a/src/huly/operations/test-management-shared.ts
+++ b/src/huly/operations/test-management-shared.ts
@@ -65,8 +65,13 @@ const stringToCaseTypeExact = {
 
 const stringToCaseType: Readonly<Record<string, TestCaseType>> = stringToCaseTypeExact
 
+const lookupEnumValue = <T>(map: Readonly<Record<string, T>>, value: string): T | undefined => {
+  const key = value.toLowerCase()
+  return Object.hasOwn(map, key) ? map[key] : undefined
+}
+
 export const testCaseTypeToString = (t: TestCaseType): TestCaseTypeStr => caseTypeToString[t]
-export const stringToTestCaseType = (s: string): TestCaseType | undefined => stringToCaseType[s.toLowerCase()]
+export const stringToTestCaseType = (s: string): TestCaseType | undefined => lookupEnumValue(stringToCaseType, s)
 
 const casePriorityToString: Record<TestCasePriority, TestCasePriorityStr> = {
   [CasePriority.Low]: "low",
@@ -86,7 +91,7 @@ const stringToCasePriority: Readonly<Record<string, TestCasePriority>> = stringT
 
 export const testCasePriorityToString = (p: TestCasePriority): TestCasePriorityStr => casePriorityToString[p]
 export const stringToTestCasePriority = (s: string): TestCasePriority | undefined =>
-  stringToCasePriority[s.toLowerCase()]
+  lookupEnumValue(stringToCasePriority, s)
 
 const caseStatusToString: Record<TestCaseStatus, TestCaseStatusStr> = {
   [CaseStatus.Draft]: "draft",
@@ -107,7 +112,7 @@ const stringToCaseStatusExact = {
 const stringToCaseStatus: Readonly<Record<string, TestCaseStatus>> = stringToCaseStatusExact
 
 export const testCaseStatusToString = (s: TestCaseStatus): TestCaseStatusStr => caseStatusToString[s]
-export const stringToTestCaseStatus = (s: string): TestCaseStatus | undefined => stringToCaseStatus[s.toLowerCase()]
+export const stringToTestCaseStatus = (s: string): TestCaseStatus | undefined => lookupEnumValue(stringToCaseStatus, s)
 
 const runStatusToString: Record<TestRunStatus, TestRunStatusStr> = {
   [RunStatus.Untested]: "untested",
@@ -126,7 +131,7 @@ const stringToRunStatusExact = {
 const stringToRunStatus: Readonly<Record<string, TestRunStatus>> = stringToRunStatusExact
 
 export const testRunStatusToString = (s: TestRunStatus): TestRunStatusStr => runStatusToString[s]
-export const stringToTestRunStatus = (s: string): TestRunStatus | undefined => stringToRunStatus[s.toLowerCase()]
+export const stringToTestRunStatus = (s: string): TestRunStatus | undefined => lookupEnumValue(stringToRunStatus, s)
 
 // --- Markup helpers ---
 

--- a/src/huly/storage.ts
+++ b/src/huly/storage.ts
@@ -15,21 +15,18 @@ import { Context, Effect, Layer } from "effect"
 import { HulyConfigService } from "../config/config.js"
 import { concatLink } from "../utils/url.js"
 import { authToOptions, connectWithRetry } from "./client.js"
-import type { HulyAuthError, HulyConnectionError } from "./errors.js"
+import type { FileFetchError, HulyAuthError, HulyConnectionError } from "./errors.js"
 import {
-  BYTES_PER_MB,
-  FileFetchError,
   FileNotFoundError,
   FileTooLargeError,
   FileUploadError,
   InvalidContentTypeError,
-  InvalidFileDataError
+  InvalidFileDataError,
+  MAX_FILE_SIZE
 } from "./errors.js"
 import { toRef } from "./operations/sdk-boundary.js"
 import { HulySdk, type HulySdkDependencies } from "./sdk-deps.js"
-
-const MAX_FILE_SIZE_MB = 100
-const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * BYTES_PER_MB
+import { fetchFromUrl } from "./url-fetch.js"
 
 const ALLOWED_CONTENT_TYPES = new Set([
   // Images
@@ -303,30 +300,25 @@ export const decodeBase64 = (
 ): Effect.Effect<Buffer, InvalidFileDataError> =>
   Effect.try({
     try: () => {
-      // Remove data URL prefix if present (e.g., "data:image/png;base64,")
-      const base64Clean = base64Data.includes(",")
-        ? base64Data.split(",")[1]
-        : base64Data
+      const dataUrlMatch = base64Data.match(
+        /^data:(?:[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+)?(?:;[A-Za-z0-9!#$&^_.+-]+=[^,;\s]+)*;base64,(.+)$/s
+      )
+      if (base64Data.includes(",") && dataUrlMatch === null) {
+        throw new Error("Malformed data URL")
+      }
+
+      const base64Clean = dataUrlMatch?.[1] ?? base64Data
+      const normalizedInput = base64Clean.replace(/[\r\n\s]/g, "")
+
+      if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$/.test(normalizedInput)) {
+        throw new Error("Invalid base64 encoding")
+      }
 
       const buffer = Buffer.from(base64Clean, "base64")
 
       // Validate the buffer is not empty and is valid base64
       if (buffer.length === 0) {
         throw new Error("Empty buffer after decoding")
-      }
-
-      // Check if the base64 decoding was successful
-      // If the input was not valid base64, Buffer.from returns an empty buffer or garbage
-      const reEncoded = buffer.toString("base64")
-      const normalizedInput = base64Clean.replace(/[\r\n\s]/g, "")
-      const normalizedOutput = reEncoded.replace(/[\r\n\s]/g, "")
-
-      // Allow for padding differences
-      const inputNoPad = normalizedInput.replace(/=/g, "")
-      const outputNoPad = normalizedOutput.replace(/=/g, "")
-
-      if (inputNoPad !== outputNoPad) {
-        throw new Error("Invalid base64 encoding")
       }
 
       return buffer
@@ -355,88 +347,4 @@ export const readFromFilePath = (
     }
   })
 
-/** Fetch timeout in milliseconds */
-const FETCH_TIMEOUT_MS = 30_000
-
-/**
- * Check if URL points to a potentially dangerous internal address.
- * Blocks: localhost, private IPs, link-local, cloud metadata endpoints.
- */
-export const isBlockedUrl = (urlString: string): boolean => {
-  try {
-    const url = new URL(urlString)
-    const hostname = url.hostname.toLowerCase()
-
-    // Block cloud metadata endpoints
-    if (hostname === "metadata.google.internal") {
-      return true
-    }
-
-    // Block localhost variants (IPv6 has brackets in URL hostname)
-    if (hostname === "localhost" || hostname === "::1" || hostname === "[::1]") {
-      return true
-    }
-
-    // Check IPv4 private/reserved ranges (RFC 1918, RFC 3927)
-    const ipMatch = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
-    if (ipMatch) {
-      const [a, b] = [Number(ipMatch[1]), Number(ipMatch[2])]
-
-      // 127.x.x.x (loopback)
-      if (a === 127) return true // eslint-disable-line no-magic-numbers
-
-      // 10.x.x.x (private)
-      if (a === 10) return true // eslint-disable-line no-magic-numbers
-
-      // 172.16-31.x.x (private)
-      if (a === 172 && b >= 16 && b <= 31) return true // eslint-disable-line no-magic-numbers
-
-      // 192.168.x.x (private)
-      if (a === 192 && b === 168) return true // eslint-disable-line no-magic-numbers
-
-      // 169.254.x.x (link-local, includes metadata endpoint)
-      if (a === 169 && b === 254) return true // eslint-disable-line no-magic-numbers
-    }
-
-    return false
-  } catch {
-    return true // Invalid URL
-  }
-}
-
-/**
- * Fetch file from URL.
- * Includes timeout, SSRF protection, and redirect blocking.
- */
-export const fetchFromUrl = (
-  fileUrl: string
-): Effect.Effect<Buffer, FileFetchError> =>
-  Effect.tryPromise({
-    try: async () => {
-      if (isBlockedUrl(fileUrl)) {
-        throw new Error("URL blocked: internal/private addresses not allowed")
-      }
-
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-
-      try {
-        const response = await fetch(fileUrl, {
-          signal: controller.signal,
-          redirect: "error" // Prevent redirect-based SSRF
-        })
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-        }
-        const arrayBuffer = await response.arrayBuffer()
-        return Buffer.from(arrayBuffer)
-      } finally {
-        clearTimeout(timeout)
-      }
-    },
-    catch: (e) =>
-      new FileFetchError({
-        fileUrl,
-        reason: String(e)
-      })
-  })
+export { fetchFromUrl, isBlockedUrl } from "./url-fetch.js"

--- a/src/huly/url-fetch.ts
+++ b/src/huly/url-fetch.ts
@@ -1,0 +1,477 @@
+/**
+ * URL fetch helpers with SSRF protection.
+ *
+ * @module
+ */
+import type { LookupAddress } from "node:dns"
+import { lookup as dnsLookup } from "node:dns/promises"
+import * as http from "node:http"
+import * as https from "node:https"
+import type { LookupFunction } from "node:net"
+
+import { Effect } from "effect"
+
+import { FileFetchError, MAX_FILE_SIZE } from "./errors.js"
+
+const FETCH_TIMEOUT_MS = 30_000
+const HTTP_PROTOCOLS = new Set(["http:", "https:"])
+const IPV4_OCTET_COUNT = 4
+const IPV4_MAX_OCTET = 255
+const IPV4_PRIVATE_10 = 10
+const IPV4_CGNAT_A = 100
+const IPV4_CGNAT_B_MIN = 64
+const IPV4_CGNAT_B_MAX = 127
+const IPV4_LOOPBACK_A = 127
+const IPV4_LINK_LOCAL_A = 169
+const IPV4_LINK_LOCAL_B = 254
+const IPV4_PRIVATE_172_A = 172
+const IPV4_PRIVATE_172_B_MIN = 16
+const IPV4_PRIVATE_172_B_MAX = 31
+const IPV4_RESERVED_192_A = 192
+const IPV4_RESERVED_192_C_DOCS = 2
+const IPV4_PRIVATE_192_B = 168
+const IPV4_BENCHMARK_A = 198
+const IPV4_BENCHMARK_B_MIN = 18
+const IPV4_BENCHMARK_B_MAX = 19
+const IPV4_DOCS_198_B = 51
+const IPV4_DOCS_198_C = 100
+const IPV4_DOCS_203_A = 203
+const IPV4_DOCS_203_C = 113
+const IPV4_MULTICAST_A_MIN = 224
+const IPV6_HEXTET_MAX = 0xffff
+const IPV6_HEXTET_COUNT = 8
+const IPV6_HEXTET_BITS = 16
+const IPV6_GLOBAL_UNICAST_MIN = 0x2000
+const IPV6_GLOBAL_UNICAST_MAX = 0x3fff
+const BYTE_BASE = 0x100
+const HTTP_STATUS_OK_MIN = 200
+const HTTP_STATUS_REDIRECT_MIN = 300
+
+interface Ipv6Prefix {
+  readonly hextets: ReadonlyArray<number>
+  readonly prefixLength: number
+}
+
+const blockedIpv6SpecialUsePrefixes: ReadonlyArray<Ipv6Prefix> = [
+  { hextets: [0xfe80], prefixLength: 10 },
+  { hextets: [0xfc00], prefixLength: 7 },
+  { hextets: [0xfec0], prefixLength: 10 },
+  { hextets: [0xff00], prefixLength: 8 },
+  { hextets: [0x2001, 0x0000], prefixLength: 32 },
+  { hextets: [0x2001, 0x0001, 0, 0, 0, 0, 0, 1], prefixLength: 128 },
+  { hextets: [0x2001, 0x0001, 0, 0, 0, 0, 0, 2], prefixLength: 128 },
+  { hextets: [0x2001, 0x0002, 0], prefixLength: 48 },
+  { hextets: [0x2001, 0x0003], prefixLength: 32 },
+  { hextets: [0x2001, 0x0004, 0x0112], prefixLength: 48 },
+  { hextets: [0x2001, 0x0010], prefixLength: 28 },
+  { hextets: [0x2001, 0x0020], prefixLength: 28 },
+  { hextets: [0x2001, 0x0db8], prefixLength: 32 },
+  { hextets: [0x2002], prefixLength: 16 },
+  { hextets: [0x3fff, 0x0000], prefixLength: 20 }
+]
+
+interface ResolvedAddress {
+  readonly address: string
+  readonly family: 4 | 6
+}
+
+interface FetchFromUrlDependencies {
+  readonly resolveHostname: (hostname: string) => Promise<ReadonlyArray<ResolvedAddress>>
+  readonly requestUrl: (url: URL, address: ResolvedAddress) => Promise<Buffer>
+}
+
+const parseIpv4Address = (hostname: string): readonly [number, number, number, number] | null => {
+  const parts = hostname.split(".")
+  if (parts.length !== IPV4_OCTET_COUNT) {
+    return null
+  }
+
+  const octets = parts.map(Number)
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > IPV4_MAX_OCTET)) {
+    return null
+  }
+
+  return [octets[0], octets[1], octets[2], octets[3]]
+}
+
+const isBlockedIpv4Address = ([a, b, c, d]: readonly [number, number, number, number]): boolean => {
+  if (a === 0) return true
+  if (a === IPV4_PRIVATE_10) return true
+  if (a === IPV4_CGNAT_A && b >= IPV4_CGNAT_B_MIN && b <= IPV4_CGNAT_B_MAX) return true
+  if (a === IPV4_LOOPBACK_A) return true
+  if (a === IPV4_LINK_LOCAL_A && b === IPV4_LINK_LOCAL_B) return true
+  if (a === IPV4_PRIVATE_172_A && b >= IPV4_PRIVATE_172_B_MIN && b <= IPV4_PRIVATE_172_B_MAX) return true
+  if (a === IPV4_RESERVED_192_A && b === 0 && c === 0) return true
+  if (a === IPV4_RESERVED_192_A && b === 0 && c === IPV4_RESERVED_192_C_DOCS) return true
+  if (a === IPV4_RESERVED_192_A && b === IPV4_PRIVATE_192_B) return true
+  if (a === IPV4_BENCHMARK_A && (b === IPV4_BENCHMARK_B_MIN || b === IPV4_BENCHMARK_B_MAX)) return true
+  if (a === IPV4_BENCHMARK_A && b === IPV4_DOCS_198_B && c === IPV4_DOCS_198_C) return true
+  if (a === IPV4_DOCS_203_A && b === 0 && c === IPV4_DOCS_203_C) return true
+  if (a >= IPV4_MULTICAST_A_MIN) return true
+
+  return a === IPV4_MAX_OCTET && b === IPV4_MAX_OCTET && c === IPV4_MAX_OCTET && d === IPV4_MAX_OCTET
+}
+
+const normalizeUrlHostname = (hostname: string): string =>
+  hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1").replace(/\.+$/, "")
+
+const mappedIpv4Prefix = "::ffff:"
+
+const ipv4FromMappedIpv6 = (hostname: string): readonly [number, number, number, number] | null =>
+  hostname.startsWith(mappedIpv4Prefix)
+    ? parseIpv4Address(hostname.slice(mappedIpv4Prefix.length)) ?? ipv4FromMappedIpv6Hextets(hostname)
+    : null
+
+const ipv4FromMappedIpv6Hextets = (hostname: string): readonly [number, number, number, number] | null => {
+  const match = hostname.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
+  if (match === null) {
+    return null
+  }
+
+  const high = Number.parseInt(match[1], 16)
+  const low = Number.parseInt(match[2], 16)
+  if (high > IPV6_HEXTET_MAX || low > IPV6_HEXTET_MAX) {
+    return null
+  }
+
+  return [
+    Math.floor(high / BYTE_BASE),
+    high % BYTE_BASE,
+    Math.floor(low / BYTE_BASE),
+    low % BYTE_BASE
+  ]
+}
+
+const parseIpv6FirstHextet = (hostname: string): number | null => {
+  if (hostname.startsWith("::")) {
+    return 0
+  }
+
+  const [firstHextet] = hostname.split(":")
+  if (!/^[0-9a-f]{1,4}$/i.test(firstHextet)) {
+    return null
+  }
+
+  return Number.parseInt(firstHextet, 16)
+}
+
+const parseIpv6Hextet = (value: string): number | null => {
+  if (!/^[0-9a-f]{1,4}$/i.test(value)) {
+    return null
+  }
+
+  return Number.parseInt(value, 16)
+}
+
+const parseIpv6Side = (value: string): ReadonlyArray<number> | null => {
+  if (value === "") {
+    return []
+  }
+
+  const parts = value.split(":")
+  const hextets = parts.flatMap((part) => {
+    const hextet = parseIpv6Hextet(part)
+    return hextet === null ? [] : [hextet]
+  })
+
+  return hextets.length === parts.length ? hextets : null
+}
+
+const parseIpv6Hextets = (hostname: string): ReadonlyArray<number> | null => {
+  if (hostname.includes(".")) {
+    return null
+  }
+
+  const compressedParts = hostname.split("::")
+  if (compressedParts.length > 2) {
+    return null
+  }
+
+  const left = parseIpv6Side(compressedParts[0] ?? "")
+  const right = compressedParts.length === 2 ? parseIpv6Side(compressedParts[1] ?? "") : []
+  if (left === null || right === null) {
+    return null
+  }
+
+  if (compressedParts.length === 1) {
+    return left.length === IPV6_HEXTET_COUNT ? left : null
+  }
+
+  const zeroCount = IPV6_HEXTET_COUNT - left.length - right.length
+  if (zeroCount < 1) {
+    return null
+  }
+
+  return [...left, ...Array.from({ length: zeroCount }, () => 0), ...right]
+}
+
+const isIpv6InPrefix = (hextets: ReadonlyArray<number>, prefix: Ipv6Prefix): boolean => {
+  const fullHextetCount = Math.floor(prefix.prefixLength / IPV6_HEXTET_BITS)
+  const remainingBits = prefix.prefixLength % IPV6_HEXTET_BITS
+
+  let index = 0
+  for (const prefixHextet of prefix.hextets.slice(0, fullHextetCount)) {
+    if (hextets[index] !== prefixHextet) {
+      return false
+    }
+
+    index += 1
+  }
+
+  if (remainingBits === 0) {
+    return true
+  }
+
+  const prefixHextet = prefix.hextets[fullHextetCount]
+  const addressHextet = hextets[fullHextetCount]
+  const mask = (IPV6_HEXTET_MAX << (IPV6_HEXTET_BITS - remainingBits)) & IPV6_HEXTET_MAX
+  return (addressHextet & mask) === (prefixHextet & mask)
+}
+
+const requestFirstSuccessfulAddress = async (
+  url: URL,
+  dependencies: FetchFromUrlDependencies,
+  addresses: ReadonlyArray<ResolvedAddress>,
+  index = 0,
+  failures: ReadonlyArray<string> = []
+): Promise<Buffer> => {
+  if (index >= addresses.length) {
+    throw new Error(`Request failed for all resolved addresses: ${failures.join("; ")}`)
+  }
+
+  const address = addresses[index]
+  try {
+    return await dependencies.requestUrl(url, address)
+  } catch (error) {
+    return requestFirstSuccessfulAddress(
+      url,
+      dependencies,
+      addresses,
+      index + 1,
+      [...failures, `${address.address}: ${String(error)}`]
+    )
+  }
+}
+
+const isBlockedIpv6Address = (hostname: string): boolean => {
+  const normalizedHostname = normalizeUrlHostname(hostname)
+  const hextets = parseIpv6Hextets(normalizedHostname)
+
+  if (hextets === null) {
+    return true
+  }
+
+  if (hextets.every((hextet) => hextet === 0)) {
+    return true
+  }
+
+  if (hextets.slice(0, 7).every((hextet) => hextet === 0) && hextets[7] === 1) {
+    return true
+  }
+
+  if (blockedIpv6SpecialUsePrefixes.some((prefix) => isIpv6InPrefix(hextets, prefix))) {
+    return true
+  }
+
+  const firstHextet = parseIpv6FirstHextet(normalizedHostname)
+  if (firstHextet === null) {
+    return true
+  }
+
+  return firstHextet < IPV6_GLOBAL_UNICAST_MIN || firstHextet > IPV6_GLOBAL_UNICAST_MAX
+}
+
+const isSupportedAddressFamily = (family: number): family is 4 | 6 => family === 4 || family === 6
+
+const toResolvedAddress = (address: LookupAddress): ResolvedAddress | null =>
+  isSupportedAddressFamily(address.family)
+    ? {
+      address: address.address,
+      family: address.family
+    }
+    : null
+
+const resolveHostname = async (hostname: string): Promise<ReadonlyArray<ResolvedAddress>> => {
+  const addresses = await dnsLookup(hostname, { all: true, order: "verbatim" })
+  return addresses.flatMap((address) => {
+    const resolved = toResolvedAddress(address)
+    return resolved === null ? [] : [resolved]
+  })
+}
+
+const isBlockedResolvedAddress = (address: ResolvedAddress): boolean => {
+  const normalizedAddress = normalizeUrlHostname(address.address)
+
+  if (address.family === 4) {
+    const ipv4Address = parseIpv4Address(normalizedAddress)
+    return ipv4Address === null || isBlockedIpv4Address(ipv4Address)
+  }
+
+  const mappedIpv4Address = ipv4FromMappedIpv6(normalizedAddress)
+  if (mappedIpv4Address !== null) {
+    return isBlockedIpv4Address(mappedIpv4Address)
+  }
+
+  return isBlockedIpv6Address(normalizedAddress)
+}
+
+const makePinnedLookup = (address: ResolvedAddress): LookupFunction => (_hostname, options, callback) => {
+  if (options.all === true) {
+    callback(null, [address])
+    return
+  }
+
+  callback(null, address.address, address.family)
+}
+
+const responseTooLargeError = (receivedBytes: number, maxBytes: number): Error =>
+  new Error(`Response exceeded maximum file size (${receivedBytes} bytes > ${maxBytes} bytes)`)
+
+export const requestUrl = (url: URL, address: ResolvedAddress, maxBytes = MAX_FILE_SIZE): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const effectiveMaxBytes = Math.min(maxBytes, MAX_FILE_SIZE)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let settled = false
+    let receivedBytes = 0
+    const rejectOnce = (error: Error): void => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timeout)
+      reject(error)
+    }
+    const request = (url.protocol === "http:" ? http : https).request(
+      url,
+      {
+        lookup: makePinnedLookup(address),
+        signal: controller.signal,
+        timeout: FETCH_TIMEOUT_MS
+      },
+      (response) => {
+        const statusCode = response.statusCode ?? 0
+        const chunks: Array<Buffer> = []
+
+        response.on("error", (error) => {
+          rejectOnce(error)
+        })
+
+        response.on("data", (chunk: Buffer | string) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+          const nextReceivedBytes = receivedBytes + buffer.length
+
+          if (nextReceivedBytes > effectiveMaxBytes) {
+            const error = responseTooLargeError(nextReceivedBytes, effectiveMaxBytes)
+            response.destroy(error)
+            request.destroy(error)
+            rejectOnce(error)
+            return
+          }
+
+          receivedBytes = nextReceivedBytes
+          chunks.push(buffer)
+        })
+
+        response.on("end", () => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          clearTimeout(timeout)
+          if (statusCode < HTTP_STATUS_OK_MIN || statusCode >= HTTP_STATUS_REDIRECT_MIN) {
+            reject(new Error(`HTTP ${statusCode}: ${response.statusMessage ?? "Unknown status"}`))
+            return
+          }
+
+          resolve(Buffer.concat(chunks))
+        })
+      }
+    )
+
+    request.on("timeout", () => {
+      request.destroy(new Error("Request timed out"))
+    })
+    request.on("error", (error) => {
+      rejectOnce(error)
+    })
+    controller.signal.addEventListener("abort", () => {
+      request.destroy(new Error("Request timed out"))
+    }, { once: true })
+    request.end()
+  })
+
+const defaultFetchFromUrlDependencies: FetchFromUrlDependencies = {
+  requestUrl,
+  resolveHostname
+}
+
+/**
+ * Check if URL points to a potentially dangerous internal address.
+ * Blocks: localhost, private IPs, non-global IPv6, link-local, and cloud metadata endpoints.
+ */
+export const isBlockedUrl = (urlString: string): boolean => {
+  try {
+    const url = new URL(urlString)
+    const hostname = normalizeUrlHostname(url.hostname)
+
+    if (!HTTP_PROTOCOLS.has(url.protocol)) {
+      return true
+    }
+
+    if (hostname === "metadata.google.internal" || hostname === "localhost") {
+      return true
+    }
+
+    const ipv4Address = parseIpv4Address(hostname)
+    if (ipv4Address !== null) {
+      return isBlockedIpv4Address(ipv4Address)
+    }
+
+    const mappedIpv4Address = ipv4FromMappedIpv6(hostname)
+    if (mappedIpv4Address !== null) {
+      return isBlockedIpv4Address(mappedIpv4Address)
+    }
+
+    return hostname.includes(":") ? isBlockedIpv6Address(hostname) : false
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Fetch file from URL.
+ * Includes timeout, SSRF protection, and redirect blocking.
+ */
+export const fetchFromUrl = (
+  fileUrl: string,
+  dependencies: FetchFromUrlDependencies = defaultFetchFromUrlDependencies
+): Effect.Effect<Buffer, FileFetchError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const url = new URL(fileUrl)
+      const hostname = normalizeUrlHostname(url.hostname)
+
+      if (isBlockedUrl(fileUrl)) {
+        throw new Error("URL blocked: internal/private/non-global addresses not allowed")
+      }
+
+      const addresses = await dependencies.resolveHostname(hostname)
+      if (addresses.length === 0) {
+        throw new Error("URL blocked: hostname did not resolve")
+      }
+
+      if (addresses.some(isBlockedResolvedAddress)) {
+        throw new Error("URL blocked: DNS resolved to an internal/private/non-global address")
+      }
+
+      return requestFirstSuccessfulAddress(url, dependencies, addresses)
+    },
+    catch: (e) =>
+      new FileFetchError({
+        fileUrl,
+        reason: String(e)
+      })
+  })

--- a/src/huly/url-fetch.ts
+++ b/src/huly/url-fetch.ts
@@ -94,7 +94,7 @@ const parseIpv4Address = (hostname: string): readonly [number, number, number, n
   return [octets[0], octets[1], octets[2], octets[3]]
 }
 
-const isBlockedIpv4Address = ([a, b, c, d]: readonly [number, number, number, number]): boolean => {
+const isBlockedIpv4Address = ([a, b, c]: readonly [number, number, number, number]): boolean => {
   if (a === 0) return true
   if (a === IPV4_PRIVATE_10) return true
   if (a === IPV4_CGNAT_A && b >= IPV4_CGNAT_B_MIN && b <= IPV4_CGNAT_B_MAX) return true
@@ -107,9 +107,8 @@ const isBlockedIpv4Address = ([a, b, c, d]: readonly [number, number, number, nu
   if (a === IPV4_BENCHMARK_A && (b === IPV4_BENCHMARK_B_MIN || b === IPV4_BENCHMARK_B_MAX)) return true
   if (a === IPV4_BENCHMARK_A && b === IPV4_DOCS_198_B && c === IPV4_DOCS_198_C) return true
   if (a === IPV4_DOCS_203_A && b === 0 && c === IPV4_DOCS_203_C) return true
-  if (a >= IPV4_MULTICAST_A_MIN) return true
-
-  return a === IPV4_MAX_OCTET && b === IPV4_MAX_OCTET && c === IPV4_MAX_OCTET && d === IPV4_MAX_OCTET
+  // 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved), and 255.255.255.255 (broadcast).
+  return a >= IPV4_MULTICAST_A_MIN
 }
 
 const normalizeUrlHostname = (hostname: string): string =>

--- a/src/mcp/tools/registry.ts
+++ b/src/mcp/tools/registry.ts
@@ -100,25 +100,58 @@ export const isEmptyArgumentsObject = (args: unknown): boolean =>
 interface ToolInputSchema {
   readonly properties?: Record<string, unknown>
   readonly required?: ReadonlyArray<string>
-  readonly anyOf?: ReadonlyArray<{ readonly required?: ReadonlyArray<string> }>
-  readonly oneOf?: ReadonlyArray<{ readonly required?: ReadonlyArray<string> }>
+  readonly anyOf?: ReadonlyArray<ToolInputSchemaVariant>
+  readonly oneOf?: ReadonlyArray<ToolInputSchemaVariant>
   readonly additionalProperties?: unknown
+}
+
+interface ToolInputSchemaVariant {
+  readonly properties?: Record<string, unknown>
+  readonly required?: ReadonlyArray<string>
+  readonly type?: unknown
 }
 
 const isToolInputSchema = (schema: object): schema is ToolInputSchema => typeof schema === "object"
 
+const hasRequiredFields = (schema: ToolInputSchemaVariant): boolean => (schema.required?.length ?? 0) > 0
+
+const hasDeclaredProperties = (schema: ToolInputSchemaVariant): boolean =>
+  Object.keys(schema.properties ?? {}).length > 0
+
+const unionVariants = (schema: ToolInputSchema): ReadonlyArray<ToolInputSchemaVariant> => [
+  ...(schema.anyOf ?? []),
+  ...(schema.oneOf ?? [])
+]
+
+const EMPTY_EFFECT_STRUCT_VARIANT_COUNT = 2
+
+const isEmptySchemaVariant = (schema: ToolInputSchemaVariant): boolean =>
+  !hasRequiredFields(schema) && !hasDeclaredProperties(schema)
+
+const isEmptyStructUnionSchema = (schema: ToolInputSchema): boolean => {
+  const variants = unionVariants(schema)
+  const types = new Set(variants.map((variant) => variant.type))
+
+  return variants.length === EMPTY_EFFECT_STRUCT_VARIANT_COUNT
+    && isEmptySchemaVariant(schema)
+    && variants.every(isEmptySchemaVariant)
+    && types.has("object")
+    && types.has("array")
+}
+
 export const requiresArgumentsObject = (tool: ToolDefinition): boolean =>
   isToolInputSchema(tool.inputSchema)
   && (
-    (tool.inputSchema.required?.length ?? 0) > 0
-    || tool.inputSchema.anyOf?.some((schema) => (schema.required?.length ?? 0) > 0) === true
-    || tool.inputSchema.oneOf?.some((schema) => (schema.required?.length ?? 0) > 0) === true
+    hasRequiredFields(tool.inputSchema)
+    || unionVariants(tool.inputSchema).some(hasRequiredFields)
   )
 
 export const isNoArgumentTool = (tool: ToolDefinition): boolean =>
-  isToolInputSchema(tool.inputSchema)
-  && Object.keys(tool.inputSchema.properties ?? {}).length === 0
-  && tool.inputSchema.additionalProperties === false
+  isToolInputSchema(tool.inputSchema) && !requiresArgumentsObject(tool)
+  && (
+    (!hasDeclaredProperties(tool.inputSchema) && tool.inputSchema.additionalProperties === false)
+    || isEmptyStructUnionSchema(tool.inputSchema)
+  )
 
 const encodeOutput = (schema: Schema.Schema.AnyNoContext, result: unknown): unknown =>
   Schema.encodeUnknownSync(schema)(result)

--- a/src/mcp/tools/registry.ts
+++ b/src/mcp/tools/registry.ts
@@ -128,6 +128,17 @@ const EMPTY_EFFECT_STRUCT_VARIANT_COUNT = 2
 const isEmptySchemaVariant = (schema: ToolInputSchemaVariant): boolean =>
   !hasRequiredFields(schema) && !hasDeclaredProperties(schema)
 
+/**
+ * Effect encodes a no-argument tool's empty `Schema.Struct({})` as a two-variant
+ * union — an empty `object` and an empty `array`, neither carrying properties or
+ * required fields. We detect that exact shape so such tools count as no-argument
+ * (callable with no input) instead of demanding an arguments object.
+ *
+ * This is coupled to Effect's JSON Schema output: if a future Effect version
+ * changes how it encodes empty structs, the "classifies empty Effect Struct union
+ * schemas" property in `test/mcp/registry.property.test.ts` fails loudly rather
+ * than this silently misclassifying tools.
+ */
 const isEmptyStructUnionSchema = (schema: ToolInputSchema): boolean => {
   const variants = unionVariants(schema)
   const types = new Set(variants.map((variant) => variant.type))

--- a/test/config/config-headers.property.test.ts
+++ b/test/config/config-headers.property.test.ts
@@ -1,0 +1,137 @@
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as fc from "fast-check"
+import { expect } from "vitest"
+
+import { hulyConfigProviderFromHeaders } from "../../src/config/config.js"
+import { HULY_CONFIG_HEADERS, REQUIRED_HULY_CONFIG_HEADERS } from "../../src/config/huly-config-constants.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const headerValueArbitrary = fc.string({ minLength: 1, maxLength: 80 })
+const supportedHeaderArbitrary = fc.constantFrom(...HULY_CONFIG_HEADERS)
+const requiredHeaderArbitrary = fc.constantFrom(...REQUIRED_HULY_CONFIG_HEADERS)
+const unsupportedHulyHeaderArbitrary = fc.stringMatching(/^x-huly-[a-z0-9-]{1,20}$/)
+  .filter((name) => !HULY_CONFIG_HEADERS.includes(name))
+const nonHulyHeaderNameArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/)
+  .filter((name) => !name.toLowerCase().startsWith("x-huly-"))
+
+const completeSupportedHeadersArbitrary = fc.record({
+  url: headerValueArbitrary,
+  workspace: headerValueArbitrary,
+  token: headerValueArbitrary,
+  timeout: fc.option(headerValueArbitrary, { nil: undefined })
+}).map(({ timeout, token, url, workspace }) => ({
+  "x-huly-url": url,
+  "x-huly-workspace": workspace,
+  "x-huly-token": token,
+  ...(timeout === undefined ? {} : { "x-huly-connection-timeout": timeout })
+}))
+
+const partialSupportedHeaderSubsetArbitrary = fc.oneof(
+  fc.constant(["x-huly-connection-timeout"]),
+  fc.subarray([...REQUIRED_HULY_CONFIG_HEADERS], { minLength: 2, maxLength: 2 }),
+  fc.subarray([...HULY_CONFIG_HEADERS], { minLength: 1 }).filter((headers) =>
+    !REQUIRED_HULY_CONFIG_HEADERS.every((requiredHeader) => headers.includes(requiredHeader))
+  )
+)
+
+const partialSupportedHeadersArbitrary = fc.tuple(
+  partialSupportedHeaderSubsetArbitrary,
+  fc.array(headerValueArbitrary, { minLength: HULY_CONFIG_HEADERS.length, maxLength: HULY_CONFIG_HEADERS.length })
+).map(([headers, values]) => Object.fromEntries(headers.map((header, index) => [header, values[index]])))
+
+const runProvider = (headers: unknown) => Effect.runPromise(hulyConfigProviderFromHeaders(headers))
+
+const expectConfigValidationFailure = async (headers: unknown): Promise<void> => {
+  const result = await Effect.runPromiseExit(hulyConfigProviderFromHeaders(headers))
+  expect(result._tag).toBe("Failure")
+}
+
+const differentCasing = (header: string): string => header.replace("x-huly", "X-Huly")
+
+describe("hulyConfigProviderFromHeaders properties", () => {
+  it("returns undefined for arbitrary non-Huly headers", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.dictionary(nonHulyHeaderNameArbitrary, headerValueArbitrary, { maxKeys: 8 }),
+        async (headers) => {
+          await expect(runProvider(headers)).resolves.toBeUndefined()
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("returns a provider when all required supported headers are single string values", async () => {
+    await fc.assert(
+      fc.asyncProperty(completeSupportedHeadersArbitrary, async (headers) => {
+        await expect(runProvider(headers)).resolves.toBeDefined()
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("fails for unsupported x-huly-* headers", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        completeSupportedHeadersArbitrary,
+        unsupportedHulyHeaderArbitrary,
+        headerValueArbitrary,
+        async (headers, unsupportedHeader, value) => {
+          await expectConfigValidationFailure({
+            ...headers,
+            [unsupportedHeader]: value
+          })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("fails when the same supported header appears with duplicate casing", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        completeSupportedHeadersArbitrary,
+        supportedHeaderArbitrary,
+        headerValueArbitrary,
+        headerValueArbitrary,
+        async (headers, header, originalValue, duplicateValue) => {
+          await expectConfigValidationFailure({
+            ...headers,
+            [header]: originalValue,
+            [differentCasing(header)]: duplicateValue
+          })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("fails when required supported headers are arrays or undefined", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        completeSupportedHeadersArbitrary,
+        requiredHeaderArbitrary,
+        fc.oneof(fc.array(headerValueArbitrary, { minLength: 1, maxLength: 3 }), fc.constant(undefined)),
+        async (headers, header, invalidValue) => {
+          await expectConfigValidationFailure({
+            ...headers,
+            [header]: invalidValue
+          })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("fails for any non-empty supported header subset missing at least one required header", async () => {
+    await fc.assert(
+      fc.asyncProperty(partialSupportedHeadersArbitrary, async (headers) => {
+        expect(Object.keys(headers).length).toBeGreaterThan(0)
+        expect(REQUIRED_HULY_CONFIG_HEADERS.every((header) => header in headers)).toBe(false)
+        await expectConfigValidationFailure(headers)
+      }),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/config/runtime-context-and-toolsets.property.test.ts
+++ b/test/config/runtime-context-and-toolsets.property.test.ts
@@ -1,0 +1,200 @@
+import { describe } from "@effect/vitest"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import { sanitizeHulyRuntimeConfigFromEnv, sanitizeHulyRuntimeConfigFromHeaders } from "../../src/config/config.js"
+import { DEFAULT_HULY_CONNECTION_TIMEOUT } from "../../src/config/huly-config-constants.js"
+import { parseToolsets } from "../../src/mcp/huly-context-tool.js"
+import { CATEGORY_NAMES } from "../../src/mcp/tools/index.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const secretArbitrary = fc.uuid().map((value) => `secret-${value}`)
+const hostnameArbitrary = fc.tuple(
+  fc.stringMatching(/^[a-z][a-z0-9]{0,8}$/),
+  fc.constantFrom("example.com", "huly.app", "internal.test")
+).map(([subdomain, domain]) => `${subdomain}.${domain}`)
+const protocolArbitrary = fc.constantFrom("http", "https")
+const validTimeoutStringArbitrary = fc.integer({ min: 1, max: Number.MAX_SAFE_INTEGER }).map(String)
+const invalidNumericTimeoutStringArbitrary = fc.oneof(
+  fc.constantFrom(
+    "0",
+    "-1",
+    "-30000",
+    "1.1",
+    "30000.5",
+    " 1",
+    "1 ",
+    "\t30000",
+    "30000\n",
+    String(Number.MAX_SAFE_INTEGER + 1),
+    "999999999999999999999999999999"
+  ),
+  fc.integer({ min: Number.MIN_SAFE_INTEGER, max: -1 }).map(String),
+  fc.integer({ min: 1, max: 100_000 }).map((value) => `${value}.5`)
+)
+const secretInvalidTimeoutStringArbitrary = fc.uuid().map((value) => `invalid-timeout-secret-${value}`)
+const invalidTimeoutStringArbitrary = fc.oneof(
+  invalidNumericTimeoutStringArbitrary.map((timeout) => ({ leakSecrets: [], timeout })),
+  secretInvalidTimeoutStringArbitrary.map((timeout) => ({ leakSecrets: [timeout], timeout }))
+)
+
+const serialized = (value: unknown): string => JSON.stringify(value)
+
+const expectNoLeak = (value: unknown, secrets: ReadonlyArray<string>): void => {
+  const output = serialized(value)
+  for (const secret of secrets) {
+    expect(output).not.toContain(secret)
+  }
+}
+
+describe("sanitized runtime context properties", () => {
+  it("never serializes env token, email, password, or unsafe URL components", () => {
+    fc.assert(
+      fc.property(
+        hostnameArbitrary,
+        protocolArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        (host, protocol, user, password, token, querySecret, pathSecret) => {
+          const context = sanitizeHulyRuntimeConfigFromEnv({
+            HULY_URL: `${protocol}://${user}:${password}@${host}/${pathSecret}?token=${querySecret}#${querySecret}`,
+            HULY_TOKEN: token,
+            HULY_EMAIL: `${user}@${host}`,
+            HULY_PASSWORD: password,
+            HULY_WORKSPACE: "workspace"
+          })
+
+          expectNoLeak(context, [user, password, token, querySecret, pathSecret])
+          expect(context.huly.url).toEqual({
+            configured: true,
+            valid: true,
+            origin: `${protocol}://${host}`,
+            host,
+            protocol: `${protocol}:`
+          })
+          expect(Object.keys(context.huly.url).sort()).toEqual(["configured", "host", "origin", "protocol", "valid"])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("never serializes header token or unsafe URL components", () => {
+    fc.assert(
+      fc.property(
+        hostnameArbitrary,
+        protocolArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        secretArbitrary,
+        (host, protocol, user, password, token, querySecret) => {
+          const context = sanitizeHulyRuntimeConfigFromHeaders({
+            "x-huly-url": `${protocol}://${user}:${password}@${host}/path?token=${querySecret}#${querySecret}`,
+            "x-huly-workspace": "workspace",
+            "x-huly-token": token
+          }, {
+            HULY_TOKEN: `env-${token}`
+          })
+
+          expectNoLeak(context, [user, password, token, `env-${token}`, querySecret])
+          expect(context.huly.url).toEqual({
+            configured: true,
+            valid: true,
+            origin: `${protocol}://${host}`,
+            host,
+            protocol: `${protocol}:`
+          })
+          expect(Object.keys(context.huly.url).sort()).toEqual(["configured", "host", "origin", "protocol", "valid"])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("reports valid generated timeout strings with their source and parsed value", () => {
+    fc.assert(
+      fc.property(validTimeoutStringArbitrary, (timeout) => {
+        const envContext = sanitizeHulyRuntimeConfigFromEnv({ HULY_CONNECTION_TIMEOUT: timeout })
+        const headerContext = sanitizeHulyRuntimeConfigFromHeaders({ "x-huly-connection-timeout": timeout })
+
+        expect(envContext.huly.connectionTimeout).toEqual({
+          configured: true,
+          valid: true,
+          valueMs: Number(timeout),
+          defaultMs: DEFAULT_HULY_CONNECTION_TIMEOUT,
+          source: "env"
+        })
+        expect(headerContext.huly.connectionTimeout).toEqual({
+          configured: true,
+          valid: true,
+          valueMs: Number(timeout),
+          defaultMs: DEFAULT_HULY_CONNECTION_TIMEOUT,
+          source: "header"
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("reports invalid generated timeout strings as invalid without leaking the raw value", () => {
+    fc.assert(
+      fc.property(invalidTimeoutStringArbitrary, ({ leakSecrets, timeout }) => {
+        const envContext = sanitizeHulyRuntimeConfigFromEnv({ HULY_CONNECTION_TIMEOUT: timeout })
+        const headerContext = sanitizeHulyRuntimeConfigFromHeaders({ "x-huly-connection-timeout": timeout })
+
+        expect(envContext.huly.connectionTimeout).toEqual({
+          configured: true,
+          valid: false,
+          defaultMs: DEFAULT_HULY_CONNECTION_TIMEOUT,
+          source: "invalid"
+        })
+        expect(headerContext.huly.connectionTimeout).toEqual({
+          configured: true,
+          valid: false,
+          defaultMs: DEFAULT_HULY_CONNECTION_TIMEOUT,
+          source: "invalid"
+        })
+        expectNoLeak(envContext, leakSecrets)
+        expectNoLeak(headerContext, leakSecrets)
+      }),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("parseToolsets properties", () => {
+  it("normalizes known categories and reports unknown categories", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom(...CATEGORY_NAMES), { maxLength: 8 }),
+        fc.array(fc.stringMatching(/^[a-z][a-z0-9_-]{1,20}$/).filter((name) => !CATEGORY_NAMES.has(name)), {
+          maxLength: 8
+        }),
+        (knownCategories, unknownCategories) => {
+          const requested = [...knownCategories, ...unknownCategories]
+          const raw = requested.map((category, index) => index % 2 === 0 ? category.toUpperCase() : ` ${category} `)
+            .join(",")
+          const warnings: Array<string> = []
+          const result = parseToolsets(raw, (message) => {
+            warnings.push(message)
+          })
+
+          expect(result.requestedCategories).toEqual(requested.map((category) => category.toLowerCase()))
+          expect(result.ignoredCategories).toEqual(unknownCategories)
+          expect(warnings).toHaveLength(unknownCategories.length)
+
+          if (knownCategories.length === 0) {
+            expect(result.enabledCategories).toBeUndefined()
+          } else {
+            expect(result.enabledCategories).toEqual(new Set(knownCategories))
+          }
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/domain/channels.test.ts
+++ b/test/domain/channels.test.ts
@@ -143,10 +143,10 @@ describe("Channel Domain Schemas", () => {
   })
 
   describe("UpdateChannelParamsSchema", () => {
-    it.effect("parses minimal params and advertises update-field requirement in JSON Schema", () =>
+    it.effect("rejects minimal params and advertises update-field requirement in JSON Schema", () =>
       Effect.gen(function*() {
-        const result = yield* parseUpdateChannelParams({ channel: "general" })
-        expect(result).toEqual({ channel: "general" })
+        const error = yield* Effect.flip(parseUpdateChannelParams({ channel: "general" }))
+        expect(error._tag).toBe("ParseError")
 
         const schema = expectJsonSchemaObject(updateChannelParamsJsonSchema)
         expect(schema.anyOf).toEqual(expect.arrayContaining([{ required: ["name"] }, { required: ["topic"] }]))

--- a/test/domain/schemas.test.ts
+++ b/test/domain/schemas.test.ts
@@ -469,10 +469,10 @@ describe("Domain Schemas", () => {
   })
 
   describe("UpdateIssueParamsSchema", () => {
-    it.effect("parses minimal params and advertises update-field requirement in JSON Schema", () =>
+    it.effect("rejects minimal params and advertises update-field requirement in JSON Schema", () =>
       Effect.gen(function*() {
-        const result = yield* parseUpdateIssueParams({ project: "HULY", identifier: "HULY-123" })
-        expect(result).toEqual({ project: "HULY", identifier: "HULY-123" })
+        const error = yield* Effect.flip(parseUpdateIssueParams({ project: "HULY", identifier: "HULY-123" }))
+        expect(error._tag).toBe("ParseError")
 
         const schema = expectJsonSchemaObject(updateIssueParamsJsonSchema)
         expect(schema.anyOf).toEqual(
@@ -504,10 +504,10 @@ describe("Domain Schemas", () => {
   })
 
   describe("Other update schemas", () => {
-    it.effect("card updates parse minimal params and advertise update-field requirement", () =>
+    it.effect("card updates reject minimal params and advertise update-field requirement", () =>
       Effect.gen(function*() {
-        const result = yield* parseUpdateCardParams({ cardSpace: "Cards", card: "Roadmap" })
-        expect(result).toEqual({ cardSpace: "Cards", card: "Roadmap" })
+        const error = yield* Effect.flip(parseUpdateCardParams({ cardSpace: "Cards", card: "Roadmap" }))
+        expect(error._tag).toBe("ParseError")
 
         const schema = expectJsonSchemaObject(updateCardParamsJsonSchema)
         expect(schema.anyOf).toEqual(
@@ -515,12 +515,12 @@ describe("Domain Schemas", () => {
         )
       }))
 
-    it.effect("workspace updates parse minimal params and advertise update-field requirement", () =>
+    it.effect("workspace updates reject minimal params and advertise update-field requirement", () =>
       Effect.gen(function*() {
-        const profile = yield* parseUpdateUserProfileParams({})
-        const guestSettings = yield* parseUpdateGuestSettingsParams({})
-        expect(profile).toEqual({})
-        expect(guestSettings).toEqual({})
+        const profileError = yield* Effect.flip(parseUpdateUserProfileParams({}))
+        const guestSettingsError = yield* Effect.flip(parseUpdateGuestSettingsParams({}))
+        expect(profileError._tag).toBe("ParseError")
+        expect(guestSettingsError._tag).toBe("ParseError")
 
         const profileSchema = expectJsonSchemaObject(updateUserProfileParamsJsonSchema)
         expect(profileSchema.anyOf).toEqual(
@@ -540,14 +540,16 @@ describe("Domain Schemas", () => {
         )
       }))
 
-    it.effect("test-management updates parse minimal params and advertise update-field requirement", () =>
+    it.effect("test-management updates reject minimal params and advertise update-field requirement", () =>
       Effect.gen(function*() {
-        const plan = yield* parseUpdateTestPlanParams({ project: "QA", plan: "Regression" })
-        const run = yield* parseUpdateTestRunParams({ project: "QA", run: "Nightly" })
-        const result = yield* parseUpdateTestResultParams({ project: "QA", result: "Login result" })
-        expect(plan).toEqual({ project: "QA", plan: "Regression" })
-        expect(run).toEqual({ project: "QA", run: "Nightly" })
-        expect(result).toEqual({ project: "QA", result: "Login result" })
+        const planError = yield* Effect.flip(parseUpdateTestPlanParams({ project: "QA", plan: "Regression" }))
+        const runError = yield* Effect.flip(parseUpdateTestRunParams({ project: "QA", run: "Nightly" }))
+        const resultError = yield* Effect.flip(
+          parseUpdateTestResultParams({ project: "QA", result: "Login result" })
+        )
+        expect(planError._tag).toBe("ParseError")
+        expect(runError._tag).toBe("ParseError")
+        expect(resultError._tag).toBe("ParseError")
 
         const planSchema = expectJsonSchemaObject(updateTestPlanParamsJsonSchema)
         expect(planSchema.anyOf).toEqual(

--- a/test/domain/schemas/domain-contracts.property.test.ts
+++ b/test/domain/schemas/domain-contracts.property.test.ts
@@ -1,0 +1,611 @@
+import { describe } from "@effect/vitest"
+import { Schema } from "effect"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import {
+  UPDATE_ATTACHMENT_FIELDS,
+  updateAttachmentParamsJsonSchema,
+  UpdateAttachmentParamsSchema
+} from "../../../src/domain/schemas/attachments.js"
+import {
+  UPDATE_EVENT_FIELDS,
+  updateEventParamsJsonSchema,
+  UpdateEventParamsSchema
+} from "../../../src/domain/schemas/calendar.js"
+import {
+  UPDATE_CARD_FIELDS,
+  updateCardParamsJsonSchema,
+  UpdateCardParamsSchema
+} from "../../../src/domain/schemas/cards.js"
+import {
+  UPDATE_CHANNEL_FIELDS,
+  updateChannelParamsJsonSchema,
+  UpdateChannelParamsSchema
+} from "../../../src/domain/schemas/channels.js"
+import {
+  UPDATE_COMPONENT_FIELDS,
+  updateComponentParamsJsonSchema,
+  UpdateComponentParamsSchema
+} from "../../../src/domain/schemas/components.js"
+import {
+  UPDATE_ORGANIZATION_FIELDS,
+  UPDATE_PERSON_FIELDS,
+  updateOrganizationParamsJsonSchema,
+  UpdateOrganizationParamsSchema,
+  updatePersonParamsJsonSchema,
+  UpdatePersonParamsSchema
+} from "../../../src/domain/schemas/contacts.js"
+import {
+  EDIT_DOCUMENT_UPDATE_FIELD_GROUPS,
+  editDocumentParamsJsonSchema,
+  EditDocumentParamsSchema,
+  UPDATE_TEAMSPACE_FIELDS,
+  updateTeamspaceParamsJsonSchema,
+  UpdateTeamspaceParamsSchema
+} from "../../../src/domain/schemas/documents.js"
+import {
+  UPDATE_ISSUE_TEMPLATE_FIELDS,
+  updateIssueTemplateParamsJsonSchema,
+  UpdateIssueTemplateParamsSchema
+} from "../../../src/domain/schemas/issue-templates.js"
+import {
+  IssuePrioritySchema,
+  IssuePriorityValues,
+  UPDATE_ISSUE_FIELDS,
+  updateIssueParamsJsonSchema,
+  UpdateIssueParamsSchema
+} from "../../../src/domain/schemas/issues.js"
+import {
+  UPDATE_LABEL_FIELDS,
+  updateLabelParamsJsonSchema,
+  UpdateLabelParamsSchema
+} from "../../../src/domain/schemas/labels.js"
+import { LeadIdentifier } from "../../../src/domain/schemas/leads.js"
+import {
+  UPDATE_MILESTONE_FIELDS,
+  updateMilestoneParamsJsonSchema,
+  UpdateMilestoneParamsSchema
+} from "../../../src/domain/schemas/milestones.js"
+import {
+  UPDATE_PROJECT_FIELDS,
+  updateProjectParamsJsonSchema,
+  UpdateProjectParamsSchema
+} from "../../../src/domain/schemas/projects.js"
+import { atLeastOneUpdateFieldMessage, NonEmptyString } from "../../../src/domain/schemas/shared.js"
+import {
+  UPDATE_TAG_CATEGORY_FIELDS,
+  updateTagCategoryParamsJsonSchema,
+  UpdateTagCategoryParamsSchema
+} from "../../../src/domain/schemas/tag-categories.js"
+import {
+  UPDATE_TAG_FIELDS,
+  updateTagParamsJsonSchema,
+  UpdateTagParamsSchema
+} from "../../../src/domain/schemas/tags.js"
+import {
+  UPDATE_TEST_CASE_FIELDS,
+  UPDATE_TEST_SUITE_FIELDS,
+  updateTestCaseParamsJsonSchema,
+  UpdateTestCaseParamsSchema,
+  updateTestSuiteParamsJsonSchema,
+  UpdateTestSuiteParamsSchema
+} from "../../../src/domain/schemas/test-management-core.js"
+import {
+  UPDATE_TEST_PLAN_FIELDS,
+  UPDATE_TEST_RESULT_FIELDS,
+  UPDATE_TEST_RUN_FIELDS,
+  updateTestPlanParamsJsonSchema,
+  UpdateTestPlanParamsSchema,
+  updateTestResultParamsJsonSchema,
+  UpdateTestResultParamsSchema,
+  updateTestRunParamsJsonSchema,
+  UpdateTestRunParamsSchema
+} from "../../../src/domain/schemas/test-management-plans.js"
+import {
+  CreateAccessLinkParamsSchema,
+  UPDATE_GUEST_SETTINGS_FIELDS,
+  UPDATE_USER_PROFILE_FIELDS,
+  updateGuestSettingsParamsJsonSchema,
+  UpdateGuestSettingsParamsSchema,
+  updateUserProfileParamsJsonSchema,
+  UpdateUserProfileParamsSchema
+} from "../../../src/domain/schemas/workspace.js"
+import { propertyTestParameters } from "../../helpers/property.js"
+
+type JsonSchemaObject = {
+  readonly anyOf?: ReadonlyArray<{ readonly required?: ReadonlyArray<string> }>
+  readonly allOf?: ReadonlyArray<unknown>
+  readonly properties?: Record<string, unknown>
+}
+
+interface UpdateSchemaCase {
+  readonly name: string
+  readonly schema: Schema.Schema.AnyNoContext
+  readonly jsonSchema: JsonSchemaObject
+  readonly base: Record<string, unknown>
+  readonly fields: ReadonlyArray<string>
+  readonly values: Readonly<Record<string, unknown>>
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const decodeSucceeds = (schema: Schema.Schema.AnyNoContext, input: unknown): boolean =>
+  Schema.decodeUnknownEither(schema)(input)._tag === "Right"
+
+const jsonSchemaRequiredFields = (schema: JsonSchemaObject): ReadonlyArray<string> =>
+  (schema.anyOf ?? []).flatMap((branch) => branch.required ?? [])
+
+const expectDecodeFailure = (schema: Schema.Schema.AnyNoContext, input: unknown): void => {
+  expect(Schema.decodeUnknownEither(schema)(input)._tag).toBe("Left")
+}
+
+const expectDecodeFailureContaining = (
+  schema: Schema.Schema.AnyNoContext,
+  input: unknown,
+  message: string
+): void => {
+  const decoded = Schema.decodeUnknownEither(schema)(input)
+
+  expect(decoded._tag).toBe("Left")
+  if (decoded._tag === "Left") {
+    expect(String(decoded.left)).toContain(message)
+  }
+}
+
+const expectDecodeSuccess = (schema: Schema.Schema.AnyNoContext, input: unknown): void => {
+  expect(Schema.decodeUnknownEither(schema)(input)._tag).toBe("Right")
+}
+
+const nonWhitespaceStringArbitrary = fc.string({ maxLength: 80 }).filter((value) => value.trim().length > 0)
+const whitespaceOnlyStringArbitrary = fc.string({ maxLength: 40 }).filter((value) => value.trim().length === 0)
+
+const caseVariant = (value: string): fc.Arbitrary<string> =>
+  fc.array(fc.boolean(), { minLength: value.length, maxLength: value.length }).map((upperByIndex) =>
+    value
+      .split("")
+      .map((char, index) => upperByIndex[index] === true ? char.toUpperCase() : char.toLowerCase())
+      .join("")
+  )
+
+const priorityInputArbitrary = fc.constantFrom(...IssuePriorityValues).chain((priority) =>
+  priority === "no-priority"
+    ? fc.constantFrom("no-priority", "no_priority", "no priority", "nopriority", "NO-PRIORITY", "No Priority")
+    : caseVariant(priority)
+      .map((variant) => variant)
+      .map((variant) => variant)
+).chain((variant) =>
+  fc.record({
+    left: fc.constantFrom("", " "),
+    right: fc.constantFrom("", " ")
+  }).map(({ left, right }) => `${left}${variant}${right}`)
+)
+
+const invalidPriorityArbitrary = fc.stringMatching(/^x[A-Za-z0-9 _-]{0,16}$/)
+
+const leadDigitsArbitrary = fc.nat({ max: 999_999 }).map(String)
+const leadInputArbitrary = leadDigitsArbitrary.chain((digits) =>
+  fc.record({
+    prefix: fc.constantFrom("", "LEAD-", "lead-", "Lead-"),
+    left: fc.stringMatching(/^\s{0,2}$/),
+    right: fc.stringMatching(/^\s{0,2}$/)
+  }).map(({ left, prefix, right }) => ({
+    input: `${left}${prefix}${digits}${right}`,
+    expected: `LEAD-${digits}`
+  }))
+)
+
+const unixSecondsArbitrary = fc.integer({ min: 0, max: 9_999_999_998 })
+const anonymousValidityWindowArbitrary = fc.integer({ min: 1, max: 86_400 }).chain((duration) =>
+  fc.integer({ min: 0, max: 9_999_999_999 - duration }).map((notBefore) => ({
+    duration,
+    notBefore
+  }))
+)
+
+const optionalStringArbitrary = fc.option(fc.string({ maxLength: 20 }), { nil: undefined })
+const optionalNonEmptyStringArbitrary = fc.option(nonWhitespaceStringArbitrary, { nil: undefined })
+const optionalBooleanArbitrary = fc.option(fc.boolean(), { nil: undefined })
+
+const editDocumentParamsArbitrary = fc.record({
+  title: optionalNonEmptyStringArbitrary,
+  content: optionalStringArbitrary,
+  old_text: optionalStringArbitrary,
+  new_text: optionalStringArbitrary,
+  replace_all: optionalBooleanArbitrary
+}).map((params) => ({
+  teamspace: "Engineering",
+  document: "Runbook",
+  ...params
+}))
+
+const modelEditDocumentAcceptance = (params: {
+  readonly title?: string | undefined
+  readonly content?: string | undefined
+  readonly old_text?: string | undefined
+  readonly new_text?: string | undefined
+  readonly replace_all?: boolean | undefined
+}): boolean => {
+  const hasContent = params.content !== undefined
+  const hasOldText = params.old_text !== undefined
+  const hasNewText = params.new_text !== undefined
+  const hasSearchReplace = hasOldText && hasNewText
+  const hasUpdateField = params.title !== undefined || hasContent || hasSearchReplace
+
+  return !(
+    hasContent && (hasOldText || hasNewText)
+    || hasOldText !== hasNewText
+    || params.replace_all !== undefined && !hasOldText
+    || !hasUpdateField
+    || hasOldText && params.old_text.trim() === ""
+  )
+}
+
+const updateSchemaCases: ReadonlyArray<UpdateSchemaCase> = [
+  {
+    name: "UpdateAttachmentParamsSchema",
+    schema: UpdateAttachmentParamsSchema,
+    jsonSchema: updateAttachmentParamsJsonSchema,
+    base: { attachmentId: "attachment-1" },
+    fields: UPDATE_ATTACHMENT_FIELDS,
+    values: { description: null, pinned: true }
+  },
+  {
+    name: "UpdateCardParamsSchema",
+    schema: UpdateCardParamsSchema,
+    jsonSchema: updateCardParamsJsonSchema,
+    base: { cardSpace: "Cards", card: "Roadmap" },
+    fields: UPDATE_CARD_FIELDS,
+    values: { content: "Updated", title: "Updated" }
+  },
+  {
+    name: "UpdateChannelParamsSchema",
+    schema: UpdateChannelParamsSchema,
+    jsonSchema: updateChannelParamsJsonSchema,
+    base: { channel: "general" },
+    fields: UPDATE_CHANNEL_FIELDS,
+    values: { name: "Updated", topic: "Updated" }
+  },
+  {
+    name: "UpdateComponentParamsSchema",
+    schema: UpdateComponentParamsSchema,
+    jsonSchema: updateComponentParamsJsonSchema,
+    base: { project: "HULY", component: "Backend" },
+    fields: UPDATE_COMPONENT_FIELDS,
+    values: { description: "Updated", label: "Updated", lead: null }
+  },
+  {
+    name: "UpdateEventParamsSchema",
+    schema: UpdateEventParamsSchema,
+    jsonSchema: updateEventParamsJsonSchema,
+    base: { eventId: "event-1" },
+    fields: UPDATE_EVENT_FIELDS,
+    values: {
+      allDay: true,
+      date: 1,
+      description: "Updated",
+      dueDate: 1,
+      location: "Updated",
+      title: "Updated",
+      visibility: "public"
+    }
+  },
+  {
+    name: "UpdateIssueParamsSchema",
+    schema: UpdateIssueParamsSchema,
+    jsonSchema: updateIssueParamsJsonSchema,
+    base: { project: "HULY", identifier: "HULY-1" },
+    fields: UPDATE_ISSUE_FIELDS,
+    values: {
+      assignee: null,
+      description: "Updated",
+      dueDate: null,
+      estimation: null,
+      priority: "low",
+      status: "Updated",
+      taskType: "Updated",
+      title: "Updated"
+    }
+  },
+  {
+    name: "UpdateIssueTemplateParamsSchema",
+    schema: UpdateIssueTemplateParamsSchema,
+    jsonSchema: updateIssueTemplateParamsJsonSchema,
+    base: { project: "HULY", template: "Bug report" },
+    fields: UPDATE_ISSUE_TEMPLATE_FIELDS,
+    values: {
+      assignee: null,
+      component: null,
+      description: "Updated",
+      estimation: 1,
+      priority: "low",
+      title: "Updated"
+    }
+  },
+  {
+    name: "UpdateLabelParamsSchema",
+    schema: UpdateLabelParamsSchema,
+    jsonSchema: updateLabelParamsJsonSchema,
+    base: { label: "bug" },
+    fields: UPDATE_LABEL_FIELDS,
+    values: { color: 1, description: "Updated", title: "Updated" }
+  },
+  {
+    name: "UpdateMilestoneParamsSchema",
+    schema: UpdateMilestoneParamsSchema,
+    jsonSchema: updateMilestoneParamsJsonSchema,
+    base: { project: "HULY", milestone: "v1" },
+    fields: UPDATE_MILESTONE_FIELDS,
+    values: { description: "Updated", label: "Updated", status: "planned", targetDate: 1 }
+  },
+  {
+    name: "UpdateOrganizationParamsSchema",
+    schema: UpdateOrganizationParamsSchema,
+    jsonSchema: updateOrganizationParamsJsonSchema,
+    base: { identifier: "Acme" },
+    fields: UPDATE_ORGANIZATION_FIELDS,
+    values: { city: null, description: null, name: "Updated" }
+  },
+  {
+    name: "UpdatePersonParamsSchema",
+    schema: UpdatePersonParamsSchema,
+    jsonSchema: updatePersonParamsJsonSchema,
+    base: { personId: "person-1" },
+    fields: UPDATE_PERSON_FIELDS,
+    values: { city: null, firstName: "Updated", lastName: "Updated" }
+  },
+  {
+    name: "UpdateProjectParamsSchema",
+    schema: UpdateProjectParamsSchema,
+    jsonSchema: updateProjectParamsJsonSchema,
+    base: { project: "HULY" },
+    fields: UPDATE_PROJECT_FIELDS,
+    values: { description: null, name: "Updated" }
+  },
+  {
+    name: "UpdateTagCategoryParamsSchema",
+    schema: UpdateTagCategoryParamsSchema,
+    jsonSchema: updateTagCategoryParamsJsonSchema,
+    base: { category: "Priority" },
+    fields: UPDATE_TAG_CATEGORY_FIELDS,
+    values: { default: true, label: "Updated" }
+  },
+  {
+    name: "UpdateTagParamsSchema",
+    schema: UpdateTagParamsSchema,
+    jsonSchema: updateTagParamsJsonSchema,
+    base: { targetClass: "tracker:class:Issue", tag: "bug" },
+    fields: UPDATE_TAG_FIELDS,
+    values: { category: "Updated", color: 1, description: "Updated", title: "Updated" }
+  },
+  {
+    name: "UpdateTeamspaceParamsSchema",
+    schema: UpdateTeamspaceParamsSchema,
+    jsonSchema: updateTeamspaceParamsJsonSchema,
+    base: { teamspace: "Engineering" },
+    fields: UPDATE_TEAMSPACE_FIELDS,
+    values: { archived: true, description: null, name: "Updated" }
+  },
+  {
+    name: "UpdateTestCaseParamsSchema",
+    schema: UpdateTestCaseParamsSchema,
+    jsonSchema: updateTestCaseParamsJsonSchema,
+    base: { project: "QA", testCase: "Login" },
+    fields: UPDATE_TEST_CASE_FIELDS,
+    values: {
+      assignee: null,
+      description: null,
+      name: "Updated",
+      priority: "low",
+      status: "draft",
+      type: "functional"
+    }
+  },
+  {
+    name: "UpdateTestPlanParamsSchema",
+    schema: UpdateTestPlanParamsSchema,
+    jsonSchema: updateTestPlanParamsJsonSchema,
+    base: { project: "QA", plan: "Regression" },
+    fields: UPDATE_TEST_PLAN_FIELDS,
+    values: { description: null, name: "Updated" }
+  },
+  {
+    name: "UpdateTestResultParamsSchema",
+    schema: UpdateTestResultParamsSchema,
+    jsonSchema: updateTestResultParamsJsonSchema,
+    base: { project: "QA", result: "Login result" },
+    fields: UPDATE_TEST_RESULT_FIELDS,
+    values: { assignee: null, description: null, status: "passed" }
+  },
+  {
+    name: "UpdateTestRunParamsSchema",
+    schema: UpdateTestRunParamsSchema,
+    jsonSchema: updateTestRunParamsJsonSchema,
+    base: { project: "QA", run: "Nightly" },
+    fields: UPDATE_TEST_RUN_FIELDS,
+    values: { description: null, dueDate: null, name: "Updated" }
+  },
+  {
+    name: "UpdateTestSuiteParamsSchema",
+    schema: UpdateTestSuiteParamsSchema,
+    jsonSchema: updateTestSuiteParamsJsonSchema,
+    base: { project: "QA", suite: "Smoke" },
+    fields: UPDATE_TEST_SUITE_FIELDS,
+    values: { description: null, name: "Updated" }
+  },
+  {
+    name: "UpdateUserProfileParamsSchema",
+    schema: UpdateUserProfileParamsSchema,
+    jsonSchema: updateUserProfileParamsJsonSchema,
+    base: {},
+    fields: UPDATE_USER_PROFILE_FIELDS,
+    values: {
+      bio: "Updated",
+      city: "Updated",
+      country: "Updated",
+      isPublic: true,
+      socialLinks: null,
+      website: "Updated"
+    }
+  },
+  {
+    name: "UpdateGuestSettingsParamsSchema",
+    schema: UpdateGuestSettingsParamsSchema,
+    jsonSchema: updateGuestSettingsParamsJsonSchema,
+    base: {},
+    fields: UPDATE_GUEST_SETTINGS_FIELDS,
+    values: { allowReadOnly: true, allowSignUp: true }
+  }
+]
+
+describe("shared/domain schema properties", () => {
+  it("NonEmptyString decodes exactly trimmed non-empty strings and rejects blank strings", () => {
+    fc.assert(
+      fc.property(nonWhitespaceStringArbitrary, (input) => {
+        const decoded = Schema.decodeUnknownEither(NonEmptyString)(input)
+
+        expect(decoded._tag).toBe("Right")
+        if (decoded._tag === "Right") {
+          expect(decoded.right).toBe(input.trim())
+        }
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(whitespaceOnlyStringArbitrary, (input) => {
+        expect(Schema.decodeUnknownEither(NonEmptyString)(input)._tag).toBe("Left")
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("IssuePrioritySchema normalizes accepted spellings and rejects unrelated values", () => {
+    fc.assert(
+      fc.property(priorityInputArbitrary, (input) => {
+        const decoded = Schema.decodeUnknownEither(IssuePrioritySchema)(input)
+
+        expect(decoded._tag).toBe("Right")
+        if (decoded._tag === "Right") {
+          expect(IssuePriorityValues).toContain(decoded.right)
+        }
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(invalidPriorityArbitrary, (input) => {
+        expect(Schema.decodeUnknownEither(IssuePrioritySchema)(input)._tag).toBe("Left")
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("LeadIdentifier canonicalizes numeric and prefixed inputs to LEAD-number", () => {
+    fc.assert(
+      fc.property(leadInputArbitrary, ({ expected, input }) => {
+        const decoded = Schema.decodeUnknownEither(LeadIdentifier)(input)
+
+        expect(decoded._tag).toBe("Right")
+        if (decoded._tag === "Right") {
+          expect(decoded.right).toBe(expected)
+        }
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(fc.stringMatching(/^[A-Z]{1,8}-[A-Z0-9]{1,8}$/), (input) => {
+        fc.pre(!/^LEAD-\d+$/i.test(input))
+        expect(Schema.decodeUnknownEither(LeadIdentifier)(input)._tag).toBe("Left")
+      }),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("access-link and document state-machine properties", () => {
+  it("CreateAccessLinkParamsSchema enforces anonymous validity windows and timestamp ordering", () => {
+    fc.assert(
+      fc.property(anonymousValidityWindowArbitrary, ({ duration, notBefore }) => {
+        expectDecodeSuccess(CreateAccessLinkParamsSchema, {
+          personalized: false,
+          notBefore,
+          expiration: notBefore + duration
+        })
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(unixSecondsArbitrary, (timestamp) => {
+        expectDecodeFailure(CreateAccessLinkParamsSchema, { personalized: false, notBefore: timestamp })
+        expectDecodeFailure(CreateAccessLinkParamsSchema, { personalized: false, expiration: timestamp })
+        expectDecodeFailure(CreateAccessLinkParamsSchema, {
+          personalized: false,
+          notBefore: timestamp,
+          expiration: timestamp
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("EditDocumentParamsSchema runtime acceptance matches the documented edit modes", () => {
+    fc.assert(
+      fc.property(editDocumentParamsArbitrary, (params) => {
+        expect(decodeSucceeds(EditDocumentParamsSchema, params)).toBe(modelEditDocumentAcceptance(params))
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("edit_document JSON Schema advertises the same update groups and old_text constraints", () => {
+    expect(jsonSchemaRequiredFields(editDocumentParamsJsonSchema)).toEqual(["title", "content", "old_text", "new_text"])
+    expect(editDocumentParamsJsonSchema.anyOf).toContainEqual({ required: ["old_text", "new_text"] })
+    expect(editDocumentParamsJsonSchema.allOf).toEqual(expect.arrayContaining([
+      { if: { required: ["old_text"] }, then: { required: ["new_text"] } },
+      { if: { required: ["new_text"] }, then: { required: ["old_text"] } },
+      { if: { required: ["replace_all"] }, then: { required: ["old_text", "new_text"] } }
+    ]))
+
+    const properties: Record<string, unknown> = isRecord(editDocumentParamsJsonSchema.properties)
+      ? editDocumentParamsJsonSchema.properties
+      : {}
+    const oldText = isRecord(properties.old_text) ? properties.old_text : {}
+    expect(oldText.pattern).toBe("\\S")
+    expect(EDIT_DOCUMENT_UPDATE_FIELD_GROUPS).toEqual(["title", "content", "old_text/new_text"])
+  })
+})
+
+describe("update schema runtime and JSON Schema agreement", () => {
+  it("rejects locator-only updates at runtime and exports the same at-least-one field set in JSON Schema", () => {
+    for (const testCase of updateSchemaCases) {
+      expectDecodeFailure(testCase.schema, testCase.base)
+      expect(jsonSchemaRequiredFields(testCase.jsonSchema)).toEqual(testCase.fields)
+
+      for (const field of testCase.fields) {
+        expectDecodeSuccess(testCase.schema, { ...testCase.base, [field]: testCase.values[field] })
+      }
+
+      fc.assert(
+        fc.property(fc.subarray([...testCase.fields], { minLength: 1 }), (fields) => {
+          const payload = Object.fromEntries(fields.map((field) => [field, testCase.values[field]]))
+
+          expectDecodeSuccess(testCase.schema, { ...testCase.base, ...payload })
+        }),
+        propertyTestParameters
+      )
+    }
+  })
+
+  it("uses the shared at-least-one error message for update schemas", () => {
+    for (const testCase of updateSchemaCases) {
+      const message = atLeastOneUpdateFieldMessage(testCase.fields)
+
+      expect(message).toContain(testCase.fields.join(", "))
+      expectDecodeFailureContaining(testCase.schema, testCase.base, message)
+    }
+  })
+})

--- a/test/domain/schemas/generic-associations.property.test.ts
+++ b/test/domain/schemas/generic-associations.property.test.ts
@@ -1,0 +1,103 @@
+import { describe } from "@effect/vitest"
+import { Schema } from "effect"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import {
+  DeleteRelationParamsSchema,
+  GenericObjectLocatorSchema,
+  ListRelationsParamsSchema
+} from "../../../src/domain/schemas/generic-associations.js"
+import { propertyTestParameters } from "../../helpers/property.js"
+
+const strictParseOptions = { onExcessProperty: "error" } as const
+
+const idArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{0,18}$/)
+const classArbitrary = fc.stringMatching(/^[a-z]+:class:[A-Za-z][A-Za-z0-9]{0,18}$/)
+
+const rawLocatorArbitrary = fc.record({
+  kind: fc.constant("raw"),
+  id: idArbitrary,
+  class: fc.option(classArbitrary, { nil: undefined })
+})
+
+const issueLocatorArbitrary = fc.record({
+  kind: fc.constant("issue"),
+  issue: fc.stringMatching(/^[A-Z]{2,5}-[1-9][0-9]{0,5}$/),
+  project: fc.option(fc.stringMatching(/^[A-Z]{2,5}$/), { nil: undefined })
+})
+
+const documentLocatorArbitrary = fc.record({
+  kind: fc.constant("document"),
+  document: idArbitrary,
+  teamspace: fc.option(idArbitrary, { nil: undefined })
+})
+
+const cardLocatorArbitrary = fc.record({
+  kind: fc.constant("card"),
+  card: idArbitrary,
+  cardSpace: fc.option(idArbitrary, { nil: undefined })
+})
+
+const locatorArbitrary = fc.oneof(
+  rawLocatorArbitrary,
+  issueLocatorArbitrary,
+  documentLocatorArbitrary,
+  cardLocatorArbitrary
+)
+
+const decodeSucceeds = (schema: Schema.Schema.AnyNoContext, input: unknown): boolean =>
+  Schema.decodeUnknownEither(schema, strictParseOptions)(input)._tag === "Right"
+
+describe("generic association locator properties", () => {
+  it("GenericObjectLocatorSchema accepts each explicit locator kind under strict decoding", () => {
+    fc.assert(
+      fc.property(locatorArbitrary, (locator) => {
+        expect(decodeSucceeds(GenericObjectLocatorSchema, locator)).toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("GenericObjectLocatorSchema rejects cross-kind field subsets under strict decoding", () => {
+    fc.assert(
+      fc.property(locatorArbitrary, (locator) => {
+        const poisonedLocator = {
+          ...locator,
+          issue: "HULY-1",
+          document: "Doc",
+          card: "Card",
+          unexpected: "extra"
+        }
+
+        expect(decodeSucceeds(GenericObjectLocatorSchema, poisonedLocator)).toBe(false)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("ListRelationsParamsSchema requires a narrowing association, source, or target", () => {
+    fc.assert(
+      fc.property(locatorArbitrary, fc.constantFrom("association", "source", "target"), (locator, field) => {
+        expect(decodeSucceeds(ListRelationsParamsSchema, {})).toBe(false)
+        expect(decodeSucceeds(ListRelationsParamsSchema, { [field]: field === "association" ? "Dependency" : locator }))
+          .toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("DeleteRelationParamsSchema is a strict either-by-id or by-triple union", () => {
+    fc.assert(
+      fc.property(locatorArbitrary, locatorArbitrary, idArbitrary, (source, target, relation) => {
+        expect(decodeSucceeds(DeleteRelationParamsSchema, { relation })).toBe(true)
+        expect(decodeSucceeds(DeleteRelationParamsSchema, { association: "Dependency", source, target })).toBe(true)
+
+        expect(decodeSucceeds(DeleteRelationParamsSchema, { relation, association: "Dependency" })).toBe(false)
+        expect(decodeSucceeds(DeleteRelationParamsSchema, { association: "Dependency", source })).toBe(false)
+        expect(decodeSucceeds(DeleteRelationParamsSchema, { relation, source, target })).toBe(false)
+      }),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/domain/schemas/huly-model.property.test.ts
+++ b/test/domain/schemas/huly-model.property.test.ts
@@ -1,0 +1,202 @@
+import { describe } from "@effect/vitest"
+import { ClassifierKind } from "@hcengineering/core"
+import { Schema } from "effect"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import { CustomFieldInfoWireSchema } from "../../../src/domain/schemas/custom-fields.js"
+import { HulyAttributeTypeSchema, HulySdkClassifierKindSchema } from "../../../src/domain/schemas/sdk-discovery.js"
+import { propertyTestParameters } from "../../helpers/property.js"
+
+const idArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{0,18}$/)
+const classArbitrary = fc.stringMatching(/^[a-z]+:(class|mixin|interface):[A-Za-z][A-Za-z0-9]{0,18}$/)
+
+interface HulyAttributeTypeFixture {
+  readonly kind:
+    | "string"
+    | "number"
+    | "boolean"
+    | "date"
+    | "markup"
+    | "unknown"
+    | "ref"
+    | "enum"
+    | "collection"
+    | "array"
+  readonly classId?: string | undefined
+  readonly raw?: Record<string, unknown> | undefined
+  readonly refTo?: string | undefined
+  readonly enumId?: string | undefined
+  readonly collectionOf?: string | undefined
+  readonly arrayOf?: HulyAttributeTypeFixture | undefined
+}
+
+const rawDetailsArbitrary = fc.dictionary(
+  fc.stringMatching(/^[a-z][a-z0-9_]{0,8}$/),
+  fc.oneof(
+    fc.string({ maxLength: 20 }),
+    fc.integer({ min: -100, max: 100 }),
+    fc.boolean()
+  ),
+  { maxKeys: 3 }
+)
+const detailsWithoutRequiredCustomFieldKeysArbitrary = fc.dictionary(
+  fc.stringMatching(/^[a-z][a-z0-9_]{0,8}$/).filter((key) => key !== "enumRef" && key !== "of" && key !== "to"),
+  fc.oneof(fc.string({ maxLength: 20 }), fc.integer({ min: -100, max: 100 }), fc.boolean()),
+  { maxKeys: 3 }
+)
+
+const attributeTypeArbitrary = (depth: number): fc.Arbitrary<HulyAttributeTypeFixture> => {
+  const baseFields = fc.record({
+    classId: fc.option(classArbitrary, { nil: undefined }),
+    raw: fc.option(rawDetailsArbitrary, { nil: undefined })
+  })
+
+  const scalar = baseFields.chain((base) =>
+    fc.constantFrom("string", "number", "boolean", "date", "markup", "unknown").map((kind) => ({
+      ...base,
+      kind
+    }))
+  )
+  const ref = baseFields.chain((base) => classArbitrary.map((refTo) => ({ ...base, kind: "ref" as const, refTo })))
+  const enumType = baseFields.chain((base) => idArbitrary.map((enumId) => ({ ...base, kind: "enum" as const, enumId })))
+  const collection = baseFields.chain((base) =>
+    classArbitrary.map((collectionOf) => ({ ...base, kind: "collection" as const, collectionOf }))
+  )
+  const variants = [scalar, ref, enumType, collection]
+
+  if (depth <= 0) {
+    return fc.oneof(...variants)
+  }
+
+  const array = baseFields.chain((base) =>
+    attributeTypeArbitrary(depth - 1).map((arrayOf) => ({ ...base, kind: "array" as const, arrayOf }))
+  )
+
+  return fc.oneof(...variants, array)
+}
+
+const customFieldBaseArbitrary = fc.record({
+  id: idArbitrary,
+  name: fc.string({ maxLength: 20 }),
+  label: fc.string({ maxLength: 20 }),
+  ownerClassId: classArbitrary,
+  ownerLabel: fc.string({ maxLength: 20 })
+})
+
+const primitiveCustomFieldTypeArbitrary = fc.constantFrom("string", "number", "boolean", "date", "markup")
+
+const decodeSucceeds = (schema: Schema.Schema.AnyNoContext, input: unknown): boolean =>
+  Schema.decodeUnknownEither(schema)(input)._tag === "Right"
+
+describe("Huly model schema properties", () => {
+  it("HulyAttributeTypeSchema recursively decodes and encodes generated attribute types", () => {
+    fc.assert(
+      fc.property(attributeTypeArbitrary(3), (attributeType) => {
+        const decoded = Schema.decodeUnknownEither(HulyAttributeTypeSchema)(attributeType)
+
+        expect(decoded._tag).toBe("Right")
+        if (decoded._tag === "Right") {
+          const encoded = Schema.encodeEither(HulyAttributeTypeSchema)(decoded.right)
+
+          expect(encoded._tag).toBe("Right")
+          if (encoded._tag === "Right") {
+            expect(encoded.right).toEqual(attributeType)
+          }
+        }
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("HulyAttributeTypeSchema rejects variants missing kind-specific required fields", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          { kind: "ref" },
+          { kind: "enum" },
+          { kind: "collection" },
+          { kind: "array" }
+        ),
+        (attributeType) => {
+          expect(decodeSucceeds(HulyAttributeTypeSchema, attributeType)).toBe(false)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("HulySdkClassifierKindSchema roundtrips the SDK classifier enum values", () => {
+    const pairs = [
+      [ClassifierKind.CLASS, "class"],
+      [ClassifierKind.INTERFACE, "interface"],
+      [ClassifierKind.MIXIN, "mixin"]
+    ] as const
+
+    for (const [sdkKind, wireKind] of pairs) {
+      const decoded = Schema.decodeUnknownEither(HulySdkClassifierKindSchema)(sdkKind)
+      const encoded = Schema.encodeEither(HulySdkClassifierKindSchema)(wireKind)
+
+      expect(decoded._tag).toBe("Right")
+      if (decoded._tag === "Right") {
+        expect(decoded.right).toBe(wireKind)
+      }
+      expect(encoded._tag).toBe("Right")
+      if (encoded._tag === "Right") {
+        expect(encoded.right).toBe(sdkKind)
+      }
+    }
+  })
+
+  it("CustomFieldInfoWireSchema enforces typeDetails required by the custom field type", () => {
+    fc.assert(
+      fc.property(customFieldBaseArbitrary, primitiveCustomFieldTypeArbitrary, (base, type) => {
+        expect(decodeSucceeds(CustomFieldInfoWireSchema, { ...base, type, typeDetails: {} })).toBe(true)
+        expect(decodeSucceeds(CustomFieldInfoWireSchema, {
+          ...base,
+          type,
+          typeDetails: { extra: "not allowed for primitives" }
+        })).toBe(false)
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(
+        customFieldBaseArbitrary,
+        rawDetailsArbitrary,
+        detailsWithoutRequiredCustomFieldKeysArbitrary,
+        (base, extraDetails, missingDetails) => {
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, {
+            ...base,
+            type: "enum",
+            typeDetails: { ...extraDetails, enumRef: "status" }
+          })).toBe(true)
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, {
+            ...base,
+            type: "array",
+            typeDetails: { ...extraDetails, of: "string" }
+          })).toBe(true)
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, {
+            ...base,
+            type: "ref",
+            typeDetails: { ...extraDetails, to: "tracker:class:Issue" }
+          })).toBe(true)
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, {
+            ...base,
+            type: "unknown",
+            typeDetails: extraDetails
+          })).toBe(true)
+
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, { ...base, type: "enum", typeDetails: missingDetails }))
+            .toBe(false)
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, { ...base, type: "array", typeDetails: missingDetails }))
+            .toBe(false)
+          expect(decodeSucceeds(CustomFieldInfoWireSchema, { ...base, type: "ref", typeDetails: missingDetails }))
+            .toBe(false)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/domain/schemas/milestones.test.ts
+++ b/test/domain/schemas/milestones.test.ts
@@ -403,13 +403,13 @@ describe("Milestone Schemas", () => {
   })
 
   describe("UpdateMilestoneParamsSchema", () => {
-    it.effect("parses minimal params and advertises update-field requirement in JSON Schema", () =>
+    it.effect("rejects minimal params and advertises update-field requirement in JSON Schema", () =>
       Effect.gen(function*() {
-        const result = yield* parseUpdateMilestoneParams({
+        const error = yield* Effect.flip(parseUpdateMilestoneParams({
           project: "HULY",
           milestone: "Sprint 1"
-        })
-        expect(result).toEqual({ project: "HULY", milestone: "Sprint 1" })
+        }))
+        expect(error._tag).toBe("ParseError")
 
         const schema = expectJsonSchemaObject(updateMilestoneParamsJsonSchema)
         expect(schema.anyOf).toEqual(

--- a/test/helpers/property.ts
+++ b/test/helpers/property.ts
@@ -1,0 +1,56 @@
+import { Either, Schema } from "effect"
+import type { Parameters } from "fast-check"
+
+const DEFAULT_NUM_RUNS = 100
+
+export const propertyTestParameters = {
+  numRuns: DEFAULT_NUM_RUNS
+} satisfies Parameters
+
+export const assertDecodeSuccess = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  input: unknown
+): A => {
+  const result = Schema.decodeUnknownEither(schema)(input)
+
+  if (Either.isLeft(result)) {
+    throw new Error(`Expected schema decode to succeed, got: ${String(result.left)}`)
+  }
+
+  return result.right
+}
+
+export const assertDecodeFailure = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  input: unknown
+): void => {
+  const result = Schema.decodeUnknownEither(schema)(input)
+
+  if (Either.isRight(result)) {
+    throw new Error(`Expected schema decode to fail, got: ${String(result.right)}`)
+  }
+}
+
+export const assertEncodeSuccess = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  value: A
+): I => {
+  const result = Schema.encodeEither(schema)(value)
+
+  if (Either.isLeft(result)) {
+    throw new Error(`Expected schema encode to succeed, got: ${String(result.left)}`)
+  }
+
+  return result.right
+}
+
+export const assertEncodeFailure = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  value: A
+): void => {
+  const result = Schema.encodeEither(schema)(value)
+
+  if (Either.isRight(result)) {
+    throw new Error(`Expected schema encode to fail, got: ${String(result.right)}`)
+  }
+}

--- a/test/huly/model-labels-and-attribute-types.property.test.ts
+++ b/test/huly/model-labels-and-attribute-types.property.test.ts
@@ -1,0 +1,106 @@
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { NonEmptyString } from "../../src/domain/schemas/shared.js"
+import {
+  HULY_ATTRIBUTE_TYPE_CLASSES_WITH_UNKNOWN_KIND,
+  HULY_ATTRIBUTE_TYPE_KIND_BY_CLASS,
+  hulyAttributeTypeKindFromClass,
+  hulyCustomFieldTypeNameFromClass
+} from "../../src/huly/huly-attribute-types.js"
+import { decodeHulyModelLabelTail, hulyModelLabelTail } from "../../src/huly/huly-labels.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const labelSegmentArbitrary = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_-]{0,18}$/)
+const knownAttributeClassIds = new Set([
+  ...HULY_ATTRIBUTE_TYPE_KIND_BY_CLASS.map(([classId]) => classId),
+  ...HULY_ATTRIBUTE_TYPE_CLASSES_WITH_UNKNOWN_KIND
+])
+
+const expectedCustomFieldTypeByKind = {
+  string: "string",
+  number: "number",
+  boolean: "boolean",
+  date: "date",
+  markup: "markup",
+  ref: "ref",
+  enum: "enum",
+  array: "array",
+  collection: "unknown"
+} as const
+
+describe("Huly model label and attribute type properties", () => {
+  it("hulyModelLabelTail returns the final colon-delimited segment", () => {
+    fc.assert(
+      fc.property(fc.array(labelSegmentArbitrary, { minLength: 1, maxLength: 5 }), (segments) => {
+        const label = segments.join(":")
+
+        expect(hulyModelLabelTail(label)).toBe(segments[segments.length - 1])
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("decodeHulyModelLabelTail roundtrips generated labels to a non-empty tail", () => {
+    fc.assert(
+      fc.property(fc.array(labelSegmentArbitrary, { minLength: 1, maxLength: 5 }), (segments) => {
+        const decoded = decodeHulyModelLabelTail(segments.join(":"))
+
+        expect(decoded._tag).toBe("Right")
+        if (decoded._tag === "Right") {
+          expect(decoded.right).toBe(NonEmptyString.make(segments[segments.length - 1]))
+        }
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("decodeHulyModelLabelTail rejects non-strings and labels with empty final tails", () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.integer(), fc.boolean(), fc.array(fc.string({ maxLength: 10 }))), (value) => {
+        expect(decodeHulyModelLabelTail(value)._tag).toBe("Left")
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(fc.array(labelSegmentArbitrary, { minLength: 1, maxLength: 4 }), (segments) => {
+        expect(decodeHulyModelLabelTail(`${segments.join(":")}:`)._tag).toBe("Left")
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("attribute type class mappings agree with the exported mapping table", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...HULY_ATTRIBUTE_TYPE_KIND_BY_CLASS), ([classId, kind]) => {
+        expect(hulyAttributeTypeKindFromClass(classId)).toBe(kind)
+        expect(hulyCustomFieldTypeNameFromClass(classId)).toBe(expectedCustomFieldTypeByKind[kind])
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("unknown and non-string attribute type classes map to unknown", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^custom:class:[A-Za-z][A-Za-z0-9]{0,18}$/), (classId) => {
+        if (!knownAttributeClassIds.has(classId)) {
+          expect(hulyAttributeTypeKindFromClass(classId)).toBe("unknown")
+          expect(hulyCustomFieldTypeNameFromClass(classId)).toBe("unknown")
+        }
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.integer(), fc.boolean(), fc.record({ classId: fc.string({ maxLength: 20 }) })),
+        (value) => {
+          expect(hulyAttributeTypeKindFromClass(value)).toBe("unknown")
+          expect(hulyCustomFieldTypeNameFromClass(value)).toBe("unknown")
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/huly/operations/markup.property.test.ts
+++ b/test/huly/operations/markup.property.test.ts
@@ -1,0 +1,343 @@
+import type { Attrs, MarkupMark, MarkupNode } from "@hcengineering/text"
+import { MarkupMarkType, MarkupNodeType, markupToJSON } from "@hcengineering/text"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { INLINE_COMMENT_MARK_TYPE, isInlineCommentMark } from "../../../src/huly/operations/inline-comment-mark.js"
+import { sanitizeNodeForMarkdown } from "../../../src/huly/operations/markup.js"
+import { propertyTestParameters } from "../../helpers/property.js"
+
+interface RuntimeMarkupMark {
+  readonly type: MarkupMarkType | typeof INLINE_COMMENT_MARK_TYPE
+  readonly attrs?: Attrs
+}
+
+interface RuntimeMarkupNode {
+  readonly type: MarkupNodeType
+  readonly content?: Array<RuntimeMarkupNode>
+  readonly marks?: Array<RuntimeMarkupMark>
+  readonly attrs?: Attrs
+  readonly text?: string
+}
+
+interface MarkupNodeParts {
+  readonly type: MarkupNodeType
+  readonly content: Array<MarkupNode> | undefined
+  readonly marks: Array<MarkupMark> | undefined
+  readonly attrs: Attrs | undefined
+  readonly text: string | undefined
+}
+
+interface RuntimeMarkupNodeParts {
+  readonly type: MarkupNodeType
+  readonly content: Array<RuntimeMarkupNode> | undefined
+  readonly marks: Array<RuntimeMarkupMark> | undefined
+  readonly attrs: Attrs | undefined
+  readonly text: string | undefined
+}
+
+const supportedMarkTypeArbitrary = fc.constantFrom(
+  MarkupMarkType.link,
+  MarkupMarkType.em,
+  MarkupMarkType.bold,
+  MarkupMarkType.code,
+  MarkupMarkType.strike,
+  MarkupMarkType.underline,
+  MarkupMarkType.textColor,
+  MarkupMarkType.textStyle
+)
+
+const attrValueArbitrary = fc.oneof(
+  fc.string({ maxLength: 40 }),
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.boolean(),
+  fc.constant(null)
+)
+
+const attrsArbitrary: fc.Arbitrary<Attrs> = fc.dictionary(
+  fc.stringMatching(/^[a-z][a-zA-Z0-9_-]{0,16}$/),
+  attrValueArbitrary,
+  { maxKeys: 4 }
+)
+
+const optionalAttrsArbitrary = fc.option(attrsArbitrary, { nil: undefined })
+
+const supportedMarkArbitrary: fc.Arbitrary<MarkupMark> = fc
+  .record({
+    type: supportedMarkTypeArbitrary,
+    attrs: optionalAttrsArbitrary
+  })
+  .map(({ attrs, type }) => attrs === undefined ? { type } : { type, attrs })
+
+const inlineCommentMarkArbitrary: fc.Arbitrary<RuntimeMarkupMark> = optionalAttrsArbitrary.map((attrs) =>
+  attrs === undefined ? { type: INLINE_COMMENT_MARK_TYPE } : { type: INLINE_COMMENT_MARK_TYPE, attrs }
+)
+
+const runtimeMarkArbitrary: fc.Arbitrary<RuntimeMarkupMark> = fc.oneof(
+  supportedMarkArbitrary,
+  inlineCommentMarkArbitrary
+)
+
+const optionalSupportedMarksArbitrary = fc.option(
+  fc.array(supportedMarkArbitrary, { maxLength: 4 }),
+  { nil: undefined }
+)
+
+const optionalRuntimeMarksArbitrary = fc.option(
+  fc.array(runtimeMarkArbitrary, { maxLength: 5 }),
+  { nil: undefined }
+)
+
+const leafNodeTypeArbitrary = fc.constantFrom(
+  MarkupNodeType.text,
+  MarkupNodeType.hard_break,
+  MarkupNodeType.horizontal_rule,
+  MarkupNodeType.image,
+  MarkupNodeType.reference,
+  MarkupNodeType.emoji
+)
+
+const containerNodeTypeArbitrary = fc.constantFrom(
+  MarkupNodeType.doc,
+  MarkupNodeType.paragraph,
+  MarkupNodeType.blockquote,
+  MarkupNodeType.heading,
+  MarkupNodeType.code_block,
+  MarkupNodeType.ordered_list,
+  MarkupNodeType.bullet_list,
+  MarkupNodeType.list_item,
+  MarkupNodeType.table,
+  MarkupNodeType.table_row,
+  MarkupNodeType.table_cell,
+  MarkupNodeType.table_header
+)
+
+const buildMarkupNode = ({ attrs, content, marks, text, type }: MarkupNodeParts): MarkupNode => ({
+  type,
+  ...(content === undefined ? {} : { content }),
+  ...(marks === undefined ? {} : { marks }),
+  ...(attrs === undefined ? {} : { attrs }),
+  ...(text === undefined ? {} : { text })
+})
+
+const buildRuntimeMarkupNode = ({
+  attrs,
+  content,
+  marks,
+  text,
+  type
+}: RuntimeMarkupNodeParts): RuntimeMarkupNode => ({
+  type,
+  ...(content === undefined ? {} : { content }),
+  ...(marks === undefined ? {} : { marks }),
+  ...(attrs === undefined ? {} : { attrs }),
+  ...(text === undefined ? {} : { text })
+})
+
+const supportedMarkupNodeArbitrary = (maxDepth: number): fc.Arbitrary<MarkupNode> => {
+  const leaf = fc
+    .record({
+      type: leafNodeTypeArbitrary,
+      text: fc.string({ minLength: 1, maxLength: 60 }),
+      marks: optionalSupportedMarksArbitrary,
+      attrs: optionalAttrsArbitrary
+    })
+    .map(({ attrs, marks, text, type }) =>
+      buildMarkupNode({
+        type,
+        content: undefined,
+        marks,
+        attrs,
+        text: type === MarkupNodeType.text ? text : undefined
+      })
+    )
+
+  if (maxDepth <= 0) {
+    return leaf
+  }
+
+  const child = supportedMarkupNodeArbitrary(maxDepth - 1)
+  const container = fc
+    .record({
+      type: containerNodeTypeArbitrary,
+      content: fc.array(child, { maxLength: 4 }),
+      marks: optionalSupportedMarksArbitrary,
+      attrs: optionalAttrsArbitrary
+    })
+    .map(({ attrs, content, marks, type }) =>
+      buildMarkupNode({
+        type,
+        content,
+        marks,
+        attrs,
+        text: undefined
+      })
+    )
+
+  return fc.oneof(leaf, container)
+}
+
+const runtimeMarkupNodeArbitrary = (maxDepth: number): fc.Arbitrary<RuntimeMarkupNode> => {
+  const leaf = fc
+    .record({
+      type: leafNodeTypeArbitrary,
+      text: fc.string({ minLength: 1, maxLength: 60 }),
+      marks: optionalRuntimeMarksArbitrary,
+      attrs: optionalAttrsArbitrary
+    })
+    .map(({ attrs, marks, text, type }) =>
+      buildRuntimeMarkupNode({
+        type,
+        content: undefined,
+        marks,
+        attrs,
+        text: type === MarkupNodeType.text ? text : undefined
+      })
+    )
+
+  if (maxDepth <= 0) {
+    return leaf
+  }
+
+  const child = runtimeMarkupNodeArbitrary(maxDepth - 1)
+  const container = fc
+    .record({
+      type: containerNodeTypeArbitrary,
+      content: fc.array(child, { maxLength: 4 }),
+      marks: optionalRuntimeMarksArbitrary,
+      attrs: optionalAttrsArbitrary
+    })
+    .map(({ attrs, content, marks, type }) =>
+      buildRuntimeMarkupNode({
+        type,
+        content,
+        marks,
+        attrs,
+        text: undefined
+      })
+    )
+
+  return fc.oneof(leaf, container)
+}
+
+const runtimeRootArbitrary = fc
+  .record({
+    content: fc.array(runtimeMarkupNodeArbitrary(4), { maxLength: 4 }),
+    marks: optionalRuntimeMarksArbitrary,
+    attrs: optionalAttrsArbitrary
+  })
+  .map(({ attrs, content, marks }) =>
+    buildRuntimeMarkupNode({
+      type: MarkupNodeType.doc,
+      content,
+      marks,
+      attrs,
+      text: undefined
+    })
+  )
+
+const supportedRootArbitrary = fc
+  .record({
+    content: fc.array(supportedMarkupNodeArbitrary(4), { maxLength: 4 }),
+    marks: optionalSupportedMarksArbitrary,
+    attrs: optionalAttrsArbitrary
+  })
+  .map(({ attrs, content, marks }) =>
+    buildMarkupNode({
+      type: MarkupNodeType.doc,
+      content,
+      marks,
+      attrs,
+      text: undefined
+    })
+  )
+
+const generatedInlineCommentMark = {
+  type: INLINE_COMMENT_MARK_TYPE,
+  attrs: { thread: "generated-thread" }
+} satisfies RuntimeMarkupMark
+
+const toRuntimeMarkupNode = (node: RuntimeMarkupNode): MarkupNode => markupToJSON(JSON.stringify(node))
+
+const addInlineCommentMarksAtEveryNode = (node: RuntimeMarkupNode): RuntimeMarkupNode => ({
+  ...node,
+  marks: [...(node.marks ?? []), generatedInlineCommentMark],
+  ...(node.content === undefined
+    ? {}
+    : { content: node.content.map(addInlineCommentMarksAtEveryNode) })
+})
+
+const collectAllMarks = (node: MarkupNode): Array<MarkupMark> => [
+  ...(node.marks ?? []),
+  ...(node.content ?? []).flatMap(collectAllMarks)
+]
+
+describe("sanitizeNodeForMarkdown properties", () => {
+  it("is recursively idempotent", () => {
+    fc.assert(
+      fc.property(runtimeRootArbitrary, (generated) => {
+        const node = toRuntimeMarkupNode(generated)
+        const once = sanitizeNodeForMarkdown(node)
+        const twice = sanitizeNodeForMarkdown(once)
+
+        expect(twice).toEqual(once)
+        expect(twice).toBe(once)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("removes inline-comment marks at every depth", () => {
+    fc.assert(
+      fc.property(runtimeRootArbitrary.map(addInlineCommentMarksAtEveryNode), (generated) => {
+        const sanitized = sanitizeNodeForMarkdown(toRuntimeMarkupNode(generated))
+
+        expect(collectAllMarks(sanitized).map((mark) => mark.type)).not.toContain(INLINE_COMMENT_MARK_TYPE)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("preserves supported non-inline-comment marks", () => {
+    fc.assert(
+      fc.property(runtimeRootArbitrary, (generated) => {
+        const node = toRuntimeMarkupNode(generated)
+        const expectedMarks = collectAllMarks(node).filter((mark) => !isInlineCommentMark(mark))
+
+        expect(collectAllMarks(sanitizeNodeForMarkdown(node))).toEqual(expectedMarks)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("preserves object identity for already unchanged nodes", () => {
+    fc.assert(
+      fc.property(supportedRootArbitrary, (node) => {
+        expect(sanitizeNodeForMarkdown(node)).toBe(node)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("preserves object identity for unchanged sibling subtrees", () => {
+    fc.assert(
+      fc.property(
+        supportedMarkupNodeArbitrary(3),
+        runtimeMarkupNodeArbitrary(3).map((node) => toRuntimeMarkupNode(addInlineCommentMarksAtEveryNode(node))),
+        (unchangedChild, changedChild) => {
+          const root: MarkupNode = {
+            type: MarkupNodeType.doc,
+            content: [unchangedChild, changedChild]
+          }
+
+          const sanitized = sanitizeNodeForMarkdown(root)
+
+          expect(sanitized).not.toBe(root)
+          expect(sanitized.content?.[0]).toBe(unchangedChild)
+          expect(sanitized.content?.[1]).not.toBe(changedChild)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/huly/operations/pure-helpers.property.test.ts
+++ b/test/huly/operations/pure-helpers.property.test.ts
@@ -1,0 +1,404 @@
+import type { Doc, FindOptions, Lookup, Ref, Status } from "@hcengineering/core"
+import type { TagElement, TagReference } from "@hcengineering/tags"
+import { IssuePriority } from "@hcengineering/tracker"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { IssuePriorityValues } from "../../../src/domain/schemas/issues.js"
+import { DocId, MAX_LIMIT, NonNegativeNumber, TagReferenceId } from "../../../src/domain/schemas/shared.js"
+import { AttachedTagSummarySchema } from "../../../src/domain/schemas/tags.js"
+import {
+  TestCasePriorityValues,
+  TestCaseStatusValues,
+  TestCaseTypeValues,
+  TestRunStatusValues
+} from "../../../src/domain/schemas/test-management-core.js"
+import { core } from "../../../src/huly/huly-plugins.js"
+import {
+  parseIssueIdentifier,
+  priorityToString,
+  stringToPriority,
+  uniqueStatusDocs,
+  uniqueStatusRefs,
+  zeroAsUnset
+} from "../../../src/huly/operations/issues-shared.js"
+import { clampLimit, escapeLikeWildcards, withLookup } from "../../../src/huly/operations/query-helpers.js"
+import { toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import { normalizeColorCode, toAttachedTagSummary } from "../../../src/huly/operations/tags-shared.js"
+import {
+  stringToTestCasePriority,
+  stringToTestCaseStatus,
+  stringToTestCaseType,
+  stringToTestRunStatus,
+  testCasePriorityToString,
+  testCaseStatusToString,
+  testCaseTypeToString,
+  testRunStatusToString
+} from "../../../src/huly/operations/test-management-shared.js"
+import {
+  TestCasePriority,
+  TestCaseStatus,
+  TestCaseType,
+  TestRunStatus
+} from "../../../src/huly/test-management-types.js"
+import { assertDecodeSuccess, propertyTestParameters } from "../../helpers/property.js"
+
+interface LookupFixtureDoc extends Doc {
+  readonly reviewer?: Ref<Doc> | undefined
+}
+
+const hulyRefArbitrary = fc.stringMatching(/^[a-z][a-z0-9:._-]{0,24}$/)
+const projectIdentifierArbitrary = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9]{0,8}$/)
+const issuePrefixArbitrary = fc.stringMatching(/^[a-zA-Z]{1,8}$/)
+const issueNumberArbitrary = fc.integer({ min: 0, max: 999_999 })
+const nonMatchingIssueIdentifierArbitrary = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((value) => !/^([A-Z]+)-(\d+)$/i.test(value.trim()) && !/^\d+$/.test(value.trim()))
+const statusDocArbitrary = fc.record({
+  _id: hulyRefArbitrary.map((id) => toRef<Status>(DocId.make(id))),
+  marker: fc.string({ maxLength: 20 })
+})
+const finiteNonNegativeArbitrary = fc.double({
+  min: 0,
+  max: 1_000_000,
+  noNaN: true,
+  noDefaultInfinity: true
+})
+
+const escapedCharacterSet = new Set(["\\", "%", "_"])
+
+const isEscapedLikePattern = (value: string): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char === "%" || char === "_") {
+      return false
+    }
+    if (char === "\\") {
+      if (index + 1 >= value.length) {
+        return false
+      }
+      const escaped = value[index + 1]
+      if (!escapedCharacterSet.has(escaped)) {
+        return false
+      }
+      index += 1
+    }
+  }
+
+  return true
+}
+
+const firstIndexesByStatusRef = (refs: ReadonlyArray<Ref<Status>>): Map<Ref<Status>, number> => {
+  const firstIndexes = new Map<Ref<Status>, number>()
+  refs.forEach((ref, index) => {
+    if (!firstIndexes.has(ref)) {
+      firstIndexes.set(ref, index)
+    }
+  })
+  return firstIndexes
+}
+
+const priorityEnumValues = [
+  IssuePriority.Urgent,
+  IssuePriority.High,
+  IssuePriority.Medium,
+  IssuePriority.Low,
+  IssuePriority.NoPriority
+] as const
+
+const assertEnumMappingProperties = <EnumValue, WireValue extends string>(
+  values: ReadonlyArray<WireValue>,
+  enumValues: ReadonlyArray<EnumValue>,
+  toString: (value: EnumValue) => WireValue,
+  fromString: (value: string) => EnumValue | undefined
+): void => {
+  const validValues = new Set<string>(values)
+
+  for (const enumValue of enumValues) {
+    expect(fromString(toString(enumValue))).toBe(enumValue)
+  }
+
+  fc.assert(
+    fc.property(fc.constantFrom(...values), fc.boolean(), (value, uppercase) => {
+      const input = uppercase ? value.toUpperCase() : value
+      const parsed = fromString(input)
+
+      expect(parsed).not.toBeUndefined()
+      if (parsed !== undefined) {
+        expect(toString(parsed)).toBe(value)
+      }
+    }),
+    propertyTestParameters
+  )
+
+  fc.assert(
+    fc.property(
+      fc.string({ minLength: 1, maxLength: 30 }).filter((value) => !validValues.has(value.toLowerCase())),
+      (unknown) => {
+        expect(fromString(unknown)).toBeUndefined()
+      }
+    ),
+    propertyTestParameters
+  )
+}
+
+describe("pure Huly operation helper properties", () => {
+  it("parseIssueIdentifier canonicalizes full identifiers and keeps numeric value", () => {
+    fc.assert(
+      fc.property(issuePrefixArbitrary, issueNumberArbitrary, fc.boolean(), (project, issueNumber, lowerCase) => {
+        const prefix = lowerCase ? project.toLowerCase() : project.toUpperCase()
+        const identifier = `${prefix}-${issueNumber}`
+
+        expect(parseIssueIdentifier(identifier, "fallback")).toEqual({
+          fullIdentifier: `${project.toUpperCase()}-${issueNumber}`,
+          number: issueNumber
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("parseIssueIdentifier expands bare numbers with the project identifier", () => {
+    fc.assert(
+      fc.property(projectIdentifierArbitrary, issueNumberArbitrary, (project, issueNumber) => {
+        expect(parseIssueIdentifier(String(issueNumber), project)).toEqual({
+          fullIdentifier: `${project.toUpperCase()}-${issueNumber}`,
+          number: issueNumber
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("parseIssueIdentifier leaves malformed identifiers unresolved", () => {
+    fc.assert(
+      fc.property(nonMatchingIssueIdentifierArbitrary, projectIdentifierArbitrary, (identifier, project) => {
+        expect(parseIssueIdentifier(identifier, project)).toEqual({
+          fullIdentifier: identifier.trim(),
+          number: null
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("issue priority mapping roundtrips every SDK and wire value", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...priorityEnumValues), (priority) => {
+        expect(stringToPriority(priorityToString(priority))).toBe(priority)
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(fc.constantFrom(...IssuePriorityValues), (priority) => {
+        expect(priorityToString(stringToPriority(priority))).toBe(priority)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("uniqueStatusRefs preserves first occurrence order and removes duplicates", () => {
+    fc.assert(
+      fc.property(fc.array(hulyRefArbitrary.map((id) => toRef<Status>(DocId.make(id))), { maxLength: 50 }), (refs) => {
+        const unique = uniqueStatusRefs(refs)
+        const firstIndexes = firstIndexesByStatusRef(refs)
+
+        expect(unique).toHaveLength(firstIndexes.size)
+        expect(new Set(unique).size).toBe(unique.length)
+        expect(unique.map((ref) => firstIndexes.get(ref))).toEqual(
+          [...firstIndexes.values()]
+        )
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("uniqueStatusDocs preserves the first document for each status ref", () => {
+    fc.assert(
+      fc.property(fc.array(statusDocArbitrary, { maxLength: 50 }), (statuses) => {
+        const unique = uniqueStatusDocs(statuses)
+        const firstIndexes = firstIndexesByStatusRef(statuses.map((status) => status._id))
+
+        expect(unique).toHaveLength(firstIndexes.size)
+        expect(unique.map((status) => status._id)).toEqual([...firstIndexes.keys()])
+        for (const status of unique) {
+          expect(status).toBe(statuses[firstIndexes.get(status._id) ?? 0])
+        }
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("zeroAsUnset treats only zero as unset for non-negative values", () => {
+    expect(zeroAsUnset(NonNegativeNumber.make(0))).toBeUndefined()
+
+    fc.assert(
+      fc.property(finiteNonNegativeArbitrary.filter((value) => value > 0), (value) => {
+        expect(zeroAsUnset(NonNegativeNumber.make(value))).toBe(value)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("escapeLikeWildcards emits a pattern with no raw LIKE wildcard characters", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 120 }), (input) => {
+        const escaped = escapeLikeWildcards(input)
+
+        expect(escaped.length).toBeGreaterThanOrEqual(input.length)
+        expect(isEscapedLikePattern(escaped)).toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("withLookup preserves options and lets incoming lookup keys override existing keys", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: MAX_LIMIT }), fc.boolean(), (limit, showArchived) => {
+        const options = {
+          limit,
+          showArchived,
+          lookup: {
+            space: core.class.Space,
+            reviewer: core.class.Space
+          }
+        } satisfies FindOptions<LookupFixtureDoc>
+        const lookup: Lookup<LookupFixtureDoc> = { reviewer: core.class.Doc }
+
+        expect(withLookup<LookupFixtureDoc>(options, lookup)).toEqual({
+          limit,
+          showArchived,
+          lookup: {
+            space: core.class.Space,
+            reviewer: core.class.Doc
+          }
+        })
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("clampLimit defaults undefined and never returns values above MAX_LIMIT", () => {
+    expect(clampLimit()).toBe(50)
+
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: MAX_LIMIT }), (limit) => {
+        expect(clampLimit(limit)).toBe(limit)
+      }),
+      propertyTestParameters
+    )
+
+    fc.assert(
+      fc.property(
+        fc.double({ min: MAX_LIMIT, noNaN: true, noDefaultInfinity: true }).filter((limit) => limit > MAX_LIMIT),
+        (
+          limit
+        ) => {
+          expect(clampLimit(limit)).toBe(MAX_LIMIT)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("normalizeColorCode is idempotent and always returns a non-negative integer", () => {
+    fc.assert(
+      fc.property(fc.double(), (color) => {
+        const normalized = normalizeColorCode(color)
+
+        expect(Number.isInteger(normalized)).toBe(true)
+        expect(normalized).toBeGreaterThanOrEqual(0)
+        expect(normalizeColorCode(normalized)).toBe(normalized)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("toAttachedTagSummary normalizes color and only includes defined weight", () => {
+    const weightArbitrary = fc.option(fc.constantFrom(0, 1, 2, 3, 4, 5, 6, 7, 8), { nil: undefined })
+
+    fc.assert(
+      fc.property(
+        hulyRefArbitrary,
+        hulyRefArbitrary,
+        fc.string({ minLength: 1, maxLength: 60 }).filter((title) => title.trim().length > 0),
+        fc.double(),
+        weightArbitrary,
+        (id, tag, title, color, weight) => {
+          const baseTagRef = {
+            _id: toRef<TagReference>(TagReferenceId.make(id)),
+            tag: toRef<TagElement>(DocId.make(tag)),
+            title,
+            color
+          } satisfies Pick<TagReference, "_id" | "tag" | "title" | "color">
+          const tagRef = weight === undefined ? baseTagRef : { ...baseTagRef, weight }
+          const summary = toAttachedTagSummary(tagRef)
+          const decoded = assertDecodeSuccess(AttachedTagSummarySchema, summary)
+
+          expect(decoded).toMatchObject({
+            id,
+            tag,
+            title: title.trim(),
+            color: normalizeColorCode(color)
+          })
+          expect("weight" in decoded).toBe(weight !== undefined)
+          if (weight !== undefined) {
+            expect(decoded.weight).toBe(weight)
+          }
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("test-management enum mappings roundtrip and reject unknown strings", () => {
+    assertEnumMappingProperties(
+      TestCaseTypeValues,
+      [
+        TestCaseType.Functional,
+        TestCaseType.Performance,
+        TestCaseType.Regression,
+        TestCaseType.Security,
+        TestCaseType.Smoke,
+        TestCaseType.Usability
+      ],
+      testCaseTypeToString,
+      stringToTestCaseType
+    )
+    assertEnumMappingProperties(
+      TestCasePriorityValues,
+      [
+        TestCasePriority.Low,
+        TestCasePriority.Medium,
+        TestCasePriority.High,
+        TestCasePriority.Urgent
+      ],
+      testCasePriorityToString,
+      stringToTestCasePriority
+    )
+    assertEnumMappingProperties(
+      TestCaseStatusValues,
+      [
+        TestCaseStatus.Draft,
+        TestCaseStatus.ReadyForReview,
+        TestCaseStatus.FixReviewComments,
+        TestCaseStatus.Approved,
+        TestCaseStatus.Rejected
+      ],
+      testCaseStatusToString,
+      stringToTestCaseStatus
+    )
+    assertEnumMappingProperties(
+      TestRunStatusValues,
+      [
+        TestRunStatus.Untested,
+        TestRunStatus.Blocked,
+        TestRunStatus.Passed,
+        TestRunStatus.Failed
+      ],
+      testRunStatusToString,
+      stringToTestRunStatus
+    )
+  })
+})

--- a/test/huly/operations/sdk-discovery-mappers.property.test.ts
+++ b/test/huly/operations/sdk-discovery-mappers.property.test.ts
@@ -1,0 +1,477 @@
+import type { AnyAttribute, Enum as HulyEnum } from "@hcengineering/core"
+import { ClassifierKind } from "@hcengineering/core"
+import { Option, Schema } from "effect"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import {
+  HulyAttributeSummarySchema,
+  HulyClassifierKindSchema,
+  HulyClassSummarySchema,
+  HulyEnumSummarySchema,
+  HulySdkClassifierKindSchema
+} from "../../../src/domain/schemas/sdk-discovery.js"
+import { HulyAttributeId, HulyEnumId, NonEmptyString, ObjectClassName } from "../../../src/domain/schemas/shared.js"
+import { core } from "../../../src/huly/huly-plugins.js"
+import type { DirectAncestorRef, MetadataClassDoc } from "../../../src/huly/operations/sdk-discovery-mappers.js"
+import {
+  attributeSearchText,
+  classSearchText,
+  directAncestorRefs,
+  encodeClassifierKindFilter,
+  enumSearchText,
+  toAttributeSummary,
+  toClassSummary,
+  toEnumSummary
+} from "../../../src/huly/operations/sdk-discovery-mappers.js"
+import { assertDecodeFailure, assertDecodeSuccess, propertyTestParameters } from "../../helpers/property.js"
+
+const labelSegmentArbitrary = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_-]{0,18}$/)
+const refTailArbitrary = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_-]{0,20}$/)
+const classRefStringArbitrary = refTailArbitrary.map((tail) => `test:class:${tail}`)
+const interfaceRefStringArbitrary = refTailArbitrary.map((tail) => `test:interface:${tail}`)
+const hulyRefStringArbitrary = fc.oneof(classRefStringArbitrary, interfaceRefStringArbitrary)
+const domainArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{0,16}$/)
+const attributeNameArbitrary = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_ -]{0,20}$/)
+const enumValueArbitrary = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_ -]{0,20}$/)
+const invalidNonEmptyStringArbitrary = fc.oneof(
+  fc.constant(""),
+  fc.constant("   "),
+  fc.integer(),
+  fc.boolean(),
+  fc.record({ label: fc.string({ maxLength: 10 }) })
+)
+
+const sdkClassifierKinds = [
+  [ClassifierKind.CLASS, "class"],
+  [ClassifierKind.INTERFACE, "interface"],
+  [ClassifierKind.MIXIN, "mixin"]
+] as const
+
+const nonSelfRefArbitrary = (classId: string): fc.Arbitrary<string> =>
+  hulyRefStringArbitrary.filter((ref) => ref !== classId)
+
+const toDirectAncestorRef = (value: string): DirectAncestorRef => {
+  // SDK boundary fixture: generated ref strings are intentionally shaped like Huly model refs.
+  return value as DirectAncestorRef
+}
+
+const makeClassDoc = (overrides: Readonly<Record<string, unknown>> & { readonly _id: string }): MetadataClassDoc => {
+  const { _id, ...rest } = overrides
+  const value: unknown = {
+    _class: core.class.Class,
+    space: "space",
+    modifiedBy: "person",
+    modifiedOn: 0,
+    label: `${_id}`,
+    kind: ClassifierKind.CLASS,
+    _id,
+    ...rest
+  }
+  // SDK boundary fixture: generated model docs only need the fields read by sdk-discovery-mappers.
+  return value as MetadataClassDoc
+}
+
+const makeAttribute = (
+  overrides: Readonly<Record<string, unknown>> & { readonly _id: string; readonly attributeOf: string }
+): AnyAttribute => {
+  const { _id, attributeOf, ...rest } = overrides
+  const value: unknown = {
+    _class: core.class.Attribute,
+    space: "space",
+    modifiedBy: "person",
+    modifiedOn: 0,
+    name: "field",
+    label: "test:field:Field",
+    type: { _class: core.class.TypeString },
+    _id,
+    attributeOf,
+    ...rest
+  }
+  // SDK boundary fixture: generated attributes contain the dynamic SDK fields consumed by the mapper.
+  return value as AnyAttribute
+}
+
+const makeEnum = (
+  overrides: Readonly<Record<string, unknown>> & { readonly _id: string; readonly enumValues: ReadonlyArray<unknown> }
+): HulyEnum => {
+  const { _id, ...rest } = overrides
+  const value: unknown = {
+    _class: core.class.Enum,
+    space: "space",
+    modifiedBy: "person",
+    modifiedOn: 0,
+    name: "Enum",
+    _id,
+    ...rest
+  }
+  // SDK boundary fixture: generated enum docs contain the SDK shape consumed by toEnumSummary.
+  return value as HulyEnum
+}
+
+const expectedUniqueDirectAncestors = (
+  classId: string,
+  extended: ReadonlyArray<string>,
+  implemented: ReadonlyArray<string>
+): ReadonlyArray<string> => {
+  const seen = new Set([classId])
+  const unique: Array<string> = []
+  for (const ref of [...extended, ...implemented]) {
+    if (!seen.has(ref)) {
+      unique.push(ref)
+      seen.add(ref)
+    }
+  }
+  return unique
+}
+
+const expectSearchTextContains = (text: string, values: ReadonlyArray<string>): void => {
+  expect(text).toBe(text.toLowerCase())
+  expect(text).not.toContain("[object object]")
+  for (const value of values) {
+    expect(text).toContain(value.toLowerCase())
+  }
+}
+
+const validAttributeTypeArbitrary = fc.oneof(
+  fc.record({
+    kind: fc.constant("string" as const),
+    classId: fc.option(classRefStringArbitrary.map(ObjectClassName.make), { nil: undefined })
+  }),
+  fc.record({
+    kind: fc.constant("ref" as const),
+    classId: fc.option(classRefStringArbitrary.map(ObjectClassName.make), { nil: undefined }),
+    refTo: classRefStringArbitrary.map(ObjectClassName.make)
+  }),
+  fc.record({
+    kind: fc.constant("enum" as const),
+    classId: fc.option(classRefStringArbitrary.map(ObjectClassName.make), { nil: undefined }),
+    enumId: refTailArbitrary.map((tail) => HulyEnumId.make(`test:enum:${tail}`))
+  }),
+  fc.record({
+    kind: fc.constant("collection" as const),
+    classId: fc.option(classRefStringArbitrary.map(ObjectClassName.make), { nil: undefined }),
+    collectionOf: classRefStringArbitrary.map(ObjectClassName.make)
+  }),
+  fc.record({
+    kind: fc.constant("unknown" as const),
+    classId: fc.option(classRefStringArbitrary.map(ObjectClassName.make), { nil: undefined }),
+    raw: fc.record({ descriptor: fc.string({ maxLength: 20 }) })
+  })
+)
+
+describe("SDK discovery mapper properties", () => {
+  it("directAncestorRefs preserves extends-before-implements order while dropping duplicates and self references", () => {
+    const directAncestorFixtureArbitrary = hulyRefStringArbitrary.chain((classId) =>
+      fc.boolean().chain((singleExtends) =>
+        fc.record({
+          classId: fc.constant(classId),
+          extendedInput: fc.array(hulyRefStringArbitrary, { maxLength: 12 }),
+          implementedInput: fc.array(hulyRefStringArbitrary, { maxLength: 12 }),
+          scalarExtends: singleExtends ? nonSelfRefArbitrary(classId) : fc.constant(undefined),
+          singleExtends: fc.constant(singleExtends)
+        })
+      )
+    )
+
+    fc.assert(
+      fc.property(
+        directAncestorFixtureArbitrary,
+        ({ classId, extendedInput, implementedInput, scalarExtends, singleExtends }) => {
+          const extended = [classId, scalarExtends, ...extendedInput].flatMap((ref) => ref === undefined ? [] : [ref])
+            .map(toDirectAncestorRef)
+          const implemented = [classId, ...implementedInput].map(toDirectAncestorRef)
+          const doc = makeClassDoc({
+            _id: classId,
+            extends: singleExtends ? toDirectAncestorRef(scalarExtends ?? classId) : extended,
+            implements: implemented
+          })
+
+          expect(directAncestorRefs(doc).map(String)).toEqual(
+            expectedUniqueDirectAncestors(
+              classId,
+              singleExtends ? [String(scalarExtends ?? classId)] : extended.map(String),
+              implemented.map(String)
+            )
+          )
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("toClassSummary normalizes labels, classifier kind, direct ancestors, and optional source fields", () => {
+    fc.assert(
+      fc.property(
+        classRefStringArbitrary,
+        fc.array(labelSegmentArbitrary, { minLength: 1, maxLength: 4 }),
+        fc.constantFrom(...sdkClassifierKinds),
+        fc.array(hulyRefStringArbitrary, { maxLength: 8 }),
+        domainArbitrary,
+        fc.boolean(),
+        fc.boolean(),
+        fc.integer({ min: 0, max: 200 }),
+        (classId, labelSegments, [sdkKind, kind], ancestors, domain, hidden, readonly, attributesCount) => {
+          const doc = makeClassDoc({
+            _id: classId,
+            label: labelSegments.join(":"),
+            kind: sdkKind,
+            extends: ancestors.map(toDirectAncestorRef),
+            domain,
+            hidden,
+            readonly
+          })
+          const summary = toClassSummary(doc, attributesCount)
+
+          assertDecodeSuccess(HulyClassSummarySchema, summary)
+          expect(summary).toMatchObject({
+            classId: ObjectClassName.make(classId),
+            label: labelSegments[labelSegments.length - 1],
+            kind,
+            directAncestors: expectedUniqueDirectAncestors(classId, ancestors, []),
+            domain,
+            hidden,
+            readonly,
+            attributesCount
+          })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("toClassSummary falls back to class IDs and omits undecodable optional labels", () => {
+    fc.assert(
+      fc.property(
+        classRefStringArbitrary,
+        invalidNonEmptyStringArbitrary,
+        invalidNonEmptyStringArbitrary,
+        invalidNonEmptyStringArbitrary,
+        fc.integer({ min: 10_000, max: 20_000 }),
+        (classId, label, shortLabel, pluralLabel, unknownKind) => {
+          const summary = toClassSummary(makeClassDoc({
+            _id: classId,
+            label,
+            shortLabel,
+            pluralLabel,
+            kind: unknownKind
+          }))
+
+          assertDecodeSuccess(HulyClassSummarySchema, summary)
+          expect(summary.label).toBe(classId)
+          expect(summary.kind).toBe("unknown")
+          expect(summary).not.toHaveProperty("shortLabel")
+          expect(summary).not.toHaveProperty("pluralLabel")
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("classSearchText indexes searchable class fields without leaking object stringification", () => {
+    fc.assert(
+      fc.property(
+        classRefStringArbitrary,
+        labelSegmentArbitrary,
+        fc.constantFrom("class", "interface", "mixin", "unknown" as const),
+        fc.uniqueArray(hulyRefStringArbitrary, { maxLength: 6 }),
+        domainArbitrary,
+        labelSegmentArbitrary,
+        labelSegmentArbitrary,
+        labelSegmentArbitrary,
+        labelSegmentArbitrary,
+        (classId, label, kind, directAncestors, domain, shortLabel, pluralLabel, hintCategory, hintTool) => {
+          const summary = assertDecodeSuccess(HulyClassSummarySchema, {
+            classId,
+            label,
+            kind,
+            directAncestors,
+            domain,
+            shortLabel,
+            pluralLabel,
+            firstClassToolHints: [{
+              category: hintCategory,
+              exampleTools: [hintTool]
+            }]
+          })
+
+          expectSearchTextContains(classSearchText(summary), [
+            classId,
+            label,
+            kind,
+            ...directAncestors,
+            domain,
+            shortLabel,
+            pluralLabel
+          ])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("toAttributeSummary preserves source fields and normalizes searchable type descriptors", () => {
+    fc.assert(
+      fc.property(
+        refTailArbitrary,
+        classRefStringArbitrary,
+        attributeNameArbitrary,
+        fc.oneof(
+          fc.constant({ _class: core.class.TypeString }),
+          classRefStringArbitrary.map((refTo) => ({ _class: core.class.RefTo, to: refTo })),
+          refTailArbitrary.map((tail) => ({ _class: core.class.EnumOf, of: `test:enum:${tail}` })),
+          classRefStringArbitrary.map((collectionOf) => ({ _class: core.class.Collection, of: collectionOf })),
+          fc.constant({ _class: core.class.ArrOf, of: { _class: core.class.TypeString } }),
+          fc.record({ _class: fc.constant("custom:class:UnknownType"), detail: fc.string({ maxLength: 12 }) })
+        ),
+        fc.boolean(),
+        (tail, ownerClassId, name, type, customOnly) => {
+          const attr = makeAttribute({
+            _id: `attr:${tail}`,
+            attributeOf: ownerClassId,
+            name,
+            label: `test:field:${name}`,
+            type,
+            isCustom: customOnly
+          })
+          const summary = toAttributeSummary(
+            attr,
+            NonEmptyString.make("Owner"),
+            ObjectClassName.make(`${ownerClassId}:Requested`)
+          )
+
+          assertDecodeSuccess(HulyAttributeSummarySchema, summary)
+          expect(summary).toMatchObject({
+            attributeId: HulyAttributeId.make(`attr:${tail}`),
+            name: name.trim(),
+            label: name.trim(),
+            ownerClassId,
+            ownerClassLabel: "Owner",
+            isCustom: customOnly,
+            inherited: true
+          })
+          expect(attributeSearchText(summary)).not.toContain("[object object]")
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("attributeSearchText indexes direct searchable fields and type targets", () => {
+    fc.assert(
+      fc.property(
+        refTailArbitrary,
+        attributeNameArbitrary,
+        labelSegmentArbitrary,
+        classRefStringArbitrary,
+        labelSegmentArbitrary,
+        validAttributeTypeArbitrary,
+        (tail, name, label, ownerClassId, ownerClassLabel, type) => {
+          const summary = assertDecodeSuccess(HulyAttributeSummarySchema, {
+            attributeId: `attr:${tail}`,
+            name,
+            label,
+            ownerClassId,
+            ownerClassLabel,
+            type,
+            inherited: false
+          })
+          const expectedTypeTargets = [
+            type.classId,
+            "refTo" in type ? type.refTo : undefined,
+            "enumId" in type ? type.enumId : undefined,
+            "collectionOf" in type ? type.collectionOf : undefined
+          ].flatMap((value) => value === undefined ? [] : [String(value)])
+
+          expectSearchTextContains(attributeSearchText(summary), [
+            `attr:${tail}`,
+            summary.name,
+            summary.label,
+            summary.ownerClassId,
+            summary.ownerClassLabel,
+            type.kind,
+            ...expectedTypeTargets
+          ])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("toEnumSummary keeps valid option order and filters invalid option values", () => {
+    fc.assert(
+      fc.property(
+        refTailArbitrary,
+        attributeNameArbitrary,
+        fc.array(fc.oneof(enumValueArbitrary, invalidNonEmptyStringArbitrary), { maxLength: 25 }),
+        (tail, name, enumValues) => {
+          const doc = makeEnum({
+            _id: `test:enum:${tail}`,
+            name,
+            enumValues
+          })
+          const summary = toEnumSummary(doc)
+          const expectedValues = enumValues.flatMap((value) =>
+            typeof value === "string" && value.trim() !== "" ? [value.trim()] : []
+          )
+
+          assertDecodeSuccess(HulyEnumSummarySchema, summary)
+          expect(summary).toEqual({
+            enumId: HulyEnumId.make(`test:enum:${tail}`),
+            name: name.trim(),
+            values: expectedValues
+          })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("enumSearchText indexes enum IDs, names, and ordered values without object leaks", () => {
+    fc.assert(
+      fc.property(
+        refTailArbitrary,
+        attributeNameArbitrary,
+        fc.array(enumValueArbitrary, { maxLength: 12 }),
+        (tail, name, values) => {
+          const summary = assertDecodeSuccess(HulyEnumSummarySchema, {
+            enumId: `test:enum:${tail}`,
+            name,
+            values
+          })
+
+          expectSearchTextContains(enumSearchText(summary), [summary.enumId, summary.name, ...summary.values])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("encodeClassifierKindFilter encodes recognized kinds, omits unknown, and relies on schema rejection for invalids", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...sdkClassifierKinds), ([sdkKind, kind]) => {
+        const encoded = encodeClassifierKindFilter(kind)
+
+        expect(Option.isSome(encoded)).toBe(true)
+        if (Option.isSome(encoded)) {
+          expect(encoded.value).toBe(sdkKind)
+          expect(Schema.encodeSync(HulySdkClassifierKindSchema)(kind)).toBe(sdkKind)
+        }
+      }),
+      propertyTestParameters
+    )
+
+    expect(Option.isNone(encodeClassifierKindFilter("unknown"))).toBe(true)
+
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 30 })
+          .filter((value) => !["class", "interface", "mixin", "unknown"].includes(value)),
+        (invalidKind) => {
+          assertDecodeFailure(HulyClassifierKindSchema, invalidKind)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/huly/storage.property.test.ts
+++ b/test/huly/storage.property.test.ts
@@ -1,0 +1,333 @@
+import { describe } from "@effect/vitest"
+import { Effect, Either } from "effect"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import { decodeBase64, isBlockedUrl } from "../../src/huly/storage.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const byteArrayArbitrary = fc.uint8Array({ minLength: 1, maxLength: 4096 })
+const base64StringArbitrary = byteArrayArbitrary.map((bytes) => Buffer.from(bytes).toString("base64"))
+const octetArbitrary = fc.integer({ min: 0, max: 255 })
+const hextetArbitrary = fc.integer({ min: 0, max: 0xffff })
+
+const decodeBase64Result = (value: string): Either.Either<Buffer, unknown> =>
+  Effect.runSync(Effect.either(decodeBase64(value)))
+
+const expectDecodedBytes = (encoded: string, expected: Uint8Array): void => {
+  const result = decodeBase64Result(encoded)
+
+  if (Either.isLeft(result)) {
+    throw new Error(`Expected base64 decode to succeed, got: ${String(result.left)}`)
+  }
+
+  expect(result.right).toEqual(Buffer.from(expected))
+}
+
+const expectDecodeFailure = (encoded: string): void => {
+  const result = decodeBase64Result(encoded)
+
+  if (Either.isRight(result)) {
+    throw new Error(`Expected base64 decode to fail, got ${result.right.length} decoded bytes`)
+  }
+}
+
+const insertWhitespace = (value: string): string =>
+  value
+    .split("")
+    .map((char, index) => index % 4 === 0 ? ` \n${char}` : char)
+    .join("") + "\r\n"
+
+const malformedBase64Arbitrary = fc.oneof(
+  base64StringArbitrary.map((value) => `${value.slice(0, 1)}!${value.slice(1)}`),
+  base64StringArbitrary.map((value) => `${value.slice(0, 1)}=${value.slice(1)}`),
+  base64StringArbitrary.map((value) => `${value}=`),
+  base64StringArbitrary.map((value) => `${value},${value}`)
+)
+
+const malformedDataUrlArbitrary = base64StringArbitrary.chain((value) =>
+  fc.constantFrom(
+    `prefix,${value}`,
+    `data:image/png,${value}`,
+    `data:image/png;base64,`
+  )
+)
+
+const ipv4Url = (a: number, b: number, c: number, d: number): string => `http://${a}.${b}.${c}.${d}/file`
+const hex = (value: number): string => value.toString(16)
+const ipv6Url = (a: number, b: number, c: number, d: number): string =>
+  `https://[${hex(a)}:${hex(b)}:${hex(c)}:${hex(d)}::1]/file`
+
+const blockedPrivateIpv4UrlArbitrary = fc.oneof(
+  fc.tuple(fc.constant(0), octetArbitrary, octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(10), octetArbitrary, octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(100), fc.integer({ min: 64, max: 127 }), octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(127), octetArbitrary, octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(172), fc.integer({ min: 16, max: 31 }), octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(192), fc.constant(0), fc.constantFrom(0, 2), octetArbitrary),
+  fc.tuple(fc.constant(192), fc.constant(168), octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(169), fc.constant(254), octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(198), fc.constantFrom(18, 19), octetArbitrary, octetArbitrary),
+  fc.tuple(fc.constant(198), fc.constant(51), fc.constant(100), octetArbitrary),
+  fc.tuple(fc.constant(203), fc.constant(0), fc.constant(113), octetArbitrary),
+  fc.tuple(fc.integer({ min: 224, max: 255 }), octetArbitrary, octetArbitrary, octetArbitrary)
+).map(([a, b, c, d]) => ipv4Url(a, b, c, d))
+
+const publicIpv4UrlArbitrary = fc.oneof(
+  fc.tuple(
+    fc.constantFrom(1, 8, 11, 128, 171, 173, 193),
+    octetArbitrary,
+    octetArbitrary,
+    octetArbitrary
+  ),
+  fc.tuple(
+    fc.constant(172),
+    fc.oneof(fc.integer({ min: 0, max: 15 }), fc.integer({ min: 32, max: 255 })),
+    octetArbitrary,
+    octetArbitrary
+  ),
+  fc.tuple(
+    fc.constant(192),
+    fc.integer({ min: 0, max: 255 }).filter((b) => b !== 0 && b !== 168),
+    octetArbitrary,
+    octetArbitrary
+  ),
+  fc.tuple(fc.constant(169), fc.integer({ min: 0, max: 255 }).filter((b) => b !== 254), octetArbitrary, octetArbitrary)
+).map(([a, b, c, d]) => ipv4Url(a, b, c, d))
+
+const publicHostnameUrlArbitrary = fc.tuple(
+  fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/).filter((label) => label !== "localhost"),
+  fc.constantFrom("example.com", "huly.app", "cdn.test")
+).map(([label, domain]) => `https://${label}.${domain}/file.png`)
+
+const blockedSpecialUseIpv6UrlArbitrary = fc.oneof(
+  fc.tuple(hextetArbitrary, hextetArbitrary).map(([fourth, fifth]) =>
+    `https://[2001:2:0:${hex(fourth)}:${hex(fifth)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0x0010, max: 0x001f }), hextetArbitrary, hextetArbitrary).map(
+    ([second, third, fourth]) => `https://[2001:${hex(second)}:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0x0020, max: 0x002f }), hextetArbitrary, hextetArbitrary).map(
+    ([second, third, fourth]) => `https://[2001:${hex(second)}:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  fc.tuple(hextetArbitrary, hextetArbitrary).map(([third, fourth]) =>
+    `https://[2001:0:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  fc.tuple(hextetArbitrary, hextetArbitrary).map(([third, fourth]) =>
+    `https://[2001:3:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  fc.tuple(hextetArbitrary, hextetArbitrary).map(([fourth, fifth]) =>
+    `https://[2001:4:112:${hex(fourth)}:${hex(fifth)}::1]/file`
+  ),
+  fc.tuple(hextetArbitrary, hextetArbitrary, hextetArbitrary).map(([second, third, fourth]) =>
+    `https://[2002:${hex(second)}:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0x0000, max: 0x0fff }), hextetArbitrary, hextetArbitrary).map(
+    ([second, third, fourth]) => `https://[3fff:${hex(second)}:${hex(third)}:${hex(fourth)}::1]/file`
+  )
+)
+
+const blockedNonGlobalIpv6UrlArbitrary = fc.oneof(
+  fc.oneof(
+    fc.integer({ min: 0, max: 0x1fff }),
+    fc.integer({ min: 0x4000, max: 0xffff })
+  ).map((firstHextet) => `https://[${hex(firstHextet)}::1]/file`),
+  fc.tuple(fc.integer({ min: 0xfe80, max: 0xfebf }), hextetArbitrary).map(([first, second]) =>
+    `https://[${hex(first)}:${hex(second)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0xfec0, max: 0xfeff }), hextetArbitrary).map(([first, second]) =>
+    `https://[${hex(first)}:${hex(second)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0xfc00, max: 0xfdff }), hextetArbitrary).map(([first, second]) =>
+    `https://[${hex(first)}:${hex(second)}::1]/file`
+  ),
+  fc.tuple(fc.integer({ min: 0xff00, max: 0xffff }), hextetArbitrary).map(([first, second]) =>
+    `https://[${hex(first)}:${hex(second)}::1]/file`
+  ),
+  fc.tuple(hextetArbitrary, hextetArbitrary).map(([third, fourth]) =>
+    `https://[2001:db8:${hex(third)}:${hex(fourth)}::1]/file`
+  ),
+  blockedSpecialUseIpv6UrlArbitrary
+)
+
+const publicIpv6UrlArbitrary = fc.tuple(
+  fc.constantFrom(0x2400, 0x2606, 0x2800, 0x2a00, 0x2c00, 0x3000),
+  hextetArbitrary,
+  hextetArbitrary,
+  hextetArbitrary
+).map(([first, second, third, fourth]) => ipv6Url(first, second, third, fourth))
+
+describe("decodeBase64 properties", () => {
+  it("roundtrips arbitrary non-empty bytes encoded with Buffer base64", () => {
+    fc.assert(
+      fc.property(byteArrayArbitrary, (bytes) => {
+        expectDecodedBytes(Buffer.from(bytes).toString("base64"), bytes)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("ignores inserted ASCII whitespace and newlines", () => {
+    fc.assert(
+      fc.property(byteArrayArbitrary, (bytes) => {
+        const encoded = Buffer.from(bytes).toString("base64")
+
+        expectDecodedBytes(insertWhitespace(encoded), bytes)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("allows omitted terminal padding", () => {
+    fc.assert(
+      fc.property(byteArrayArbitrary, (bytes) => {
+        const encoded = Buffer.from(bytes).toString("base64").replace(/=+$/, "")
+
+        expectDecodedBytes(encoded, bytes)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("decodes valid data URLs with explicit media type and preserves the payload bytes", () => {
+    fc.assert(
+      fc.property(
+        byteArrayArbitrary,
+        fc.constantFrom("image/png", "text/plain", "application/octet-stream"),
+        (bytes, mediaType) => {
+          const encoded = Buffer.from(bytes).toString("base64")
+
+          expectDecodedBytes(`data:${mediaType};base64,${encoded}`, bytes)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("decodes valid data URLs with omitted media type and preserves the payload bytes", () => {
+    fc.assert(
+      fc.property(byteArrayArbitrary, (bytes) => {
+        const encoded = Buffer.from(bytes).toString("base64")
+
+        expectDecodedBytes(`data:;base64,${encoded}`, bytes)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("rejects malformed base64 and malformed data URL prefixes", () => {
+    fc.assert(
+      fc.property(fc.oneof(malformedBase64Arbitrary, malformedDataUrlArbitrary), (value) => {
+        expectDecodeFailure(value)
+      }),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("isBlockedUrl properties", () => {
+  it("blocks private, loopback, link-local, and reserved IPv4 ranges", () => {
+    fc.assert(
+      fc.property(blockedPrivateIpv4UrlArbitrary, (url) => {
+        expect(isBlockedUrl(url)).toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("blocks non-http protocols before fetch can reach them", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          "data:text/plain;base64,SGVsbG8=",
+          "file:///etc/passwd",
+          "ftp://example.com/file",
+          "ws://example.com/file",
+          "mailto:test@example.com"
+        ),
+        (url) => {
+          expect(isBlockedUrl(url)).toBe(true)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("blocks localhost, IPv6 non-global addresses, cloud metadata hostnames, and unparsable strings", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          "http://localhost/file",
+          "http://localhost./file",
+          "http://LOCALHOST:8080/file",
+          "http://LOCALHOST.:8080/file",
+          "http://[::]/file",
+          "http://[::1]/file",
+          "http://[fe80::1]/file",
+          "http://[febf::1]/file",
+          "http://[fec0::1]/file",
+          "http://[feff::1]/file",
+          "http://[fc00::1]/file",
+          "http://[fdff::1]/file",
+          "http://[ff00::1]/file",
+          "http://[ffff::1]/file",
+          "http://[100::1]/file",
+          "http://[2001::1]/file",
+          "http://[2001:1::1]/file",
+          "http://[2001:1::2]/file",
+          "http://[2001:2::1]/file",
+          "http://[2001:10::1]/file",
+          "http://[2001:20::1]/file",
+          "http://[2001:db8::1]/file",
+          "http://[2002::1]/file",
+          "http://[3fff::1]/file",
+          "http://[::ffff:10.0.0.1]/file",
+          "http://[::ffff:127.0.0.1]/file",
+          "http://[::ffff:192.168.1.1]/file",
+          "http://metadata.google.internal/file",
+          "http://metadata.google.internal./file",
+          "not-a-url",
+          ""
+        ),
+        (url) => {
+          expect(isBlockedUrl(url)).toBe(true)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("blocks generated IPv6 addresses outside the accepted global-unicast policy", () => {
+    fc.assert(
+      fc.property(blockedNonGlobalIpv6UrlArbitrary, (url) => {
+        expect(isBlockedUrl(url)).toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("blocks generated IPv6 special-use ranges inside 2000::/3", () => {
+    fc.assert(
+      fc.property(blockedSpecialUseIpv6UrlArbitrary, (url) => {
+        expect(isBlockedUrl(url)).toBe(true)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("allows public IPv4 addresses, representative global IPv6 addresses, and ordinary hostnames", () => {
+    fc.assert(
+      fc.property(fc.oneof(publicIpv4UrlArbitrary, publicIpv6UrlArbitrary, publicHostnameUrlArbitrary), (url) => {
+        expect(isBlockedUrl(url)).toBe(false)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("keeps 172.16/12 boundaries exact", () => {
+    expect(isBlockedUrl("http://172.15.255.255/file")).toBe(false)
+    expect(isBlockedUrl("http://172.16.0.0/file")).toBe(true)
+    expect(isBlockedUrl("http://172.31.255.255/file")).toBe(true)
+    expect(isBlockedUrl("http://172.32.0.0/file")).toBe(false)
+  })
+})

--- a/test/huly/storage.test.ts
+++ b/test/huly/storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@effect/vitest"
 import type { Blob, Ref, WorkspaceUuid } from "@hcengineering/core"
 import { Effect, Layer } from "effect"
 import * as fs from "node:fs/promises"
+import * as http from "node:http"
 import * as os from "node:os"
 import * as path from "node:path"
 import { expect } from "vitest"
@@ -21,6 +22,7 @@ import {
   validateContentType,
   validateFileSize
 } from "../../src/huly/storage.js"
+import { requestUrl } from "../../src/huly/url-fetch.js"
 import { mockFn } from "../helpers/mock-fn.js"
 
 const mockPut = mockFn<
@@ -430,51 +432,133 @@ describe("fetchFromUrl", () => {
       expect(error.reason).toContain("blocked")
     }))
 
+  it.effect("blocks public hostnames when DNS resolves to a private address", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        fetchFromUrl("https://example.com/file.png", {
+          requestUrl: () => Promise.reject(new Error("request should not run")),
+          resolveHostname: () => Promise.resolve([{ address: "10.0.0.1", family: 4 }])
+        })
+      )
+
+      expect(error._tag).toBe("FileFetchError")
+      expect(error.reason).toContain("DNS resolved")
+    }))
+
+  it.effect("blocks public hostnames when DNS resolves to non-global IPv6", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        fetchFromUrl("https://example.com/file.png", {
+          requestUrl: () => Promise.reject(new Error("request should not run")),
+          resolveHostname: () => Promise.resolve([{ address: "fc00::1", family: 6 }])
+        })
+      )
+
+      expect(error._tag).toBe("FileFetchError")
+      expect(error.reason).toContain("DNS resolved")
+    }))
+
   it.effect("returns FileFetchError for non-ok HTTP responses", () =>
     Effect.gen(function*() {
-      const originalFetch = globalThis.fetch
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial Fetch Response for the file-fetch branch
-      const response: Response = {
-        ok: false,
-        status: 403,
-        statusText: "Forbidden"
-      } as Response
-      globalThis.fetch = async () => response
-
-      try {
-        const error = yield* Effect.flip(
-          fetchFromUrl("https://example.com/secret-file.png")
-        )
-        expect(error._tag).toBe("FileFetchError")
-        expect(error.fileUrl).toBe("https://example.com/secret-file.png")
-        expect(error.reason).toContain("403")
-      } finally {
-        globalThis.fetch = originalFetch
-      }
+      const error = yield* Effect.flip(
+        fetchFromUrl("https://example.com/secret-file.png", {
+          requestUrl: () => Promise.reject(new Error("HTTP 403: Forbidden")),
+          resolveHostname: () => Promise.resolve([{ address: "93.184.216.34", family: 4 }])
+        })
+      )
+      expect(error._tag).toBe("FileFetchError")
+      expect(error.fileUrl).toBe("https://example.com/secret-file.png")
+      expect(error.reason).toContain("403")
     }))
 
   it.effect("returns buffer on successful fetch", () =>
     Effect.gen(function*() {
-      const originalFetch = globalThis.fetch
       const fileContent = Buffer.from("fetched file data")
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial Fetch Response for the file-fetch branch
-      const response: Response = {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        arrayBuffer: () =>
-          Promise.resolve(fileContent.buffer.slice(
-            fileContent.byteOffset,
-            fileContent.byteOffset + fileContent.byteLength
-          ))
-      } as Response
-      globalThis.fetch = async () => response
+
+      const buffer = yield* fetchFromUrl("https://example.com/file.png", {
+        requestUrl: () => Promise.resolve(fileContent),
+        resolveHostname: () => Promise.resolve([{ address: "93.184.216.34", family: 4 }])
+      })
+
+      expect(buffer.toString()).toBe("fetched file data")
+    }))
+
+  it.effect("tries each pre-vetted resolved address until a request succeeds", () =>
+    Effect.gen(function*() {
+      const fileContent = Buffer.from("fetched from fallback address")
+      const requestedAddresses: Array<string> = []
+
+      const buffer = yield* fetchFromUrl("https://example.com/file.png", {
+        requestUrl: (_url, address) => {
+          requestedAddresses.push(address.address)
+          return address.address === "93.184.216.34"
+            ? Promise.reject(new Error("first address unavailable"))
+            : Promise.resolve(fileContent)
+        },
+        resolveHostname: () =>
+          Promise.resolve([
+            { address: "93.184.216.34", family: 4 },
+            { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 }
+          ])
+      })
+
+      expect(buffer.toString()).toBe("fetched from fallback address")
+      expect(requestedAddresses).toEqual([
+        "93.184.216.34",
+        "2606:2800:220:1:248:1893:25c8:1946"
+      ])
+    }))
+
+  it.effect("destroys the request when received chunks exceed the byte cap", () =>
+    Effect.gen(function*() {
+      const maxBytes = 4
+      let resolveResponseClosed: (() => void) | undefined
+      const responseClosed = new Promise<void>((resolve) => {
+        resolveResponseClosed = resolve
+      })
+      const server = http.createServer((_request, response) => {
+        response.on("close", () => {
+          resolveResponseClosed?.()
+        })
+        response.write(Buffer.alloc(maxBytes, "a"))
+        setImmediate(() => {
+          response.write(Buffer.from("b"))
+        })
+      })
+
+      yield* Effect.tryPromise(() =>
+        new Promise<void>((resolve, reject) => {
+          server.once("error", reject)
+          server.listen(0, "127.0.0.1", resolve)
+        })
+      )
 
       try {
-        const buffer = yield* fetchFromUrl("https://example.com/file.png")
-        expect(buffer.toString()).toBe("fetched file data")
+        const address = server.address()
+        if (address === null || typeof address === "string") {
+          throw new Error("Expected server to listen on a TCP address")
+        }
+
+        const error = yield* Effect.flip(
+          Effect.tryPromise({
+            try: () =>
+              requestUrl(
+                new URL(`http://example.com:${address.port}/file.bin`),
+                { address: "127.0.0.1", family: 4 },
+                maxBytes
+              ),
+            catch: (e) => e
+          })
+        )
+
+        expect(String(error)).toContain("maximum file size")
+        yield* Effect.tryPromise(() => responseClosed)
       } finally {
-        globalThis.fetch = originalFetch
+        yield* Effect.tryPromise(() =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => error === undefined ? resolve() : reject(error))
+          })
+        )
       }
     }))
 })
@@ -565,6 +649,18 @@ describe("isBlockedUrl", () => {
 
   it("blocks ::1 IPv6 loopback", () => {
     expect(isBlockedUrl("http://[::1]/file")).toBe(true)
+  })
+
+  it("blocks IPv6 special-use ranges inside 2000::/3", () => {
+    expect(isBlockedUrl("http://[2001::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:1::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:1::2]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:2::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:10::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:20::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2001:db8::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[2002::1]/file")).toBe(true)
+    expect(isBlockedUrl("http://[3fff::1]/file")).toBe(true)
   })
 
   it("blocks 10.x.x.x private range", () => {

--- a/test/huly/url-builders.property.test.ts
+++ b/test/huly/url-builders.property.test.ts
@@ -1,0 +1,90 @@
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { DocumentId, OrganizationId, PersonId, UrlString, WorkspaceUrlSlug } from "../../src/domain/schemas/shared.js"
+import { buildContactUrl, buildDocumentUrl, slugifyTitle } from "../../src/huly/url-builders.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const nonEmptyPathSegmentArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,16}$/)
+const hulyRefArbitrary = fc.stringMatching(/^[a-z][a-z0-9:._-]{0,24}$/)
+const baseUrlArbitrary = fc.record({
+  host: fc.stringMatching(/^[a-z][a-z0-9-]{0,12}$/),
+  trailingSlashCount: fc.integer({ min: 0, max: 3 })
+}).map(({ host, trailingSlashCount }) => UrlString.make(`https://${host}.example${"/".repeat(trailingSlashCount)}`))
+
+const lowerAlphaNumArbitrary = fc.stringMatching(/^[a-z0-9]{1,8}$/)
+const slugWordTitleArbitrary = fc.array(lowerAlphaNumArbitrary, { minLength: 1, maxLength: 5 }).map((words) =>
+  words.join("  -  ")
+)
+
+describe("Huly URL builder properties", () => {
+  it("slugifyTitle is idempotent and returns a path-safe lowercase slug", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 120 }), (title) => {
+        const slug = slugifyTitle(title)
+
+        expect(slugifyTitle(slug)).toBe(slug)
+        expect(slug).toBe(slug.toLowerCase())
+        expect(slug).not.toMatch(/\s/)
+        expect(slug).not.toMatch(/--/)
+        expect(slug).not.toMatch(/^-|-$/)
+        expect(slug).toMatch(/^[a-z0-9.-]*$/)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("slugifyTitle preserves generated word order across whitespace and hyphen runs", () => {
+    fc.assert(
+      fc.property(slugWordTitleArbitrary, (title) => {
+        const words = title.split("  -  ")
+
+        expect(slugifyTitle(title)).toBe(words.join("-"))
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("buildDocumentUrl trims base slashes and ends with the slug plus document id", () => {
+    fc.assert(
+      fc.property(
+        baseUrlArbitrary,
+        nonEmptyPathSegmentArbitrary,
+        fc.string({ maxLength: 80 }),
+        hulyRefArbitrary,
+        (baseUrl, workspace, title, idValue) => {
+          const workspaceSlug = WorkspaceUrlSlug.make(workspace)
+          const documentId = DocumentId.make(idValue)
+          const url = buildDocumentUrl(baseUrl, workspaceSlug, title, documentId)
+          const parsed = new URL(url)
+          const slug = slugifyTitle(title)
+          const expectedDocumentSegment = slug === "" ? idValue : `${slug}-${idValue}`
+
+          expect(url).not.toContain("//workbench")
+          expect(parsed.pathname).toBe(`/workbench/${workspace}/document/${expectedDocumentSegment}`)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("buildContactUrl trims base slashes and preserves person or organization ids", () => {
+    fc.assert(
+      fc.property(baseUrlArbitrary, nonEmptyPathSegmentArbitrary, hulyRefArbitrary, fc.boolean(), (
+        baseUrl,
+        workspace,
+        idValue,
+        isPerson
+      ) => {
+        const workspaceSlug = WorkspaceUrlSlug.make(workspace)
+        const contactId = isPerson ? PersonId.make(idValue) : OrganizationId.make(idValue)
+        const url = buildContactUrl(baseUrl, workspaceSlug, contactId)
+        const parsed = new URL(url)
+
+        expect(url).not.toContain("//workbench")
+        expect(parsed.pathname).toBe(`/workbench/${workspace}/contact/${idValue}`)
+      }),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/mcp/input-schema-compat.property.test.ts
+++ b/test/mcp/input-schema-compat.property.test.ts
@@ -1,0 +1,122 @@
+import { describe } from "@effect/vitest"
+import * as fc from "fast-check"
+import { expect, it } from "vitest"
+
+import type { McpInputSchema } from "../../src/mcp/input-schema-compat.js"
+import { toClientCompatibleInputSchema } from "../../src/mcp/input-schema-compat.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const ROOT_COMPOSITION_KEYS = ["anyOf", "oneOf", "allOf"] as const
+
+const identifierArbitrary = fc.stringMatching(/^[a-z][a-z0-9]{0,8}$/)
+
+const leafSchemaFor = (key: string, origin: string): Record<string, unknown> => ({
+  type: "string",
+  description: `generated field ${origin}:${key}`
+})
+
+const objectFromKeys = (keys: ReadonlyArray<string>, origin: string): Record<string, unknown> =>
+  Object.fromEntries(keys.map((key) => [key, leafSchemaFor(key, origin)]))
+
+const defsFromKeys = (keys: ReadonlyArray<string>, origin: string): Record<string, unknown> =>
+  Object.fromEntries(keys.map((key) => [`${key}Def`, { type: "object", title: `${origin}:${key} definition` }]))
+
+interface CompositionNode {
+  readonly properties: ReadonlyArray<string>
+  readonly defs: ReadonlyArray<string>
+  readonly children: ReadonlyArray<CompositionNode>
+}
+
+const compositionNodeArbitrary = (depth: number): fc.Arbitrary<CompositionNode> =>
+  fc.record({
+    properties: fc.uniqueArray(identifierArbitrary, { maxLength: 3 }),
+    defs: fc.uniqueArray(identifierArbitrary, { maxLength: 3 }),
+    children: depth <= 0 ? fc.constant([]) : fc.array(compositionNodeArbitrary(depth - 1), { maxLength: 3 })
+  })
+
+const nodeToSchema = (node: CompositionNode, index: number, origin = `branch-${index}`): Record<string, unknown> => {
+  const compositionKey = ROOT_COMPOSITION_KEYS[index % ROOT_COMPOSITION_KEYS.length]
+
+  return {
+    properties: objectFromKeys(node.properties, origin),
+    $defs: defsFromKeys(node.defs, origin),
+    ...(node.children.length === 0
+      ? {}
+      : {
+        [compositionKey]: node.children.map((child, childIndex) =>
+          nodeToSchema(child, childIndex, `${origin}.${childIndex}`)
+        )
+      })
+  }
+}
+
+const generatedSchemaArbitrary: fc.Arbitrary<McpInputSchema> = fc.record({
+  title: fc.string({ maxLength: 40 }),
+  description: fc.string({ maxLength: 80 }),
+  additionalProperties: fc.boolean(),
+  rootProperties: fc.uniqueArray(identifierArbitrary, { maxLength: 3 }),
+  rootDefs: fc.uniqueArray(identifierArbitrary, { maxLength: 3 }),
+  required: fc.uniqueArray(identifierArbitrary, { maxLength: 3 }),
+  branches: fc.array(compositionNodeArbitrary(3), { minLength: 1, maxLength: 4 })
+}).map(({ additionalProperties, branches, description, required, rootDefs, rootProperties, title }) => ({
+  type: "object",
+  title,
+  description,
+  additionalProperties,
+  required,
+  properties: objectFromKeys(rootProperties, "root"),
+  $defs: defsFromKeys(rootDefs, "root"),
+  anyOf: branches.slice(0, 1).map((branch, index) => nodeToSchema(branch, index)),
+  oneOf: branches.slice(1, 3).map((branch, index) => nodeToSchema(branch, index)),
+  allOf: branches.slice(3).map((branch, index) => nodeToSchema(branch, index))
+}))
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const compositionBranches = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> =>
+  ROOT_COMPOSITION_KEYS.flatMap((key) => {
+    const value = schema[key]
+    return Array.isArray(value) ? value.filter(isRecord) : []
+  })
+
+const descendants = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> => [
+  schema,
+  ...compositionBranches(schema).flatMap(descendants)
+]
+
+const expectedMergedField = (schema: McpInputSchema, field: "properties" | "$defs"): Record<string, unknown> =>
+  descendants(schema)
+    .map((descendant) => descendant[field])
+    .reduce<Record<string, unknown>>(
+      (merged, value) => isRecord(value) ? { ...value, ...merged } : merged,
+      {}
+    )
+
+describe("toClientCompatibleInputSchema properties", () => {
+  it("removes root composition, recursively merges fields, preserves root metadata, and is idempotent", () => {
+    fc.assert(
+      fc.property(generatedSchemaArbitrary, (schema) => {
+        const sanitized = toClientCompatibleInputSchema(schema)
+        const sanitizedAgain = toClientCompatibleInputSchema(sanitized)
+
+        expect(sanitized.anyOf).toBeUndefined()
+        expect(sanitized.oneOf).toBeUndefined()
+        expect(sanitized.allOf).toBeUndefined()
+        expect(sanitized.type).toBe("object")
+        expect(sanitized.title).toBe(schema.title)
+        expect(sanitized.description).toBe(schema.description)
+        expect(sanitized.additionalProperties).toBe(schema.additionalProperties)
+        expect(sanitized.required).toEqual(schema.required)
+        expect(sanitizedAgain).toEqual(sanitized)
+
+        const properties = isRecord(sanitized.properties) ? sanitized.properties : {}
+        const defs = isRecord(sanitized.$defs) ? sanitized.$defs : {}
+
+        expect(properties).toEqual(expectedMergedField(schema, "properties"))
+        expect(defs).toEqual(expectedMergedField(schema, "$defs"))
+      }),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/mcp/registry.property.test.ts
+++ b/test/mcp/registry.property.test.ts
@@ -1,0 +1,272 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { CATEGORY_NAMES, createFilteredRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
+import {
+  isNoArgumentTool,
+  requiresArgumentsObject,
+  resolveAnnotations,
+  type ToolDefinition
+} from "../../src/mcp/tools/registry.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const knownCategories = [...CATEGORY_NAMES]
+const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
+const unknownCategoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{1,24}$/).filter(
+  (category) => !CATEGORY_NAMES.has(category)
+)
+
+const wordArbitrary = fc.stringMatching(/^[a-z][a-z0-9]{0,10}$/)
+const toolNameArbitrary = fc.array(wordArbitrary, { minLength: 1, maxLength: 5 }).map((parts) => parts.join("_"))
+const requiredArbitrary = fc.array(fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/), { maxLength: 4 })
+const unionSchemaArbitrary = fc.record({ required: requiredArbitrary }, { requiredKeys: [] })
+
+const deriveTitle = (name: string): string =>
+  name.split("_").map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(" ")
+
+const annotationKeys = [
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+  "readOnlyHint",
+  "title"
+] satisfies ReadonlyArray<keyof ToolAnnotations>
+
+const prefixDefaults = [
+  {
+    prefixes: ["list_", "get_", "search_", "fulltext_", "download_", "preview_"],
+    defaults: { destructiveHint: false, idempotentHint: true, openWorldHint: false, readOnlyHint: true }
+  },
+  {
+    prefixes: ["create_", "add_", "upload_", "send_", "log_"],
+    defaults: { destructiveHint: false, idempotentHint: false, openWorldHint: false, readOnlyHint: false }
+  },
+  {
+    prefixes: [
+      "update_",
+      "edit_",
+      "set_",
+      "pin_",
+      "unpin_",
+      "mark_",
+      "archive_",
+      "start_",
+      "stop_",
+      "save_",
+      "unsave_",
+      "remove_",
+      "move_"
+    ],
+    defaults: { destructiveHint: false, idempotentHint: true, openWorldHint: false, readOnlyHint: false }
+  },
+  {
+    prefixes: ["delete_"],
+    defaults: { destructiveHint: true, idempotentHint: true, openWorldHint: false, readOnlyHint: false }
+  },
+  {
+    prefixes: ["custom_"],
+    defaults: { destructiveHint: true, idempotentHint: false, openWorldHint: false, readOnlyHint: false }
+  }
+] satisfies ReadonlyArray<{
+  readonly defaults: Omit<ToolAnnotations, "title">
+  readonly prefixes: ReadonlyArray<string>
+}>
+
+const prefixCaseArbitrary = fc.constantFrom(
+  ...prefixDefaults.flatMap(({ defaults, prefixes }) => prefixes.map((prefix) => ({ defaults, prefix })))
+)
+
+const toolDefinition = (name: string, inputSchema: object, annotations?: ToolAnnotations): ToolDefinition => ({
+  name,
+  description: "generated test tool",
+  inputSchema,
+  category: "generated",
+  ...(annotations !== undefined && { annotations })
+})
+
+describe("createFilteredRegistry properties", () => {
+  it("preserves registry order and map membership for any requested category set", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(knownCategoryArbitrary, unknownCategoryArbitrary), { maxLength: 12 }),
+        (categories) => {
+          const requested = new Set(categories)
+          const filtered = createFilteredRegistry(requested)
+          const expectedDefinitions = toolRegistry.definitions.filter((tool) => requested.has(tool.category))
+
+          expect(filtered.definitions).toEqual(expectedDefinitions)
+          expect([...filtered.tools.keys()]).toEqual(expectedDefinitions.map((tool) => tool.name))
+          for (const tool of filtered.definitions) {
+            expect(requested.has(tool.category)).toBe(true)
+            expect(filtered.tools.get(tool.name)).toBe(tool)
+          }
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("returns an empty registry when all requested categories are invalid", () => {
+    fc.assert(
+      fc.property(fc.array(unknownCategoryArbitrary, { maxLength: 12 }), (categories) => {
+        const filtered = createFilteredRegistry(new Set(categories))
+
+        expect(filtered.definitions).toEqual([])
+        expect(filtered.tools.size).toBe(0)
+      }),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("tool argument schema properties", () => {
+  it("requires an arguments object exactly when direct or union required fields are present", () => {
+    fc.assert(
+      fc.property(
+        requiredArbitrary,
+        fc.array(unionSchemaArbitrary, { maxLength: 4 }),
+        fc.array(unionSchemaArbitrary, { maxLength: 4 }),
+        (required, anyOf, oneOf) => {
+          const inputSchema = { required, anyOf, oneOf }
+          const expected = required.length > 0
+            || anyOf.some((schema) => (schema.required?.length ?? 0) > 0)
+            || oneOf.some((schema) => (schema.required?.length ?? 0) > 0)
+
+          expect(requiresArgumentsObject(toolDefinition("generated_tool", inputSchema))).toBe(expected)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("classifies no-argument tools by empty properties and additionalProperties false", () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/), fc.anything()),
+        fc.option(fc.boolean(), { nil: undefined }),
+        (properties, additionalProperties) => {
+          const inputSchema = {
+            properties,
+            ...(additionalProperties !== undefined && { additionalProperties })
+          }
+
+          expect(isNoArgumentTool(toolDefinition("generated_tool", inputSchema))).toBe(
+            Object.keys(properties).length === 0 && additionalProperties === false
+          )
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("classifies empty Effect Struct union schemas and actual registry no-arg tools", () => {
+    fc.assert(
+      fc.property(fc.boolean(), (useOneOf) => {
+        const inputSchema = {
+          [useOneOf ? "oneOf" : "anyOf"]: [{ type: "object" }, { type: "array" }]
+        }
+
+        expect(isNoArgumentTool(toolDefinition("generated_empty_struct", inputSchema))).toBe(true)
+        expect(requiresArgumentsObject(toolDefinition("generated_empty_struct", inputSchema))).toBe(false)
+      }),
+      propertyTestParameters
+    )
+
+    const listProjectTypes = toolRegistry.tools.get("list_project_types")
+
+    expect(listProjectTypes).toBeDefined()
+    if (listProjectTypes !== undefined) {
+      expect(isNoArgumentTool(listProjectTypes)).toBe(true)
+      expect(requiresArgumentsObject(listProjectTypes)).toBe(false)
+    }
+  })
+
+  it("does not classify union schemas with declared fields as no-argument tools", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("anyOf", "oneOf"),
+        fc.array(fc.array(fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/), { minLength: 1, maxLength: 4 }), {
+          minLength: 1,
+          maxLength: 4
+        }),
+        (unionKey, requiredGroups) => {
+          const inputSchema = {
+            [unionKey]: [
+              { type: "object" },
+              ...requiredGroups.map((required) => ({
+                properties: Object.fromEntries(required.map((key) => [key, { type: "string" }])),
+                required
+              }))
+            ]
+          }
+
+          expect(isNoArgumentTool(toolDefinition("generated_union", inputSchema))).toBe(
+            requiredGroups.every((required) => required.length === 0)
+          )
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("does not classify scalar or underspecified union variants as no-argument tools", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("anyOf", "oneOf"),
+        fc.array(
+          fc.oneof(
+            fc.record({ type: fc.constantFrom("string", "number", "boolean", "null") }),
+            fc.constant({})
+          ),
+          { minLength: 1, maxLength: 4 }
+        ),
+        (unionKey, variants) => {
+          expect(isNoArgumentTool(toolDefinition("generated_union", { [unionKey]: variants }))).toBe(false)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("resolveAnnotations properties", () => {
+  it("is stable, defaulted, and gives explicit annotations precedence", () => {
+    fc.assert(
+      fc.property(
+        prefixCaseArbitrary,
+        toolNameArbitrary,
+        fc.record(
+          {
+            destructiveHint: fc.boolean(),
+            idempotentHint: fc.boolean(),
+            openWorldHint: fc.boolean(),
+            readOnlyHint: fc.boolean(),
+            title: fc.string({ maxLength: 32 })
+          },
+          { requiredKeys: [] }
+        ),
+        ({ defaults, prefix }, suffix, annotations) => {
+          const tool = toolDefinition(`${prefix}${suffix}`, {}, annotations)
+          const resolved = resolveAnnotations(tool)
+
+          expect(resolveAnnotations(tool)).toEqual(resolved)
+          expect(resolved).toEqual({ ...resolved, ...annotations })
+          for (const key of annotationKeys) {
+            if (annotations[key] !== undefined) {
+              expect(resolved[key]).toBe(annotations[key])
+            }
+          }
+          if (annotations.title === undefined) {
+            expect(resolved.title).toBe(deriveTitle(tool.name))
+          }
+          expect(resolved.destructiveHint).toBe(annotations.destructiveHint ?? defaults.destructiveHint)
+          expect(resolved.idempotentHint).toBe(annotations.idempotentHint ?? defaults.idempotentHint)
+          expect(resolved.openWorldHint).toBe(annotations.openWorldHint ?? defaults.openWorldHint)
+          expect(resolved.readOnlyHint).toBe(annotations.readOnlyHint ?? defaults.readOnlyHint)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/mcp/stdio-output.property.test.ts
+++ b/test/mcp/stdio-output.property.test.ts
@@ -1,0 +1,90 @@
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { type ConsoleRedirectTarget, redirectConsoleToStderr } from "../../src/mcp/stdio-output.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+type ConsoleMethodName = keyof ConsoleRedirectTarget
+
+interface ConsoleCall {
+  readonly data: ReadonlyArray<unknown>
+  readonly method: ConsoleMethodName
+}
+
+const methodArbitrary = fc.constantFrom<ConsoleMethodName>("debug", "error", "info", "log", "warn")
+const dataArbitrary = fc.array(
+  fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)),
+  { maxLength: 4 }
+)
+const callArbitrary = fc.record({
+  data: dataArbitrary,
+  method: methodArbitrary
+})
+
+const createConsoleTarget = (calls: Array<ConsoleCall>): ConsoleRedirectTarget => {
+  const writer = (method: ConsoleMethodName) => (...data: ReadonlyArray<unknown>): void => {
+    calls.push({ data, method })
+  }
+
+  return {
+    debug: writer("debug"),
+    error: writer("error"),
+    info: writer("info"),
+    log: writer("log"),
+    warn: writer("warn")
+  }
+}
+
+const invoke = (target: ConsoleRedirectTarget, call: ConsoleCall): void => {
+  target[call.method](...call.data)
+}
+
+describe("redirectConsoleToStderr properties", () => {
+  it("routes every redirected console method through the original error sink in call order", () => {
+    fc.assert(
+      fc.property(fc.array(callArbitrary, { maxLength: 20 }), (callsToMake) => {
+        const calls: Array<ConsoleCall> = []
+        const target = createConsoleTarget(calls)
+        const handle = redirectConsoleToStderr(target)
+
+        for (const call of callsToMake) {
+          invoke(target, call)
+        }
+
+        handle.restore()
+
+        expect(calls).toEqual(callsToMake.map((call) => ({ data: call.data, method: "error" })))
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("restores the original method routing after any redirected call sequence", () => {
+    fc.assert(
+      fc.property(
+        fc.array(callArbitrary, { maxLength: 20 }),
+        fc.array(callArbitrary, { maxLength: 20 }),
+        (beforeRestore, afterRestore) => {
+          const calls: Array<ConsoleCall> = []
+          const target = createConsoleTarget(calls)
+          const handle = redirectConsoleToStderr(target)
+
+          for (const call of beforeRestore) {
+            invoke(target, call)
+          }
+          handle.restore()
+          handle.restore()
+          for (const call of afterRestore) {
+            invoke(target, call)
+          }
+
+          expect(calls).toEqual([
+            ...beforeRestore.map((call) => ({ data: call.data, method: "error" })),
+            ...afterRestore
+          ])
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/property-harness.test.ts
+++ b/test/property-harness.test.ts
@@ -1,0 +1,30 @@
+import { Schema } from "effect"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import {
+  assertDecodeFailure,
+  assertDecodeSuccess,
+  assertEncodeFailure,
+  assertEncodeSuccess,
+  propertyTestParameters
+} from "./helpers/property.js"
+
+describe("property test harness", () => {
+  it("runs fast-check properties under Vitest with Effect Schema helpers", () => {
+    fc.assert(
+      fc.property(fc.integer(), (value) => {
+        const decoded = assertDecodeSuccess(Schema.Int, value)
+        const encoded = assertEncodeSuccess(Schema.Int, decoded)
+
+        expect(encoded).toBe(value)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("reports Effect Schema decode and encode failures", () => {
+    assertDecodeFailure(Schema.Int, 1.5)
+    assertEncodeFailure(Schema.Int, 1.5)
+  })
+})

--- a/test/telemetry/posthog.property.test.ts
+++ b/test/telemetry/posthog.property.test.ts
@@ -1,0 +1,209 @@
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { createPostHogTelemetry, type PostHogTelemetryDependencies } from "../../src/telemetry/posthog.js"
+import type { SessionStartProps, ToolCalledProps } from "../../src/telemetry/telemetry.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+type TelemetryOperation =
+  | { readonly props: SessionStartProps; readonly type: "sessionStart" }
+  | { readonly type: "firstListTools" }
+  | { readonly props: ToolCalledProps; readonly type: "toolCalled" }
+
+type TimelineEntry =
+  | {
+    readonly distinctId: string
+    readonly event: string
+    readonly properties: Record<string, unknown>
+    readonly type: "capture"
+  }
+  | { readonly timeoutMs: number | undefined; readonly type: "shutdown" }
+
+const categoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{0,16}$/)
+const sessionStartArbitrary = fc.record({
+  authMethod: fc.constantFrom("token", "password"),
+  toolCount: fc.integer({ min: 0, max: 10_000 }),
+  toolsets: fc.option(fc.array(categoryArbitrary, { maxLength: 8 }), { nil: null }),
+  transport: fc.constantFrom("stdio", "http")
+}) satisfies fc.Arbitrary<SessionStartProps>
+
+const toolCalledArbitrary = fc.record(
+  {
+    durationMs: fc.integer({ min: 0, max: 3_600_000 }),
+    editMode: fc.string({ maxLength: 24 }),
+    errorTag: fc.string({ maxLength: 48 }),
+    inputBytes: fc.integer({ min: 0, max: 10_000_000 }),
+    outputBytes: fc.integer({ min: 0, max: 10_000_000 }),
+    status: fc.constantFrom("success", "error"),
+    toolName: fc.stringMatching(/^[a-z][a-z0-9_]{0,40}$/)
+  },
+  { requiredKeys: ["durationMs", "status", "toolName"] }
+) satisfies fc.Arbitrary<ToolCalledProps>
+
+const operationArbitrary = fc.oneof(
+  sessionStartArbitrary.map((props): TelemetryOperation => ({ props, type: "sessionStart" })),
+  fc.constant({ type: "firstListTools" }),
+  toolCalledArbitrary.map((props): TelemetryOperation => ({ props, type: "toolCalled" }))
+) satisfies fc.Arbitrary<TelemetryOperation>
+
+const makeDependencies = (
+  timeline: Array<TimelineEntry>,
+  rejectShutdown: boolean
+): PostHogTelemetryDependencies => ({
+  createClient: () => ({
+    capture: (event) => {
+      timeline.push({
+        distinctId: event.distinctId,
+        event: event.event,
+        properties: event.properties,
+        type: "capture"
+      })
+    },
+    shutdown: (timeoutMs) => {
+      timeline.push({ timeoutMs, type: "shutdown" })
+      return rejectShutdown ? Promise.reject(new Error("flush failed")) : Promise.resolve()
+    }
+  }),
+  createSessionId: () => "00000000-0000-4000-8000-000000000001",
+  writeDebug: () => {}
+})
+
+const applyOperation = (
+  telemetry: ReturnType<typeof createPostHogTelemetry>,
+  operation: TelemetryOperation
+): void => {
+  switch (operation.type) {
+    case "sessionStart":
+      telemetry.sessionStart(operation.props)
+      break
+    case "firstListTools":
+      telemetry.firstListTools()
+      break
+    case "toolCalled":
+      telemetry.toolCalled(operation.props)
+      break
+  }
+}
+
+const expectedEvents = (operations: ReadonlyArray<TelemetryOperation>): ReadonlyArray<string> => {
+  let firstListToolsSeen = false
+  const events: Array<string> = []
+
+  for (const operation of operations) {
+    switch (operation.type) {
+      case "sessionStart":
+        events.push("session_start")
+        break
+      case "firstListTools":
+        if (!firstListToolsSeen) {
+          events.push("first_list_tools")
+          firstListToolsSeen = true
+        }
+        break
+      case "toolCalled":
+        events.push("tool_called")
+        break
+    }
+  }
+
+  return events
+}
+
+const expectedEventProperties = (
+  operations: ReadonlyArray<TelemetryOperation>
+): ReadonlyArray<Readonly<Record<string, unknown>>> => {
+  let firstListToolsSeen = false
+  const properties: Array<Readonly<Record<string, unknown>>> = []
+
+  for (const operation of operations) {
+    switch (operation.type) {
+      case "sessionStart":
+        properties.push({
+          auth_method: operation.props.authMethod,
+          tool_count: operation.props.toolCount,
+          toolsets: operation.props.toolsets,
+          transport: operation.props.transport
+        })
+        break
+      case "firstListTools":
+        if (!firstListToolsSeen) {
+          properties.push({})
+          firstListToolsSeen = true
+        }
+        break
+      case "toolCalled":
+        properties.push({
+          duration_ms: operation.props.durationMs,
+          status: operation.props.status,
+          tool_name: operation.props.toolName,
+          ...(operation.props.editMode === undefined ? {} : { edit_mode: operation.props.editMode }),
+          ...(operation.props.errorTag === undefined ? {} : { error_tag: operation.props.errorTag }),
+          ...(operation.props.inputBytes === undefined ? {} : { input_bytes: operation.props.inputBytes }),
+          ...(operation.props.outputBytes === undefined ? {} : { output_bytes: operation.props.outputBytes })
+        })
+        break
+    }
+  }
+
+  return properties
+}
+
+const captureEntries = (
+  timeline: ReadonlyArray<TimelineEntry>
+): ReadonlyArray<Extract<TimelineEntry, { readonly type: "capture" }>> =>
+  timeline.filter((entry) => entry.type === "capture")
+
+describe("createPostHogTelemetry properties", () => {
+  it("captures generated operation sequences in order with one first_list_tools event", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(operationArbitrary, { maxLength: 30 }), async (operations) => {
+        const timeline: Array<TimelineEntry> = []
+        const telemetry = createPostHogTelemetry(false, makeDependencies(timeline, false))
+
+        for (const operation of operations) {
+          applyOperation(telemetry, operation)
+        }
+
+        const captures = captureEntries(timeline)
+
+        expect(captures.map((entry) => entry.event)).toEqual(expectedEvents(operations))
+        expect(captures.map((entry) => {
+          const { $ip: _ip, session_id: _sessionId, version: _version, ...eventProperties } = entry.properties
+          return eventProperties
+        })).toEqual(expectedEventProperties(operations))
+        expect(captures.filter((entry) => entry.event === "first_list_tools")).toHaveLength(
+          operations.some((operation) => operation.type === "firstListTools") ? 1 : 0
+        )
+        for (const entry of captures) {
+          expect(entry.distinctId).toBe("00000000-0000-4000-8000-000000000001")
+          expect(entry.properties.session_id).toBe("00000000-0000-4000-8000-000000000001")
+          expect(entry.properties.version).toBeTypeOf("string")
+          expect(entry.properties.$ip).toBeNull()
+        }
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("emits session_end before flushing and swallows generated shutdown failures", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(operationArbitrary, { maxLength: 20 }),
+        fc.boolean(),
+        async (operations, rejectShutdown) => {
+          const timeline: Array<TimelineEntry> = []
+          const telemetry = createPostHogTelemetry(false, makeDependencies(timeline, rejectShutdown))
+
+          for (const operation of operations) {
+            applyOperation(telemetry, operation)
+          }
+          await expect(telemetry.shutdown()).resolves.toBeUndefined()
+
+          expect(timeline.at(-2)).toMatchObject({ event: "session_end", type: "capture" })
+          expect(timeline.at(-1)).toEqual({ timeoutMs: 2000, type: "shutdown" })
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/utils/url-normalize.property.test.ts
+++ b/test/utils/url-normalize.property.test.ts
@@ -1,0 +1,71 @@
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { normalizeForComparison } from "../../src/utils/normalize.js"
+import { concatLink } from "../../src/utils/url.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const hostArbitrary = fc.stringMatching(/^https:\/\/[a-z][a-z0-9-]{0,12}\.example$/)
+const pathSegmentArbitrary = fc.stringMatching(/^[a-z][a-z0-9._-]{0,16}$/)
+const separatorArbitrary = fc.constantFrom("-", "_", " ")
+
+const withInsertedSeparators = (value: string, separator: string): string => [...value].join(separator)
+
+describe("URL and normalization utility properties", () => {
+  it("concatLink normalizes exactly one slash between host and path for canonical inputs", () => {
+    fc.assert(
+      fc.property(
+        hostArbitrary,
+        pathSegmentArbitrary,
+        fc.boolean(),
+        fc.boolean(),
+        (host, path, hostSlash, pathSlash) => {
+          const inputHost = hostSlash ? `${host}/` : host
+          const inputPath = pathSlash ? `/${path}` : path
+
+          expect(concatLink(inputHost, inputPath)).toBe(`${host}/${path}`)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("concatLink preserves query and fragment text after the path boundary", () => {
+    fc.assert(
+      fc.property(
+        hostArbitrary,
+        pathSegmentArbitrary,
+        fc.stringMatching(/^[a-z0-9_=&-]{0,20}$/),
+        fc.stringMatching(/^[a-z0-9_-]{0,12}$/),
+        (host, path, query, fragment) => {
+          const suffix = `?${query}#${fragment}`
+
+          expect(concatLink(`${host}/`, `${path}${suffix}`)).toBe(`${host}/${path}${suffix}`)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("normalizeForComparison is idempotent", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 120 }), (value) => {
+        const normalized = normalizeForComparison(value)
+
+        expect(normalizeForComparison(normalized)).toBe(normalized)
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("normalizeForComparison ignores case and separator insertion", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[a-zA-Z0-9]{1,24}$/), separatorArbitrary, (value, separator) => {
+        const separatedUppercase = withInsertedSeparators(value.toUpperCase(), separator)
+
+        expect(normalizeForComparison(separatedUppercase)).toBe(value.toLowerCase())
+      }),
+      propertyTestParameters
+    )
+  })
+})


### PR DESCRIPTION
gpt55+opus4.8

## Summary

Adds a comprehensive fast-check property-based testing layer across the MCP server, Huly helpers, domain schemas, storage handling, SDK discovery mappers, registry/stdout behavior, and telemetry ports.

The work also fixes issues the properties exposed:

- hardens remote URL fetching against SSRF and oversized responses
- tightens base64/data URL validation
- enforces update-schema at-least-one-field contracts at runtime
- fixes no-argument MCP tool detection for Effect empty structs
- deduplicates/self-filters SDK discovery direct ancestors
- hardens enum lookup helpers against inherited object keys
- tightens helper edge cases for color normalization and tag summary schema contracts

## Validation

- `pnpm check-all`
- Full local Huly integration suite with `NODE_OPTIONS="-r ./scripts/container-patch.cjs" bash scripts/integration_test_full.sh`: 222 passed, 0 failed, 38 skipped
