### PR TITLE
add 2026 stateless HTTP MCP support

### DIFF
--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -70,6 +70,19 @@ HULY_URL="${HULY_URL/localhost/host.docker.internal}" \
 
 By default, this starts `node dist/index.cjs` with `MCP_TRANSPORT=http` and lets the server resolve Huly credentials from process environment variables. This tests HTTP transport parity with local stdio configuration.
 
+The HTTP server supports both the existing SDK initialize-compatible request flow and the 2026 stateless request flow at the same `/mcp` endpoint. Dispatch is per request: 2026 requests use `MCP-Protocol-Version: 2026-07-28` and per-request `_meta`; requests without those 2026 signals continue through the SDK transport.
+
+`INTEGRATION_MCP_PROTOCOL=legacy|2026` is only a test harness switch for choosing which request shape the suite sends. It does not configure the server to support only one protocol mode. The HTTP suite defaults to `legacy` initialize-compatible MCP requests. To exercise the 2026 stateless HTTP path, add `INTEGRATION_MCP_PROTOCOL=2026`; the harness injects per-request `_meta`, `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers:
+
+```bash
+pnpm build
+set -a && source .env.local && set +a
+HULY_URL="${HULY_URL/localhost/host.docker.internal}" \
+  INTEGRATION_TRANSPORT=http \
+  INTEGRATION_MCP_PROTOCOL=2026 \
+  bash scripts/integration_test_full.sh
+```
+
 To test hosted URL header configuration, provide a Huly API token and run the same suite with credentials sent as request headers:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ Configure with `MCP_HTTP_PORT` and `MCP_HTTP_HOST`:
 MCP_TRANSPORT=http MCP_HTTP_PORT=8080 MCP_HTTP_HOST=0.0.0.0 npx -y @firfi/huly-mcp@latest
 ```
 
+### HTTP MCP Protocol Support
+
+The HTTP server supports both the existing SDK initialize-compatible Streamable HTTP flow and the 2026 stateless HTTP flow at the same `/mcp` endpoint. Dispatch is per request:
+
+- Requests with `MCP-Protocol-Version: 2026-07-28`, matching `_meta.io.modelcontextprotocol/protocolVersion`, or `server/discover` use the 2026 stateless dispatcher.
+- Requests without 2026 protocol signals continue through the SDK transport for compatibility with existing clients.
+
+The 2026 path requires one JSON-RPC message per POST, `Accept: application/json, text/event-stream`, `Mcp-Method`, method-specific `Mcp-Name`, and per-request `_meta.io.modelcontextprotocol/*` client metadata. Huly credentials are still configured separately through env vars or supported `x-huly-*` headers.
+
 For hosted or tunneled HTTP deployments, you can require an MCP endpoint bearer token:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@hcengineering/text-markdown": "0.7.21",
     "@hcengineering/time": "0.7.0",
     "@hcengineering/tracker": "0.7.0",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/express": "^5.0.6",
     "@types/node": "^25.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: 0.7.0
         version: 0.7.0
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
+        specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@total-typescript/ts-reset':
         specifier: ^0.6.1

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -13,6 +13,7 @@ if ! command -v jq &>/dev/null; then
 fi
 
 INTEGRATION_TRANSPORT="${INTEGRATION_TRANSPORT:-stdio}"
+INTEGRATION_MCP_PROTOCOL="${INTEGRATION_MCP_PROTOCOL:-legacy}"
 INTEGRATION_HTTP_CONFIG="${INTEGRATION_HTTP_CONFIG:-env}"
 INTEGRATION_HTTP_HOST="${INTEGRATION_HTTP_HOST:-127.0.0.1}"
 INTEGRATION_HTTP_PORT="${INTEGRATION_HTTP_PORT:-19888}"
@@ -33,6 +34,16 @@ fi
 
 if [ "$INTEGRATION_TRANSPORT" != "stdio" ] && [ "$INTEGRATION_TRANSPORT" != "http" ]; then
   echo "ERROR: INTEGRATION_TRANSPORT must be 'stdio' or 'http'"
+  exit 1
+fi
+
+if [ "$INTEGRATION_MCP_PROTOCOL" != "legacy" ] && [ "$INTEGRATION_MCP_PROTOCOL" != "2026" ]; then
+  echo "ERROR: INTEGRATION_MCP_PROTOCOL must be 'legacy' or '2026'"
+  exit 1
+fi
+
+if [ "$INTEGRATION_MCP_PROTOCOL" = "2026" ] && [ "$INTEGRATION_TRANSPORT" != "http" ]; then
+  echo "ERROR: INTEGRATION_MCP_PROTOCOL=2026 requires INTEGRATION_TRANSPORT=http"
   exit 1
 fi
 
@@ -57,6 +68,7 @@ if [ "$INTEGRATION_TRANSPORT" = "http" ] && [ "$INTEGRATION_HTTP_CONFIG" = "head
 fi
 
 INIT='{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
+MCP_2026_META='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"hulymcp-integration","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}'
 PROJECT="HULY"
 RUN_ID="$(date +%s)-$$"
 PASSED=0
@@ -202,7 +214,23 @@ call_tool_stdio() {
 call_tool_http() {
   local payload="$1"
   local response
-  response=$(curl -sS --max-time "$TOOL_TIMEOUT" --config "$HTTP_CURL_CONFIG" --request POST --data "$payload" "$HTTP_ENDPOINT" 2>/dev/null)
+  local request_payload="$payload"
+  local curl_args=(-sS --max-time "$TOOL_TIMEOUT" --config "$HTTP_CURL_CONFIG" --request POST)
+  if [ "$INTEGRATION_MCP_PROTOCOL" = "2026" ]; then
+    local method
+    local name
+    request_payload=$(printf '%s\n' "$payload" | jq -c --argjson meta "$MCP_2026_META" '.params = ((.params // {}) + {"_meta": $meta})')
+    method=$(printf '%s\n' "$request_payload" | jq -r '.method')
+    name=$(printf '%s\n' "$request_payload" | jq -r 'if .method == "tools/call" then .params.name elif .method == "resources/read" then .params.uri else empty end')
+    curl_args+=(
+      --header "MCP-Protocol-Version: 2026-07-28"
+      --header "Mcp-Method: $method"
+    )
+    if [ -n "$name" ]; then
+      curl_args+=(--header "Mcp-Name: $name")
+    fi
+  fi
+  response=$(curl "${curl_args[@]}" --data "$request_payload" "$HTTP_ENDPOINT" 2>/dev/null)
   extract_http_json_response "$response" | grep '"id":2'
 }
 

--- a/src/mcp/create-mcp-server.ts
+++ b/src/mcp/create-mcp-server.ts
@@ -1,75 +1,21 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
-import { Schema } from "effect"
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema
+} from "@modelcontextprotocol/sdk/types.js"
 
-import { type GetHulyContextResult, GetHulyContextResultSchema } from "../domain/schemas/index.js"
-import type { HulyClient } from "../huly/client.js"
-import { HulyError } from "../huly/errors-base.js"
-import type { HulyStorageClient } from "../huly/storage.js"
-import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
+import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import type { TelemetryOperations } from "../telemetry/telemetry.js"
-import { VERSION } from "../version.js"
-import type { McpToolResponse } from "./error-mapping.js"
-import { createSuccessResponse, createUnknownToolError, mapDomainErrorToMcp, toMcpResponse } from "./error-mapping.js"
-import {
-  GET_HULY_CONTEXT_TOOL_NAME,
-  getHulyContextToolDefinition,
-  VERSION_TOOL_NAME,
-  versionToolDefinition
-} from "./huly-context-tool.js"
-import { isObjectSchema, toClientCompatibleInputSchema } from "./input-schema-compat.js"
-import { registerResourceHandlers } from "./resources.js"
+import { type ClientBundle, createMcpProtocolHandlers } from "./protocol-handlers.js"
 import { createDefaultMcpSdkServer } from "./sdk-server.js"
-import { defaultToolOutputSchema } from "./tool-output-schema.js"
 import type { ToolRegistry } from "./tools/index.js"
-import { resolveAnnotations } from "./tools/index.js"
-import {
-  createMissingArgumentsError,
-  createUnexpectedArgumentsError,
-  isEmptyArgumentsObject,
-  isNoArgumentTool,
-  requiresArgumentsObject
-} from "./tools/registry.js"
 
-export interface ClientBundle {
-  readonly hulyClient: HulyClient["Type"]
-  readonly storageClient: HulyStorageClient["Type"]
-  readonly workspaceClient?: WorkspaceClientOperations
-}
+export type { ClientBundle } from "./protocol-handlers.js"
 
 type McpServerHandle = readonly [server: Server, drainInflight: () => Promise<void>]
-
-const DRAIN_POLL_MS = 50
-const DRAIN_TIMEOUT_MS = 30_000
-
-const computeOutputBytes = (response: McpToolResponse): number =>
-  response.content.reduce((sum, c) => sum + c.text.length, 0)
-
-const deriveEditMode = (name: string, args: unknown): string | undefined => {
-  if (name !== "edit_document" || args === undefined) return undefined
-  if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined
-  if ("old_text" in args) return "search_and_replace"
-  if ("content" in args) return "full_replace"
-  return "title_only"
-}
-
-const validateHulyContextResult = (value: unknown): GetHulyContextResult =>
-  Schema.decodeUnknownSync(GetHulyContextResultSchema)(value)
-
-const createDrainInflight = (getInflight: () => number): () => Promise<void> => () => {
-  if (getInflight() <= 0) return Promise.resolve()
-  return new Promise((resolve) => {
-    const start = Date.now() // eslint-disable-line no-restricted-syntax -- non-Effect Promise-based drain loop
-    const check = () => {
-      if (getInflight() <= 0 || Date.now() - start > DRAIN_TIMEOUT_MS) { // eslint-disable-line no-restricted-syntax
-        resolve()
-      } else {
-        setTimeout(check, DRAIN_POLL_MS)
-      }
-    }
-    check()
-  })
-}
 
 export const createMcpServer = (
   resolveClients: () => Promise<ClientBundle>,
@@ -78,167 +24,14 @@ export const createMcpServer = (
   getHulyContext: () => GetHulyContextResult,
   createServer: () => Server = createDefaultMcpSdkServer
 ): McpServerHandle => {
-  let inflight = 0
-  const drainInflight = createDrainInflight(() => inflight)
   const server = createServer()
+  const handlers = createMcpProtocolHandlers(resolveClients, telemetry, registry, getHulyContext)
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    telemetry.firstListTools()
-    return {
-      tools: [
-        versionToolDefinition,
-        getHulyContextToolDefinition,
-        ...registry.definitions.flatMap((tool) => {
-          if (!isObjectSchema(tool.inputSchema)) return []
-          return [{
-            name: tool.name,
-            description: tool.description,
-            inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
-            outputSchema: defaultToolOutputSchema,
-            annotations: resolveAnnotations(tool)
-          }]
-        })
-      ]
-    }
-  })
+  server.setRequestHandler(ListToolsRequestSchema, handlers.listTools)
+  server.setRequestHandler(CallToolRequestSchema, handlers.callTool)
+  server.setRequestHandler(ListResourcesRequestSchema, handlers.listResources)
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, handlers.listResourceTemplates)
+  server.setRequestHandler(ReadResourceRequestSchema, handlers.readResource)
 
-  registerResourceHandlers(server, resolveClients, {
-    enter: () => {
-      inflight++
-    },
-    leave: () => {
-      inflight--
-    }
-  })
-
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    inflight++
-    try {
-      const { arguments: args, name } = request.params
-
-      const start = Date.now() // eslint-disable-line no-restricted-syntax -- non-Effect async handler
-      const inputBytes = JSON.stringify(args ?? {}).length
-
-      const returnError = (errorResponse: McpToolResponse, editMode?: string) => {
-        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
-        telemetry.toolCalled({
-          toolName: name,
-          status: "error",
-          errorTag: errorResponse._meta?.errorTag,
-          durationMs,
-          inputBytes,
-          outputBytes: computeOutputBytes(errorResponse),
-          editMode
-        })
-        return toMcpResponse(errorResponse)
-      }
-
-      if (name === VERSION_TOOL_NAME) {
-        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
-
-        const latest = await fetchLatestNpmVersion()
-        const versionResponse = createSuccessResponse({ current: VERSION, latest })
-        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
-        telemetry.toolCalled({
-          toolName: name,
-          status: "success",
-          durationMs,
-          inputBytes,
-          outputBytes: computeOutputBytes(versionResponse)
-        })
-        return toMcpResponse(versionResponse)
-      }
-
-      if (name === GET_HULY_CONTEXT_TOOL_NAME) {
-        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
-
-        let context: GetHulyContextResult
-        try {
-          context = validateHulyContextResult(getHulyContext())
-        } catch {
-          return returnError(mapDomainErrorToMcp(new HulyError({ message: "Failed to build Huly context" })))
-        }
-
-        const contextResponse = createSuccessResponse(context)
-        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
-        telemetry.toolCalled({
-          toolName: name,
-          status: "success",
-          durationMs,
-          inputBytes,
-          outputBytes: computeOutputBytes(contextResponse)
-        })
-        return toMcpResponse(contextResponse)
-      }
-
-      const tool = registry.tools.get(name)
-      if (tool === undefined) return returnError(createUnknownToolError(name))
-
-      if (isNoArgumentTool(tool) && !isEmptyArgumentsObject(args)) {
-        return returnError(createUnexpectedArgumentsError(name))
-      }
-
-      if (args === undefined && requiresArgumentsObject(tool)) {
-        return returnError(createMissingArgumentsError(name))
-      }
-
-      const editMode = deriveEditMode(name, args)
-
-      let clients: ClientBundle
-      try {
-        clients = await resolveClients()
-      } catch (e) {
-        const errorResponse = mapDomainErrorToMcp(
-          new HulyError({ message: `Failed to initialize Huly clients: ${e instanceof Error ? e.message : String(e)}` })
-        )
-        return returnError(errorResponse, editMode)
-      }
-
-      const response = await registry.handleToolCall(
-        name,
-        args,
-        clients.hulyClient,
-        clients.storageClient,
-        clients.workspaceClient
-      )
-      const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax
-      if (response === null) return returnError(createUnknownToolError(name), editMode)
-
-      telemetry.toolCalled({
-        toolName: name,
-        status: response.isError === true ? "error" : "success",
-        errorTag: response._meta?.errorTag,
-        durationMs,
-        inputBytes,
-        outputBytes: computeOutputBytes(response),
-        editMode
-      })
-
-      return toMcpResponse(response)
-    } finally {
-      inflight--
-    }
-  })
-
-  const handle: McpServerHandle = [server, drainInflight]
-  return handle
-}
-
-const NPM_FETCH_TIMEOUT_MS = 5_000
-const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
-
-const fetchLatestNpmVersion = async (): Promise<string> => {
-  try {
-    const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`, {
-      signal: AbortSignal.timeout(NPM_FETCH_TIMEOUT_MS)
-    })
-    if (!res.ok) return "unknown"
-    const data: unknown = await res.json()
-    if (typeof data === "object" && data !== null && "version" in data && typeof data.version === "string") {
-      return data.version
-    }
-    return "unknown"
-  } catch {
-    return "unknown"
-  }
+  return [server, handlers.drainInflight]
 }

--- a/src/mcp/http-2026-dispatcher.ts
+++ b/src/mcp/http-2026-dispatcher.ts
@@ -1,0 +1,372 @@
+import { McpError } from "@modelcontextprotocol/sdk/types.js"
+import type { Request, Response } from "express"
+
+import type { McpProtocolHandlers } from "./protocol-handlers.js"
+
+const MCP_2026_PROTOCOL_VERSION = "2026-07-28"
+
+const HEADER_MISMATCH = -32001
+const UNSUPPORTED_PROTOCOL_VERSION = -32004
+const INVALID_REQUEST = -32600
+const METHOD_NOT_FOUND = -32601
+const INVALID_PARAMS = -32602
+const INTERNAL_ERROR = -32603
+const RESOURCE_NOT_FOUND = -32002
+
+const HTTP_BAD_REQUEST = 400
+const HTTP_NOT_FOUND = 404
+const HTTP_OK = 200
+const PUBLIC_LIST_TTL_MS = 300_000
+const PRIVATE_RESOURCE_TTL_MS = 60_000
+
+type CacheScope = "public" | "private"
+
+interface JsonRpcRequest {
+  readonly jsonrpc: "2.0"
+  readonly id?: string | number | null
+  readonly method: string
+  readonly params?: unknown
+}
+
+interface JsonRpcErrorObject {
+  readonly code: number
+  readonly message: string
+  readonly data?: unknown
+}
+
+interface JsonRpcErrorResponse {
+  readonly jsonrpc: "2.0"
+  readonly id: string | number | null
+  readonly error: JsonRpcErrorObject
+}
+
+interface JsonRpcSuccessResponse {
+  readonly jsonrpc: "2.0"
+  readonly id: string | number | null
+  readonly result: unknown
+}
+
+interface HeaderValidation {
+  readonly request: JsonRpcRequest
+  readonly params: Record<string, unknown>
+  readonly id: string | number | null
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const firstHeader = (value: string | ReadonlyArray<string> | undefined): string | undefined => {
+  if (typeof value === "string") return value
+  return value?.[0]
+}
+
+const requestId = (body: unknown): string | number | null => {
+  if (!isRecord(body)) return null
+  const id = body.id
+  return typeof id === "string" || typeof id === "number" || id === null ? id : null
+}
+
+const metaProtocolVersion = (body: unknown): string | undefined => {
+  if (!isRecord(body) || !isRecord(body.params) || !isRecord(body.params._meta)) return undefined
+  const version = body.params._meta["io.modelcontextprotocol/protocolVersion"]
+  return typeof version === "string" ? version : undefined
+}
+
+const bodyMethod = (body: unknown): string | undefined => {
+  if (!isRecord(body)) return undefined
+  return typeof body.method === "string" ? body.method : undefined
+}
+
+export const shouldDispatchMcp2026Request = (req: Request): boolean =>
+  firstHeader(req.headers["mcp-protocol-version"]) === MCP_2026_PROTOCOL_VERSION
+  || metaProtocolVersion(req.body) === MCP_2026_PROTOCOL_VERSION
+  || bodyMethod(req.body) === "server/discover"
+
+const jsonRpcError = (
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown
+): JsonRpcErrorResponse => {
+  if (data === undefined) {
+    return { jsonrpc: "2.0", id, error: { code, message } }
+  }
+  return { jsonrpc: "2.0", id, error: { code, message, data } }
+}
+
+const writeError = (
+  res: Response,
+  status: number,
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown
+): void => {
+  res.status(status).json(jsonRpcError(id, code, message, data))
+}
+
+const writeSuccess = (res: Response, id: string | number | null, result: unknown): void => {
+  const body: JsonRpcSuccessResponse = { jsonrpc: "2.0", id, result }
+  res.status(HTTP_OK).json(body)
+}
+
+const acceptsModernResponseTypes = (req: Request): boolean => {
+  const accept = firstHeader(req.headers.accept)
+  if (accept === undefined) return false
+  const parts = accept.split(",").map(part => part.trim().toLowerCase().split(";")[0])
+  return parts.includes("application/json") && parts.includes("text/event-stream")
+}
+
+const validateJsonRpcRequest = (body: unknown): JsonRpcRequest | JsonRpcErrorObject => {
+  if (Array.isArray(body)) {
+    return { code: INVALID_REQUEST, message: "Batch JSON-RPC requests are not supported" }
+  }
+  if (!isRecord(body)) {
+    return { code: INVALID_REQUEST, message: "Request body must be a single JSON-RPC object" }
+  }
+  if (body.jsonrpc !== "2.0") {
+    return { code: INVALID_REQUEST, message: "Request body must include jsonrpc: \"2.0\"" }
+  }
+  if (typeof body.method !== "string" || body.method === "") {
+    return { code: INVALID_REQUEST, message: "Request body must include a non-empty method" }
+  }
+  return {
+    jsonrpc: "2.0",
+    id: requestId(body),
+    method: body.method,
+    params: body.params
+  }
+}
+
+const requiredStringHeader = (req: Request, name: string): string | JsonRpcErrorObject => {
+  const header = firstHeader(req.headers[name.toLowerCase()])
+  if (header === undefined || header.trim() === "") {
+    return { code: HEADER_MISMATCH, message: `Header mismatch: required ${name} header is missing` }
+  }
+  return header
+}
+
+const validateMeta = (params: Record<string, unknown>): JsonRpcErrorObject | undefined => {
+  if (!isRecord(params._meta)) {
+    return { code: HEADER_MISMATCH, message: "Header mismatch: params._meta is required" }
+  }
+  if (params._meta["io.modelcontextprotocol/protocolVersion"] !== MCP_2026_PROTOCOL_VERSION) {
+    return {
+      code: HEADER_MISMATCH,
+      message: "Header mismatch: params._meta protocol version must be 2026-07-28"
+    }
+  }
+  if (!isRecord(params._meta["io.modelcontextprotocol/clientInfo"])) {
+    return { code: HEADER_MISMATCH, message: "Header mismatch: clientInfo metadata is required" }
+  }
+  if (!isRecord(params._meta["io.modelcontextprotocol/clientCapabilities"])) {
+    return { code: HEADER_MISMATCH, message: "Header mismatch: clientCapabilities metadata is required" }
+  }
+  return undefined
+}
+
+const validateHeadersAndMeta = (req: Request): HeaderValidation | JsonRpcErrorResponse => {
+  const id = requestId(req.body)
+  const parsed = validateJsonRpcRequest(req.body)
+  if ("code" in parsed) return jsonRpcError(id, parsed.code, parsed.message, parsed.data)
+
+  if (!acceptsModernResponseTypes(req)) {
+    return jsonRpcError(
+      parsed.id ?? null,
+      HEADER_MISMATCH,
+      "Header mismatch: Accept header must include application/json and text/event-stream"
+    )
+  }
+
+  const protocolHeader = requiredStringHeader(req, "MCP-Protocol-Version")
+  if (typeof protocolHeader !== "string") {
+    return jsonRpcError(parsed.id ?? null, protocolHeader.code, protocolHeader.message, protocolHeader.data)
+  }
+  if (protocolHeader !== MCP_2026_PROTOCOL_VERSION) {
+    return jsonRpcError(
+      parsed.id ?? null,
+      UNSUPPORTED_PROTOCOL_VERSION,
+      "Unsupported protocol version",
+      { supported: [MCP_2026_PROTOCOL_VERSION], requested: protocolHeader }
+    )
+  }
+
+  const methodHeader = requiredStringHeader(req, "Mcp-Method")
+  if (typeof methodHeader !== "string") {
+    return jsonRpcError(parsed.id ?? null, methodHeader.code, methodHeader.message, methodHeader.data)
+  }
+  if (methodHeader !== parsed.method) {
+    return jsonRpcError(
+      parsed.id ?? null,
+      HEADER_MISMATCH,
+      `Header mismatch: Mcp-Method header value '${methodHeader}' does not match body value '${parsed.method}'`
+    )
+  }
+
+  const params = isRecord(parsed.params) ? parsed.params : {}
+  const metaError = validateMeta(params)
+  if (metaError !== undefined) {
+    return jsonRpcError(parsed.id ?? null, metaError.code, metaError.message, metaError.data)
+  }
+
+  const nameValidation = validateNameHeader(req, parsed.method, params)
+  if (nameValidation !== undefined) {
+    return jsonRpcError(parsed.id ?? null, nameValidation.code, nameValidation.message, nameValidation.data)
+  }
+
+  return { request: parsed, params, id: parsed.id ?? null }
+}
+
+const validateNameHeader = (
+  req: Request,
+  method: string,
+  params: Record<string, unknown>
+): JsonRpcErrorObject | undefined => {
+  if (method !== "tools/call" && method !== "resources/read") return undefined
+
+  const nameHeader = requiredStringHeader(req, "Mcp-Name")
+  if (typeof nameHeader !== "string") return nameHeader
+
+  const bodyName = method === "tools/call" ? params.name : params.uri
+  if (typeof bodyName !== "string" || bodyName === "") {
+    return {
+      code: INVALID_PARAMS,
+      message: method === "tools/call"
+        ? "Invalid params: tools/call requires params.name"
+        : "Invalid params: resources/read requires params.uri"
+    }
+  }
+  if (nameHeader !== bodyName) {
+    return {
+      code: HEADER_MISMATCH,
+      message: `Header mismatch: Mcp-Name header value '${nameHeader}' does not match body value '${bodyName}'`
+    }
+  }
+  return undefined
+}
+
+const complete = <T extends object>(result: T): T & { readonly resultType: "complete" } => ({
+  ...result,
+  resultType: "complete"
+})
+
+const cacheable = (
+  result: object,
+  ttlMs: number,
+  cacheScope: CacheScope
+): object => ({
+  ...complete(result),
+  ttlMs,
+  cacheScope
+})
+
+const toModernMcpError = (error: McpError): JsonRpcErrorObject => {
+  if (error.code === RESOURCE_NOT_FOUND) {
+    return { code: INVALID_PARAMS, message: "Resource not found", data: error.data }
+  }
+  return {
+    code: error.code,
+    message: error.message,
+    data: error.data
+  }
+}
+
+const thrownToJsonRpcError = (error: unknown): JsonRpcErrorObject => {
+  if (error instanceof McpError) return toModernMcpError(error)
+  return { code: INTERNAL_ERROR, message: `Internal server error: ${String(error)}` }
+}
+
+export const dispatchMcp2026Request = async (
+  req: Request,
+  res: Response,
+  handlers: McpProtocolHandlers
+): Promise<void> => {
+  res.setHeader("Content-Type", "application/json")
+
+  const validation = validateHeadersAndMeta(req)
+  if ("error" in validation) {
+    const status = validation.error.code === METHOD_NOT_FOUND ? HTTP_NOT_FOUND : HTTP_BAD_REQUEST
+    res.status(status).json(validation)
+    return
+  }
+
+  try {
+    switch (validation.request.method) {
+      case "server/discover":
+        writeSuccess(res, validation.id, handlers.serverDiscover())
+        return
+
+      case "tools/list":
+        writeSuccess(res, validation.id, cacheable(await handlers.listTools(), PUBLIC_LIST_TTL_MS, "public"))
+        return
+
+      case "tools/call":
+        if (typeof validation.params.name !== "string") {
+          writeError(
+            res,
+            HTTP_BAD_REQUEST,
+            validation.id,
+            INVALID_PARAMS,
+            "Invalid params: tools/call requires params.name"
+          )
+          return
+        }
+        writeSuccess(
+          res,
+          validation.id,
+          complete(
+            await handlers.callTool({
+              params: {
+                name: validation.params.name,
+                arguments: validation.params.arguments
+              }
+            })
+          )
+        )
+        return
+
+      case "resources/list":
+        writeSuccess(res, validation.id, cacheable(await handlers.listResources(), PRIVATE_RESOURCE_TTL_MS, "private"))
+        return
+
+      case "resources/templates/list":
+        writeSuccess(res, validation.id, cacheable(handlers.listResourceTemplates(), PUBLIC_LIST_TTL_MS, "public"))
+        return
+
+      case "resources/read":
+        if (typeof validation.params.uri !== "string") {
+          writeError(
+            res,
+            HTTP_BAD_REQUEST,
+            validation.id,
+            INVALID_PARAMS,
+            "Invalid params: resources/read requires params.uri"
+          )
+          return
+        }
+        writeSuccess(
+          res,
+          validation.id,
+          cacheable(
+            await handlers.readResource({ params: { uri: validation.params.uri } }),
+            PRIVATE_RESOURCE_TTL_MS,
+            "private"
+          )
+        )
+        return
+
+      default:
+        writeError(res, HTTP_NOT_FOUND, validation.id, METHOD_NOT_FOUND, "Method not found")
+    }
+  } catch (error) {
+    const mapped = thrownToJsonRpcError(error)
+    writeError(
+      res,
+      mapped.code === METHOD_NOT_FOUND ? HTTP_NOT_FOUND : HTTP_BAD_REQUEST,
+      validation.id,
+      mapped.code,
+      mapped.message,
+      mapped.data
+    )
+  }
+}

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -17,6 +17,9 @@ import type { Scope } from "effect"
 import { Context, Effect, Layer, Schema } from "effect"
 import type { Express, Request, Response } from "express"
 
+import { dispatchMcp2026Request, shouldDispatchMcp2026Request } from "./http-2026-dispatcher.js"
+import type { McpProtocolHandlers } from "./protocol-handlers.js"
+
 export const DEFAULT_HTTP_PORT = 3000
 const HTTP_METHOD_NOT_ALLOWED = 405
 const HTTP_UNAUTHORIZED = 401
@@ -99,6 +102,8 @@ export interface HttpTransportDependencies {
   readonly writeError: (message: string) => void
 }
 
+type HttpProtocolHandlerFactory = (req: Request) => McpProtocolHandlers
+
 const defaultTransportDependencies: HttpTransportDependencies = {
   createTransport: () => new StreamableHTTPServerTransport({}),
   writeError: writeStderr
@@ -173,7 +178,8 @@ export class HttpServerFactoryService extends Context.Tag("@hulymcp/HttpServerFa
 export const createMcpHandlers = (
   createServer: (req: Request) => Server,
   dependencies: HttpTransportDependencies = defaultTransportDependencies,
-  authToken?: string
+  authToken?: string,
+  createProtocolHandlers?: HttpProtocolHandlerFactory
 ): {
   post: (req: Request, res: Response) => Promise<void>
   get: (req: Request, res: Response) => void
@@ -183,6 +189,11 @@ export const createMcpHandlers = (
     try {
       if (!isAuthorizedMcpRequest(req, authToken)) {
         writeUnauthorized(res)
+        return
+      }
+
+      if (createProtocolHandlers !== undefined && shouldDispatchMcp2026Request(req)) {
+        await dispatchMcp2026Request(req, res, createProtocolHandlers(req))
         return
       }
 
@@ -274,17 +285,23 @@ const closeHttpServer = (
 export const startHttpTransport = (
   config: HttpTransportConfig,
   createServer: (req: Request) => Server,
-  dependencies?: Partial<HttpTransportDependencies>
+  dependencies?: Partial<HttpTransportDependencies>,
+  createProtocolHandlers?: HttpProtocolHandlerFactory
 ): Effect.Effect<void, HttpTransportError, HttpServerFactoryService | Scope.Scope> =>
   Effect.gen(function*() {
     const factory = yield* HttpServerFactoryService
     const writeError: (message: string) => void = dependencies?.writeError ?? factory.writeError ?? writeStderr
 
     const app = factory.createApp(config.host)
-    const handlers = createMcpHandlers(createServer, {
-      createTransport: dependencies?.createTransport ?? defaultTransportDependencies.createTransport,
-      writeError
-    }, config.authToken)
+    const handlers = createMcpHandlers(
+      createServer,
+      {
+        createTransport: dependencies?.createTransport ?? defaultTransportDependencies.createTransport,
+        writeError
+      },
+      config.authToken,
+      createProtocolHandlers
+    )
     app.post("/mcp", handlers.post)
     app.get("/mcp", handlers.get)
     app.delete("/mcp", handlers.delete)

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -1,0 +1,402 @@
+import type {
+  CallToolResult,
+  ListResourcesResult,
+  ListResourceTemplatesResult,
+  ListToolsResult,
+  ReadResourceResult
+} from "@modelcontextprotocol/sdk/types.js"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Chunk, Effect, Exit, Schema } from "effect"
+
+import { type GetHulyContextResult, GetHulyContextResultSchema } from "../domain/schemas/index.js"
+import { HulyClient } from "../huly/client.js"
+import { HulyError } from "../huly/errors-base.js"
+import type { HulyStorageClient } from "../huly/storage.js"
+import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
+import type { TelemetryOperations } from "../telemetry/telemetry.js"
+import { VERSION } from "../version.js"
+import type { McpToolResponse } from "./error-mapping.js"
+import { createSuccessResponse, createUnknownToolError, mapDomainErrorToMcp, toMcpResponse } from "./error-mapping.js"
+import {
+  GET_HULY_CONTEXT_TOOL_NAME,
+  getHulyContextToolDefinition,
+  VERSION_TOOL_NAME,
+  versionToolDefinition
+} from "./huly-context-tool.js"
+import { isObjectSchema, toClientCompatibleInputSchema } from "./input-schema-compat.js"
+import { listResources, listResourceTemplates, readHulyResource } from "./resources.js"
+import { defaultToolOutputSchema } from "./tool-output-schema.js"
+import type { ToolRegistry } from "./tools/index.js"
+import { resolveAnnotations } from "./tools/index.js"
+import {
+  createMissingArgumentsError,
+  createUnexpectedArgumentsError,
+  isEmptyArgumentsObject,
+  isNoArgumentTool,
+  requiresArgumentsObject
+} from "./tools/registry.js"
+
+export interface ClientBundle {
+  readonly hulyClient: HulyClient["Type"]
+  readonly storageClient: HulyStorageClient["Type"]
+  readonly workspaceClient?: WorkspaceClientOperations
+}
+
+interface ToolCallRequest {
+  readonly params: {
+    readonly name: string
+    readonly arguments?: unknown
+  }
+}
+
+interface ResourceReadRequest {
+  readonly params: {
+    readonly uri: string
+  }
+}
+
+type ListToolsProtocolResult = ListToolsResult
+
+export interface McpProtocolHandlers {
+  readonly listTools: () => Promise<ListToolsProtocolResult>
+  readonly callTool: (request: ToolCallRequest) => Promise<CallToolResult>
+  readonly listResources: () => Promise<ListResourcesResult>
+  readonly listResourceTemplates: () => ListResourceTemplatesResult
+  readonly readResource: (request: ResourceReadRequest) => Promise<ReadResourceResult>
+  readonly serverDiscover: () => ServerDiscoverResult
+  readonly drainInflight: () => Promise<void>
+}
+
+interface ServerDiscoverResult {
+  readonly resultType: "complete"
+  readonly supportedVersions: readonly ["2026-07-28"]
+  readonly capabilities: {
+    readonly tools: Record<string, never>
+    readonly resources: Record<string, never>
+  }
+  readonly serverInfo: {
+    readonly name: "huly-mcp"
+    readonly version: string
+  }
+}
+
+const DRAIN_POLL_MS = 50
+const DRAIN_TIMEOUT_MS = 30_000
+const NPM_FETCH_TIMEOUT_MS = 5_000
+const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
+
+const computeOutputBytes = (response: McpToolResponse): number =>
+  response.content.reduce((sum, c) => sum + c.text.length, 0)
+
+const deriveEditMode = (name: string, args: unknown): string | undefined => {
+  if (name !== "edit_document" || args === undefined) return undefined
+  if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined
+  if ("old_text" in args) return "search_and_replace"
+  if ("content" in args) return "full_replace"
+  return "title_only"
+}
+
+const validateHulyContextResult = (value: unknown): GetHulyContextResult =>
+  Schema.decodeUnknownSync(GetHulyContextResultSchema)(value)
+
+const createDrainInflight = (getInflight: () => number): () => Promise<void> => () => {
+  if (getInflight() <= 0) return Promise.resolve()
+  return new Promise((resolve) => {
+    const start = Date.now() // eslint-disable-line no-restricted-syntax -- non-Effect Promise-based drain loop
+    const check = () => {
+      if (getInflight() <= 0 || Date.now() - start > DRAIN_TIMEOUT_MS) { // eslint-disable-line no-restricted-syntax
+        resolve()
+      } else {
+        setTimeout(check, DRAIN_POLL_MS)
+      }
+    }
+    check()
+  })
+}
+
+const fetchLatestNpmVersion = async (): Promise<string> => {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`, {
+      signal: AbortSignal.timeout(NPM_FETCH_TIMEOUT_MS)
+    })
+    if (!res.ok) return "unknown"
+    const data: unknown = await res.json()
+    if (typeof data === "object" && data !== null && "version" in data && typeof data.version === "string") {
+      return data.version
+    }
+    return "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
+interface ProtocolObjectSchemaSource {
+  readonly type: "object"
+  readonly properties?: Record<string, unknown> | undefined
+  readonly required?: ReadonlyArray<string> | undefined
+  readonly [key: string]: unknown
+}
+
+type ProtocolObjectSchema = ListToolsResult["tools"][number]["inputSchema"]
+
+const isObjectPropertyEntry = (entry: [string, unknown]): entry is [string, object] => {
+  const value = entry[1]
+  return typeof value === "object" && value !== null
+}
+
+const objectProperties = (properties: Record<string, unknown> | undefined): Record<string, object> | undefined => {
+  if (properties === undefined) return undefined
+
+  return Object.entries(properties).filter(isObjectPropertyEntry).reduce<Record<string, object>>(
+    (acc, [key, value]) => ({ ...acc, [key]: value }),
+    {}
+  )
+}
+
+const toProtocolObjectSchema = (schema: ProtocolObjectSchemaSource): ProtocolObjectSchema => {
+  const { properties, required, ...rest } = schema
+  const convertedProperties = objectProperties(properties)
+  return {
+    ...rest,
+    type: "object",
+    ...(convertedProperties === undefined ? {} : { properties: convertedProperties }),
+    ...(required === undefined ? {} : { required: [...required] })
+  }
+}
+
+const createResourceClientResolutionError = (uri: string, _error: unknown): McpError =>
+  new McpError(
+    ErrorCode.InternalError,
+    `Failed to initialize Huly clients while reading resource "${uri}". Verify Huly URL, workspace, and authentication configuration.`
+  )
+
+const createResourceListClientResolutionError = (_error: unknown): McpError =>
+  new McpError(
+    ErrorCode.InternalError,
+    "Failed to initialize Huly clients while listing resources. Verify Huly URL, workspace, and authentication configuration."
+  )
+
+const resolveResourceClientsOrThrow = async (
+  resolveClients: () => Promise<ClientBundle>,
+  mapError: (error: unknown) => McpError
+): Promise<ClientBundle> => {
+  try {
+    return await resolveClients()
+  } catch (e) {
+    throw mapError(e)
+  }
+}
+
+const throwResourceReadError = (uri: string, cause: Cause.Cause<McpError>): never => {
+  const failures = Chunk.toArray(Cause.failures(cause))
+  const failure = failures[0]
+  if (failure instanceof McpError) throw failure
+  throw new McpError(ErrorCode.InternalError, `Failed to read Huly resource "${uri}"`)
+}
+
+const throwResourceListError = (cause: Cause.Cause<McpError>): never => {
+  const failures = Chunk.toArray(Cause.failures(cause))
+  const failure = failures[0]
+  if (failure instanceof McpError) throw failure
+  throw new McpError(ErrorCode.InternalError, "Failed to list Huly resources")
+}
+
+export const createMcpProtocolHandlers = (
+  resolveClients: () => Promise<ClientBundle>,
+  telemetry: TelemetryOperations,
+  registry: ToolRegistry,
+  getHulyContext: () => GetHulyContextResult
+): McpProtocolHandlers => {
+  let inflight = 0
+  const drainInflight = createDrainInflight(() => inflight)
+  const enter = () => {
+    inflight++
+  }
+  const leave = () => {
+    inflight--
+  }
+
+  const listTools = async (): Promise<ListToolsProtocolResult> => {
+    telemetry.firstListTools()
+    return {
+      tools: [
+        versionToolDefinition,
+        getHulyContextToolDefinition,
+        ...registry.definitions.flatMap((tool) => {
+          if (!isObjectSchema(tool.inputSchema)) return []
+          return [{
+            name: tool.name,
+            description: tool.description,
+            inputSchema: toProtocolObjectSchema(toClientCompatibleInputSchema(tool.inputSchema)),
+            outputSchema: toProtocolObjectSchema(defaultToolOutputSchema),
+            annotations: resolveAnnotations(tool)
+          }]
+        })
+      ].map(tool => ({
+        ...tool,
+        inputSchema: toProtocolObjectSchema(tool.inputSchema),
+        outputSchema: toProtocolObjectSchema(tool.outputSchema)
+      }))
+    }
+  }
+
+  const callTool = async (request: ToolCallRequest): Promise<CallToolResult> => {
+    enter()
+    try {
+      const { arguments: args, name } = request.params
+
+      const start = Date.now() // eslint-disable-line no-restricted-syntax -- non-Effect async handler
+      const inputBytes = JSON.stringify(args ?? {}).length
+
+      const returnError = (errorResponse: McpToolResponse, editMode?: string) => {
+        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
+        telemetry.toolCalled({
+          toolName: name,
+          status: "error",
+          errorTag: errorResponse._meta?.errorTag,
+          durationMs,
+          inputBytes,
+          outputBytes: computeOutputBytes(errorResponse),
+          editMode
+        })
+        return toMcpResponse(errorResponse)
+      }
+
+      if (name === VERSION_TOOL_NAME) {
+        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
+
+        const latest = await fetchLatestNpmVersion()
+        const versionResponse = createSuccessResponse({ current: VERSION, latest })
+        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
+        telemetry.toolCalled({
+          toolName: name,
+          status: "success",
+          durationMs,
+          inputBytes,
+          outputBytes: computeOutputBytes(versionResponse)
+        })
+        return toMcpResponse(versionResponse)
+      }
+
+      if (name === GET_HULY_CONTEXT_TOOL_NAME) {
+        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
+
+        let context: GetHulyContextResult
+        try {
+          context = validateHulyContextResult(getHulyContext())
+        } catch {
+          return returnError(mapDomainErrorToMcp(new HulyError({ message: "Failed to build Huly context" })))
+        }
+
+        const contextResponse = createSuccessResponse(context)
+        const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax -- non-Effect async handler
+        telemetry.toolCalled({
+          toolName: name,
+          status: "success",
+          durationMs,
+          inputBytes,
+          outputBytes: computeOutputBytes(contextResponse)
+        })
+        return toMcpResponse(contextResponse)
+      }
+
+      const tool = registry.tools.get(name)
+      if (tool === undefined) return returnError(createUnknownToolError(name))
+
+      if (isNoArgumentTool(tool) && !isEmptyArgumentsObject(args)) {
+        return returnError(createUnexpectedArgumentsError(name))
+      }
+
+      if (args === undefined && requiresArgumentsObject(tool)) {
+        return returnError(createMissingArgumentsError(name))
+      }
+
+      const editMode = deriveEditMode(name, args)
+
+      let clients: ClientBundle
+      try {
+        clients = await resolveClients()
+      } catch (e) {
+        const errorResponse = mapDomainErrorToMcp(
+          new HulyError({ message: `Failed to initialize Huly clients: ${e instanceof Error ? e.message : String(e)}` })
+        )
+        return returnError(errorResponse, editMode)
+      }
+
+      const response = await registry.handleToolCall(
+        name,
+        args,
+        clients.hulyClient,
+        clients.storageClient,
+        clients.workspaceClient
+      )
+      const durationMs = Date.now() - start // eslint-disable-line no-restricted-syntax
+      if (response === null) return returnError(createUnknownToolError(name), editMode)
+
+      telemetry.toolCalled({
+        toolName: name,
+        status: response.isError === true ? "error" : "success",
+        errorTag: response._meta?.errorTag,
+        durationMs,
+        inputBytes,
+        outputBytes: computeOutputBytes(response),
+        editMode
+      })
+
+      return toMcpResponse(response)
+    } finally {
+      leave()
+    }
+  }
+
+  const listResourcesHandler = async (): Promise<ListResourcesResult> => {
+    enter()
+    try {
+      const clients = await resolveResourceClientsOrThrow(resolveClients, createResourceListClientResolutionError)
+      const resourceList = await Effect.runPromiseExit(
+        listResources().pipe(
+          Effect.provideService(HulyClient, clients.hulyClient)
+        )
+      )
+      if (Exit.isSuccess(resourceList)) return resourceList.value
+      return throwResourceListError(resourceList.cause)
+    } finally {
+      leave()
+    }
+  }
+
+  const readResource = async (request: ResourceReadRequest): Promise<ReadResourceResult> => {
+    enter()
+    try {
+      const { uri } = request.params
+      const clients = await resolveResourceClientsOrThrow(
+        resolveClients,
+        error => createResourceClientResolutionError(uri, error)
+      )
+      const resourceRead = await Effect.runPromiseExit(
+        readHulyResource(uri).pipe(
+          Effect.provideService(HulyClient, clients.hulyClient)
+        )
+      )
+      if (Exit.isSuccess(resourceRead)) return resourceRead.value
+      return throwResourceReadError(uri, resourceRead.cause)
+    } finally {
+      leave()
+    }
+  }
+
+  return {
+    listTools,
+    callTool,
+    listResources: listResourcesHandler,
+    listResourceTemplates,
+    readResource,
+    serverDiscover: () => ({
+      resultType: "complete",
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: "huly-mcp", version: VERSION }
+    }),
+    drainInflight
+  }
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -3,18 +3,14 @@
  *
  * @module
  */
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import {
   ErrorCode,
-  ListResourcesRequestSchema,
   type ListResourcesResult,
-  ListResourceTemplatesRequestSchema,
   type ListResourceTemplatesResult,
   McpError,
-  ReadResourceRequestSchema,
   type ReadResourceResult
 } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Chunk, Effect, Exit, ParseResult, Schema } from "effect"
+import { Effect, ParseResult, Schema } from "effect"
 
 import {
   type Issue,
@@ -27,7 +23,7 @@ import {
   type ProjectSummary
 } from "../domain/schemas.js"
 import { IssueIdentifier, MAX_LIMIT, ProjectIdentifier } from "../domain/schemas/shared.js"
-import { HulyClient } from "../huly/client.js"
+import type { HulyClient } from "../huly/client.js"
 import type { HulyDomainError } from "../huly/errors.js"
 import { getIssue } from "../huly/operations/issues.js"
 import { getProject, listProjects } from "../huly/operations/projects.js"
@@ -371,91 +367,3 @@ export const readHulyResource = (
   }).pipe(
     Effect.flatMap(readParsedHulyResource)
   )
-
-const createResourceClientResolutionError = (uri: string, _error: unknown): McpError =>
-  new McpError(
-    ErrorCode.InternalError,
-    `Failed to initialize Huly clients while reading resource "${uri}". Verify Huly URL, workspace, and authentication configuration.`
-  )
-
-const createResourceListClientResolutionError = (_error: unknown): McpError =>
-  new McpError(
-    ErrorCode.InternalError,
-    "Failed to initialize Huly clients while listing resources. Verify Huly URL, workspace, and authentication configuration."
-  )
-
-interface ResourceClientBundle {
-  readonly hulyClient: HulyClient["Type"]
-}
-
-interface InflightResourceGuard {
-  readonly enter: () => void
-  readonly leave: () => void
-}
-
-const resolveResourceClientsOrThrow = async (
-  resolveClients: () => Promise<ResourceClientBundle>,
-  mapError: (error: unknown) => McpError
-): Promise<ResourceClientBundle> => {
-  try {
-    return await resolveClients()
-  } catch (e) {
-    throw mapError(e)
-  }
-}
-
-const throwResourceReadError = (uri: string, cause: Cause.Cause<McpError>): never => {
-  const failures = Chunk.toArray(Cause.failures(cause))
-  const failure = failures[0]
-  if (failure instanceof McpError) throw failure
-  throw new McpError(ErrorCode.InternalError, `Failed to read Huly resource "${uri}"`)
-}
-
-const throwResourceListError = (cause: Cause.Cause<McpError>): never => {
-  const failures = Chunk.toArray(Cause.failures(cause))
-  const failure = failures[0]
-  if (failure instanceof McpError) throw failure
-  throw new McpError(ErrorCode.InternalError, "Failed to list Huly resources")
-}
-
-export const registerResourceHandlers = (
-  server: Server,
-  resolveClients: () => Promise<ResourceClientBundle>,
-  inflight?: InflightResourceGuard
-): void => {
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    inflight?.enter()
-    try {
-      const clients = await resolveResourceClientsOrThrow(resolveClients, createResourceListClientResolutionError)
-      const resourceList = await Effect.runPromiseExit(
-        listResources().pipe(
-          Effect.provideService(HulyClient, clients.hulyClient)
-        )
-      )
-      if (Exit.isSuccess(resourceList)) return resourceList.value
-      return throwResourceListError(resourceList.cause)
-    } finally {
-      inflight?.leave()
-    }
-  })
-  server.setRequestHandler(ListResourceTemplatesRequestSchema, listResourceTemplates)
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-    inflight?.enter()
-    try {
-      const { uri } = request.params
-      const clients = await resolveResourceClientsOrThrow(
-        resolveClients,
-        error => createResourceClientResolutionError(uri, error)
-      )
-      const resourceRead = await Effect.runPromiseExit(
-        readHulyResource(uri).pipe(
-          Effect.provideService(HulyClient, clients.hulyClient)
-        )
-      )
-      if (Exit.isSuccess(resourceRead)) return resourceRead.value
-      return throwResourceReadError(uri, resourceRead.cause)
-    } finally {
-      inflight?.leave()
-    }
-  })
-}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -12,6 +12,7 @@ import { type ClientBundle, createMcpServer } from "./create-mcp-server.js"
 import type { HttpServerFactoryService, HttpTransportDependencies, HttpTransportError } from "./http-transport.js"
 import { DEFAULT_HTTP_PORT, startHttpTransport } from "./http-transport.js"
 import { buildHulyContext, parseToolsets } from "./huly-context-tool.js"
+import { createMcpProtocolHandlers } from "./protocol-handlers.js"
 
 import { type SanitizedHulyRuntimeConfigContext, sanitizeHulyRuntimeConfigFromEnv } from "../config/config.js"
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
@@ -171,18 +172,21 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
               } else {
                 const port = config.httpPort ?? DEFAULT_HTTP_PORT
                 const host = config.httpHost ?? "127.0.0.1"
+                const createHttpRequestContext = (req: Request) => {
+                  const resolveClientsForRequest = config.resolveClientsForHttpRequest
+                  const requestResolveClients = resolveClientsForRequest === undefined
+                    ? config.resolveClients
+                    : () => resolveClientsForRequest(req)
+                  const requestRuntimeConfig = config.getRuntimeConfigContextForHttpRequest === undefined
+                    ? getRuntimeConfigContext()
+                    : config.getRuntimeConfigContextForHttpRequest(req)
+                  return { requestResolveClients, requestRuntimeConfig }
+                }
 
                 yield* startHttpTransport(
                   { port, host, authToken: config.mcpAuthToken },
                   (req) => {
-                    const resolveClientsForRequest = config.resolveClientsForHttpRequest
-                    const requestResolveClients = resolveClientsForRequest === undefined
-                      ? config.resolveClients
-                      : () => resolveClientsForRequest(req)
-                    const getRuntimeConfigContextForRequest = config.getRuntimeConfigContextForHttpRequest
-                    const requestRuntimeConfig = getRuntimeConfigContextForRequest === undefined
-                      ? getRuntimeConfigContext()
-                      : getRuntimeConfigContextForRequest(req)
+                    const { requestResolveClients, requestRuntimeConfig } = createHttpRequestContext(req)
                     return createMcpServer(
                       requestResolveClients,
                       telemetry,
@@ -191,7 +195,16 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
                       config.createServer
                     )[0]
                   },
-                  config.httpTransportDependencies
+                  config.httpTransportDependencies,
+                  (req) => {
+                    const { requestResolveClients, requestRuntimeConfig } = createHttpRequestContext(req)
+                    return createMcpProtocolHandlers(
+                      requestResolveClients,
+                      telemetry,
+                      registry,
+                      () => getHulyContext(requestRuntimeConfig)
+                    )
+                  }
                 ).pipe(
                   Effect.scoped,
                   Effect.mapError(

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -9,6 +9,7 @@
 import type http from "node:http"
 
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { McpError } from "@modelcontextprotocol/sdk/types.js"
 import { Effect, Exit, Layer } from "effect"
 import type { Express, Request, Response } from "express"
 import { describe, expect, it } from "vitest"
@@ -21,6 +22,7 @@ import {
   HttpTransportError,
   startHttpTransport
 } from "../../src/mcp/http-transport.js"
+import type { McpProtocolHandlers } from "../../src/mcp/protocol-handlers.js"
 
 // Test mock factory: accepts any object, returns it typed as T.
 // Single cast from Record<string,unknown> to T (valid for test mocks of large interfaces).
@@ -174,6 +176,46 @@ const createMockRequest = (
   })
 }
 
+const modernMeta = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientInfo": { name: "test", version: "1.0.0" },
+  "io.modelcontextprotocol/clientCapabilities": {}
+}
+
+const modernHeaders = (method: string, name?: string): Request["headers"] => ({
+  accept: "application/json, text/event-stream",
+  "mcp-protocol-version": "2026-07-28",
+  "mcp-method": method,
+  ...(name === undefined ? {} : { "mcp-name": name })
+})
+
+const createMockProtocolHandlers = (): McpProtocolHandlers => ({
+  listTools: () => Promise.resolve({ tools: [] }),
+  callTool: () =>
+    Promise.resolve({
+      content: [{ type: "text", text: "ok" }]
+    }),
+  listResources: () => Promise.resolve({ resources: [] }),
+  listResourceTemplates: () => ({ resourceTemplates: [] }),
+  readResource: (request) =>
+    Promise.resolve({
+      contents: [{
+        uri: request.params.uri,
+        mimeType: "application/json",
+        text: "{}"
+      }]
+    }),
+  serverDiscover: () => ({
+    resultType: "complete",
+    supportedVersions: ["2026-07-28"],
+    capabilities: { tools: {}, resources: {} },
+    serverInfo: { name: "huly-mcp", version: "0.0.0-test" }
+  }),
+  drainInflight: () => Promise.resolve()
+})
+
+const modernHandlerFactory = createMockProtocolHandlers
+
 const expectUnauthorizedResponse = (response: Response): void => {
   const calls = getResponseCalls(response)
   expect(calls.status).toEqual([[401]])
@@ -224,6 +266,311 @@ describe("HTTP Transport", () => {
 
       await handlers.post(req, res)
 
+      expect(getServerCalls(mockServer).connect).toHaveLength(1)
+      expect(transport.calls.handleRequest).toEqual([[req, res, req.body]])
+    })
+
+    it("dispatches server/discover on the 2026 path without initialize", async () => {
+      const transport = createMockTransportDependencies()
+      const handlers = createMcpHandlers(createMockMcpServer, transport.dependencies, undefined, modernHandlerFactory)
+      const req = createMockRequest(
+        { jsonrpc: "2.0", method: "server/discover", id: "discover", params: { _meta: modernMeta } },
+        modernHeaders("server/discover")
+      )
+      const res = createMockResponse()
+
+      await handlers.post(req, res)
+
+      const calls = getResponseCalls(res)
+      expect(transport.calls.handleRequest).toHaveLength(0)
+      expect(calls.status).toEqual([[200]])
+      expect(calls.json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: "discover",
+          result: {
+            resultType: "complete",
+            supportedVersions: ["2026-07-28"],
+            capabilities: { tools: {}, resources: {} },
+            serverInfo: { name: "huly-mcp", version: "0.0.0-test" }
+          }
+        }
+      ]])
+    })
+
+    it("adds resultType and public cache hints to 2026 tools/list", async () => {
+      const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
+      const res = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "tools/list", id: 1, params: { _meta: modernMeta } },
+          modernHeaders("tools/list")
+        ),
+        res
+      )
+
+      expect(getResponseCalls(res).json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          result: { tools: [], resultType: "complete", ttlMs: 300000, cacheScope: "public" }
+        }
+      ]])
+    })
+
+    it("adds resultType to 2026 tools/call", async () => {
+      const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
+      const res = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "tools/call",
+            id: 2,
+            params: { name: "get_huly_context", arguments: {}, _meta: modernMeta }
+          },
+          modernHeaders("tools/call", "get_huly_context")
+        ),
+        res
+      )
+
+      expect(getResponseCalls(res).json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          result: { content: [{ type: "text", text: "ok" }], resultType: "complete" }
+        }
+      ]])
+    })
+
+    it("adds resultType and cache hints to 2026 resource list, template list, and read results", async () => {
+      const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
+      const listRes = createMockResponse()
+      const templatesRes = createMockResponse()
+      const readRes = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "resources/list", id: 3, params: { _meta: modernMeta } },
+          modernHeaders("resources/list")
+        ),
+        listRes
+      )
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "resources/templates/list", id: 4, params: { _meta: modernMeta } },
+          modernHeaders("resources/templates/list")
+        ),
+        templatesRes
+      )
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "resources/read",
+            id: 5,
+            params: { uri: "huly://projects/HULY", _meta: modernMeta }
+          },
+          modernHeaders("resources/read", "huly://projects/HULY")
+        ),
+        readRes
+      )
+
+      expect(getResponseCalls(listRes).json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          result: { resources: [], resultType: "complete", ttlMs: 60000, cacheScope: "private" }
+        }
+      ]])
+      expect(getResponseCalls(templatesRes).json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: 4,
+          result: { resourceTemplates: [], resultType: "complete", ttlMs: 300000, cacheScope: "public" }
+        }
+      ]])
+      expect(getResponseCalls(readRes).json).toEqual([[
+        {
+          jsonrpc: "2.0",
+          id: 5,
+          result: {
+            contents: [{ uri: "huly://projects/HULY", mimeType: "application/json", text: "{}" }],
+            resultType: "complete",
+            ttlMs: 60000,
+            cacheScope: "private"
+          }
+        }
+      ]])
+    })
+
+    it("returns modern header validation errors for missing and mismatched 2026 headers", async () => {
+      const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
+      const missingMethod = createMockResponse()
+      const missingName = createMockResponse()
+      const mismatchedName = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "tools/list", id: 6, params: { _meta: modernMeta } },
+          {
+            accept: "application/json, text/event-stream",
+            "mcp-protocol-version": "2026-07-28"
+          }
+        ),
+        missingMethod
+      )
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "tools/call",
+            id: 7,
+            params: { name: "get_huly_context", arguments: {}, _meta: modernMeta }
+          },
+          {
+            accept: "application/json, text/event-stream",
+            "mcp-protocol-version": "2026-07-28",
+            "mcp-method": "tools/call"
+          }
+        ),
+        missingName
+      )
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "resources/read",
+            id: 8,
+            params: { uri: "huly://projects/HULY", _meta: modernMeta }
+          },
+          modernHeaders("resources/read", "huly://projects/OTHER")
+        ),
+        mismatchedName
+      )
+
+      expect(getResponseCalls(missingMethod).status).toEqual([[400]])
+      expect(getResponseCalls(missingMethod).json[0]?.[0]).toMatchObject({
+        error: { code: -32001, message: expect.stringContaining("Mcp-Method") }
+      })
+      expect(getResponseCalls(missingName).status).toEqual([[400]])
+      expect(getResponseCalls(missingName).json[0]?.[0]).toMatchObject({
+        error: { code: -32001, message: expect.stringContaining("Mcp-Name") }
+      })
+      expect(getResponseCalls(mismatchedName).status).toEqual([[400]])
+      expect(getResponseCalls(mismatchedName).json[0]?.[0]).toMatchObject({
+        error: { code: -32001, message: expect.stringContaining("does not match") }
+      })
+    })
+
+    it("returns modern errors for missing _meta, unsupported protocol, invalid body, and unknown methods", async () => {
+      const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
+      const missingMeta = createMockResponse()
+      const unsupported = createMockResponse()
+      const invalidBody = createMockResponse()
+      const unknownMethod = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "tools/list", id: 9, params: {} },
+          modernHeaders("tools/list")
+        ),
+        missingMeta
+      )
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "server/discover",
+            id: 10,
+            params: {
+              _meta: {
+                ...modernMeta,
+                "io.modelcontextprotocol/protocolVersion": "1900-01-01"
+              }
+            }
+          },
+          {
+            ...modernHeaders("server/discover"),
+            "mcp-protocol-version": "1900-01-01"
+          }
+        ),
+        unsupported
+      )
+      await handlers.post(
+        createMockRequest(
+          [{ jsonrpc: "2.0", method: "tools/list", id: 11 }],
+          modernHeaders("tools/list")
+        ),
+        invalidBody
+      )
+      await handlers.post(
+        createMockRequest(
+          { jsonrpc: "2.0", method: "unknown/method", id: 12, params: { _meta: modernMeta } },
+          modernHeaders("unknown/method")
+        ),
+        unknownMethod
+      )
+
+      expect(getResponseCalls(missingMeta).json[0]?.[0]).toMatchObject({ error: { code: -32001 } })
+      expect(getResponseCalls(unsupported).json[0]?.[0]).toMatchObject({
+        error: { code: -32004, data: { supported: ["2026-07-28"], requested: "1900-01-01" } }
+      })
+      expect(getResponseCalls(invalidBody).json[0]?.[0]).toMatchObject({ error: { code: -32600 } })
+      expect(getResponseCalls(unknownMethod).status).toEqual([[404]])
+      expect(getResponseCalls(unknownMethod).json[0]?.[0]).toMatchObject({ error: { code: -32601 } })
+    })
+
+    it("maps 2026 resource-not-found failures to invalid params", async () => {
+      const handlers = createMcpHandlers(
+        createMockMcpServer,
+        undefined,
+        undefined,
+        () => ({
+          ...createMockProtocolHandlers(),
+          readResource: () =>
+            Promise.reject(new McpError(-32002, "Resource not found", { uri: "huly://projects/NOPE" }))
+        })
+      )
+      const res = createMockResponse()
+
+      await handlers.post(
+        createMockRequest(
+          {
+            jsonrpc: "2.0",
+            method: "resources/read",
+            id: 14,
+            params: { uri: "huly://projects/NOPE", _meta: modernMeta }
+          },
+          modernHeaders("resources/read", "huly://projects/NOPE")
+        ),
+        res
+      )
+
+      expect(getResponseCalls(res).status).toEqual([[400]])
+      expect(getResponseCalls(res).json[0]?.[0]).toMatchObject({
+        error: { code: -32602, message: "Resource not found", data: { uri: "huly://projects/NOPE" } }
+      })
+    })
+
+    it("delegates legacy HTTP requests to the SDK transport even when a 2026 handler factory exists", async () => {
+      const mockServer = createMockMcpServer()
+      const transport = createMockTransportDependencies()
+      const createProtocolHandlers = createProbe<[Request], McpProtocolHandlers>(modernHandlerFactory)
+      const handlers = createMcpHandlers(
+        () => mockServer,
+        transport.dependencies,
+        undefined,
+        createProtocolHandlers.fn
+      )
+      const req = createMockRequest({ jsonrpc: "2.0", method: "tools/list", id: 13 })
+      const res = createMockResponse()
+
+      await handlers.post(req, res)
+
+      expect(createProtocolHandlers.calls).toHaveLength(0)
       expect(getServerCalls(mockServer).connect).toHaveLength(1)
       expect(transport.calls.handleRequest).toEqual([[req, res, req.body]])
     })


### PR DESCRIPTION
codex/5.5

## Summary
- Add a custom HTTP-only dispatcher for MCP 2026-07-28 stateless requests while preserving the existing SDK transport path.
- Extract shared MCP protocol handlers so SDK registration and the 2026 dispatcher use the same tool/resource behavior.
- Add server/discover, modern header/meta validation, resultType envelopes, cache hints, and 2026 error mapping.
- Extend the integration harness with INTEGRATION_MCP_PROTOCOL=legacy|2026 and document that it is a harness-only request-mode switch.

## Validation
- pnpm check-all
- stdio legacy integration: 222 passed, 0 failed, 38 skipped
- HTTP legacy integration: 222 passed, 0 failed, 38 skipped
- HTTP 2026 integration: 222 passed, 0 failed, 38 skipped
