### PR TITLE
Fix corrupted document content read errors

### DIFF
--- a/scripts/corrupt-document-content.ts
+++ b/scripts/corrupt-document-content.ts
@@ -1,0 +1,113 @@
+import type { TxOperations } from "@hcengineering/core"
+import type { Document as HulyDocument } from "@hcengineering/document"
+import { createRequire } from "node:module"
+
+const require = createRequire(import.meta.url)
+// CJS interop boundary: createRequire returns unknown, while this package exposes the same runtime API as its TS import type.
+const apiClient = require("@hcengineering/api-client") as typeof import("@hcengineering/api-client")
+// CJS interop boundary: createRequire returns unknown, while the document plugin is a CommonJS default export.
+const documentPlugin = require("@hcengineering/document").default as typeof import("@hcengineering/document").default
+
+interface Args {
+  readonly content: string
+  readonly documentId: string
+}
+
+const usage = `Usage:
+  pnpm exec tsx scripts/corrupt-document-content.ts --document <document-id> --content <raw-markdown>
+
+This integration-test helper deliberately writes raw markdown into Document.content.
+Do not use it outside disposable test documents.
+`
+
+const readValue = (args: ReadonlyArray<string>, index: number, flag: string): string => {
+  const value = args[index + 1]
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.\n${usage}`)
+  }
+  return value
+}
+
+const parseArgs = (argv: ReadonlyArray<string>): Args => {
+  let content = ""
+  let documentId = ""
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    switch (arg) {
+      case "--content":
+        content = readValue(argv, index, arg)
+        index++
+        break
+      case "--document":
+        documentId = readValue(argv, index, arg)
+        index++
+        break
+      case "--help":
+        console.log(usage)
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}\n${usage}`)
+    }
+  }
+
+  if (documentId.trim() === "" || content.trim() === "") {
+    throw new Error(`--document and --content are required.\n${usage}`)
+  }
+
+  return { content, documentId }
+}
+
+const requiredEnv = (name: string): string => {
+  const value = process.env[name]
+  if (value === undefined || value.trim() === "") throw new Error(`${name} is required.`)
+  return value
+}
+
+const connect = async (): Promise<TxOperations> => {
+  const url = requiredEnv("HULY_URL")
+  const workspace = requiredEnv("HULY_WORKSPACE")
+  const serverConfig = await apiClient.loadServerConfig(url)
+  const token = process.env["HULY_TOKEN"]
+  const auth = token !== undefined && token.trim() !== ""
+    ? { token, workspace }
+    : {
+      email: requiredEnv("HULY_EMAIL"),
+      password: requiredEnv("HULY_PASSWORD"),
+      workspace
+    }
+  const { endpoint, token: workspaceToken, workspaceId } = await apiClient.getWorkspaceToken(url, auth, serverConfig)
+  return await apiClient.createRestTxOperations(endpoint, workspaceId, workspaceToken)
+}
+
+const corruptDocumentContent = async (client: TxOperations, args: Args): Promise<void> => {
+  const docs = await client.findAll<HulyDocument>(
+    documentPlugin.class.Document,
+    { _id: args.documentId },
+    { limit: 1 }
+  )
+  const doc = docs[0]
+  if (doc === undefined) {
+    throw new Error(`Document '${args.documentId}' not found.`)
+  }
+
+  await client.updateDoc(
+    documentPlugin.class.Document,
+    doc.space,
+    doc._id,
+    { content: args.content }
+  )
+}
+
+const main = async (): Promise<void> => {
+  const args = parseArgs(process.argv.slice(2))
+  const client = await connect()
+  await corruptDocumentContent(client, args)
+  console.log(`Corrupted Document.content for ${args.documentId}`)
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -441,6 +441,21 @@ assert_json_field_equals() {
   return 1
 }
 
+assert_json_field_contains() {
+  local name="$1" json="$2" jq_expr="$3" expected="$4"
+  local value
+  value=$(printf '%s\n' "$json" | jq -r "$jq_expr // empty" 2>/dev/null)
+  if printf '%s\n' "$value" | grep -qF -- "$expected"; then
+    echo "PASS: $name"
+    PASSED=$((PASSED + 1))
+    return 0
+  fi
+  echo "FAIL: $name (field $jq_expr missing substring: $expected)"
+  FAILED=$((FAILED + 1))
+  ERRORS="${ERRORS}\n  - ${name}: field ${jq_expr} missing substring"
+  return 1
+}
+
 assert_json_issue_summary_contains_issue_id() {
   local name="$1" json="$2" identifier="$3" issue_id="$4"
   if printf '%s\n' "$json" | jq -e --arg identifier "$identifier" --arg issue_id "$issue_id" \
@@ -524,6 +539,33 @@ run_expect_error() {
   return 1
 }
 
+run_expect_error_contains() {
+  local name="$1"
+  local payload="$2"
+  local expected="$3"
+  local result
+  result=$(call_tool "$payload")
+  if [ -z "$result" ]; then
+    echo "FAIL: $name (no response, expected error)"
+    FAILED=$((FAILED + 1))
+    ERRORS="${ERRORS}\n  - ${name}: no response (expected error)"
+    return 1
+  fi
+  local is_error
+  is_error=$(echo "$result" | jq -r '.result.isError // false' 2>/dev/null)
+  local err_text
+  err_text=$(echo "$result" | jq -r '.result.content[0].text // empty' 2>/dev/null)
+  if [ "$is_error" = "true" ] && printf '%s\n' "$err_text" | grep -qF -- "$expected"; then
+    echo "PASS: $name (got expected error)"
+    PASSED=$((PASSED + 1))
+    return 0
+  fi
+  echo "FAIL: $name (expected error containing: $expected)"
+  FAILED=$((FAILED + 1))
+  ERRORS="${ERRORS}\n  - ${name}: expected error containing ${expected}"
+  return 1
+}
+
 # Fetch doc content, assert substring present. Args: test_name teamspace doc_id substring
 assert_contains() {
   local name="$1" ts="$2" doc="$3" substr="$4"
@@ -536,7 +578,7 @@ assert_contains() {
     ERRORS="${ERRORS}\n  - ${name}: could not fetch doc"
     return 1
   fi
-  if printf '%s\n' "$text" | grep -qF "$substr"; then
+  if printf '%s\n' "$text" | grep -qF -- "$substr"; then
     echo "PASS: $name"
     PASSED=$((PASSED + 1))
     return 0
@@ -559,7 +601,7 @@ assert_not_contains() {
     ERRORS="${ERRORS}\n  - ${name}: could not fetch doc"
     return 1
   fi
-  if printf '%s\n' "$text" | grep -qF "$substr"; then
+  if printf '%s\n' "$text" | grep -qF -- "$substr"; then
     echo "FAIL: $name (substring should be absent: $substr)"
     FAILED=$((FAILED + 1))
     ERRORS="${ERRORS}\n  - ${name}: substring should be absent"
@@ -1061,8 +1103,16 @@ if [ -n "$TS_NAME" ]; then
   run_test "list_documents($TS_NAME)" \
     "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_documents\",\"arguments\":{\"teamspace\":\"$TS_NAME\"}},\"id\":2}"
 
+  DOC_CONTENT=$'# Integration Markdown\n\nThis has **bold**, *italic*, and [Huly](https://huly.io).\n\n- First item\n- Second item'
+  DOC_CONTENT_JSON=$(json_string "$DOC_CONTENT")
+  DOC_EDITED_CONTENT=$'# Edited Integration Markdown\n\nThe full replacement path repaired this document.\n\n- Repaired item'
+  DOC_EDITED_CONTENT_JSON=$(json_string "$DOC_EDITED_CONTENT")
+  DOC_REPAIR_CONTENT=$'# Repaired After Corruption\n\nFull replacement restored readable content.'
+  DOC_REPAIR_CONTENT_JSON=$(json_string "$DOC_REPAIR_CONTENT")
+  DOC_CORRUPT_CONTENT='raw-markdown-that-is-not-a-blob-ref'
+
   DOC_TEXT=$(run_capture "create_document" \
-    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"title\":\"IntTest Doc\",\"content\":\"# Test\"}},\"id\":2}")
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"title\":\"IntTest Doc\",\"content\":$DOC_CONTENT_JSON}},\"id\":2}")
   if [ $? -eq 0 ]; then
     DOC_ID=$(echo "$DOC_TEXT" | jq -r '.id' 2>/dev/null)
     echo "  => doc: $DOC_ID"
@@ -1072,12 +1122,56 @@ if [ -n "$TS_NAME" ]; then
       "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$DOC_ID\"}},\"id\":2}")
     if [ $? -eq 0 ]; then
       assert_json_field_nonempty "get_document($DOC_ID) returns url" "$GET_DOC_TEXT" '.url'
+      assert_json_field_contains "get_document($DOC_ID) round-trips heading" "$GET_DOC_TEXT" '.content' "# Integration Markdown"
+      assert_json_field_contains "get_document($DOC_ID) round-trips bold" "$GET_DOC_TEXT" '.content' "**bold**"
+      assert_json_field_contains "get_document($DOC_ID) round-trips italic" "$GET_DOC_TEXT" '.content' "*italic*"
+      assert_json_field_contains "get_document($DOC_ID) round-trips link" "$GET_DOC_TEXT" '.content' "[Huly](https://huly.io)"
+      assert_json_field_contains "get_document($DOC_ID) round-trips list" "$GET_DOC_TEXT" '.content' "- First item"
     fi
 
     EDIT_DOC_TEXT=$(run_capture "edit_document($DOC_ID) title rename" \
       "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"edit_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$DOC_ID\",\"title\":\"Updated Doc\"}},\"id\":2}")
     if [ $? -eq 0 ]; then
       assert_json_field_nonempty "edit_document($DOC_ID) returns url" "$EDIT_DOC_TEXT" '.url'
+    fi
+
+    run_test "edit_document($DOC_ID) full replace" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"edit_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$DOC_ID\",\"content\":$DOC_EDITED_CONTENT_JSON}},\"id\":2}"
+    GET_EDITED_DOC_TEXT=$(run_capture "get_document($DOC_ID) after full replace" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$DOC_ID\"}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_contains "get_document($DOC_ID) returns full replacement" "$GET_EDITED_DOC_TEXT" '.content' "# Edited Integration Markdown"
+      assert_json_field_contains "get_document($DOC_ID) replacement list" "$GET_EDITED_DOC_TEXT" '.content' "- Repaired item"
+    fi
+
+    CORRUPT_DOC_ID=""
+    CORRUPT_DOC_TEXT=$(run_capture "create_document(raw corruption fixture)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"title\":\"IntTest Raw Corruption Fixture\"}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      CORRUPT_DOC_ID=$(echo "$CORRUPT_DOC_TEXT" | jq -r '.id' 2>/dev/null)
+      echo "  => corrupt_doc: $CORRUPT_DOC_ID"
+    fi
+
+    if [ -n "${CORRUPT_DOC_ID:-}" ] && pnpm exec tsx scripts/corrupt-document-content.ts --document "$CORRUPT_DOC_ID" --content "$DOC_CORRUPT_CONTENT" >/dev/null; then
+      sleep 2
+      run_expect_error_contains "get_document($CORRUPT_DOC_ID) corrupted content error" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$CORRUPT_DOC_ID\"}},\"id\":2}" \
+        "Document content is unreadable or corrupted. Use edit_document with the full content field to replace and repair it."
+      run_test "edit_document($CORRUPT_DOC_ID) repairs corrupted content" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"edit_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$CORRUPT_DOC_ID\",\"content\":$DOC_REPAIR_CONTENT_JSON}},\"id\":2}"
+      GET_REPAIRED_DOC_TEXT=$(run_capture "get_document($CORRUPT_DOC_ID) after repair" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$CORRUPT_DOC_ID\"}},\"id\":2}")
+      if [ $? -eq 0 ]; then
+        assert_json_field_contains "get_document($CORRUPT_DOC_ID) repaired content" "$GET_REPAIRED_DOC_TEXT" '.content' "# Repaired After Corruption"
+      fi
+      run_test "delete_document($CORRUPT_DOC_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$CORRUPT_DOC_ID\"}},\"id\":2}"
+    else
+      fail_test "corrupt_document_content(${CORRUPT_DOC_ID:-missing})" "SDK helper failed"
+      if [ -n "${CORRUPT_DOC_ID:-}" ]; then
+        run_test "delete_document($CORRUPT_DOC_ID)" \
+          "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_document\",\"arguments\":{\"teamspace\":\"$TS_NAME\",\"document\":\"$CORRUPT_DOC_ID\"}},\"id\":2}"
+      fi
     fi
 
     LIST_DOCS_TEXT=$(run_capture_only \

--- a/src/huly/errors-documents.ts
+++ b/src/huly/errors-documents.ts
@@ -81,6 +81,21 @@ export class DocumentEmptyContentError extends Schema.TaggedError<DocumentEmptyC
 }
 
 /**
+ * Document.content points at a missing or invalid markup blob.
+ */
+export class DocumentContentCorruptedError extends Schema.TaggedError<DocumentContentCorruptedError>()(
+  "DocumentContentCorruptedError",
+  {
+    identifier: Schema.String,
+    causeMessage: Schema.optional(Schema.String)
+  }
+) {
+  override get message(): string {
+    return "Document content is unreadable or corrupted. Use edit_document with the full content field to replace and repair it."
+  }
+}
+
+/**
  * edit_document parameters mix mutually exclusive edit modes.
  */
 export class DocumentEditModeError extends Schema.TaggedError<DocumentEditModeError>()(

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -31,6 +31,7 @@ import {
 } from "./errors-contacts.js"
 import { CustomFieldNotFoundError, CustomFieldObjectNotFoundError } from "./errors-custom-fields.js"
 import {
+  DocumentContentCorruptedError,
   DocumentEditModeError,
   DocumentEmptyContentError,
   DocumentNotFoundError,
@@ -134,6 +135,7 @@ export {
   CustomFieldObjectNotFoundError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
+  DocumentContentCorruptedError,
   DocumentEditModeError,
   DocumentEmptyContentError,
   DocumentNotFoundError,
@@ -233,6 +235,7 @@ export const HulyDomainError: Schema.Union<
     typeof DocumentTextNotFoundError,
     typeof DocumentTextMultipleMatchesError,
     typeof DocumentEmptyContentError,
+    typeof DocumentContentCorruptedError,
     typeof DocumentEditModeError,
     typeof CommentNotFoundError,
     typeof MilestoneNotFoundError,
@@ -322,6 +325,7 @@ export const HulyDomainError: Schema.Union<
   DocumentTextNotFoundError,
   DocumentTextMultipleMatchesError,
   DocumentEmptyContentError,
+  DocumentContentCorruptedError,
   DocumentEditModeError,
   CommentNotFoundError,
   MilestoneNotFoundError,

--- a/src/huly/operations/documents-inline-comments.ts
+++ b/src/huly/operations/documents-inline-comments.ts
@@ -22,10 +22,10 @@ import type {
 } from "../../domain/schemas/documents.js"
 import type { PersonName } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
-import type { DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
+import type { DocumentContentCorruptedError, DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
 import { chunter } from "../huly-plugins.js"
 import { buildSocialIdToPersonNameMap } from "./channels.js"
-import { findTeamspaceAndDocument } from "./documents-shared.js"
+import { fetchReadableDocumentContent, findTeamspaceAndDocument } from "./documents-shared.js"
 import { isInlineCommentMark } from "./inline-comment-mark.js"
 import { traverseAllMarks } from "./markup-traversal.js"
 import { optionalMarkupToMarkdown } from "./markup.js"
@@ -65,6 +65,7 @@ type ListInlineCommentsError =
   | HulyClientError
   | TeamspaceNotFoundError
   | DocumentNotFoundError
+  | DocumentContentCorruptedError
 
 export const listInlineComments = (
   params: ListInlineCommentsParams
@@ -76,17 +77,16 @@ export const listInlineComments = (
     })
     const markupUrlConfig = client.markupUrlConfig
 
-    if (!doc.content) {
+    const rawMarkup = yield* fetchReadableDocumentContent({
+      client,
+      doc,
+      format: "markup",
+      identifier: params.document
+    })
+
+    if (rawMarkup === undefined) {
       return { comments: [], total: 0 }
     }
-
-    const rawMarkup: string = yield* client.fetchMarkup(
-      doc._class,
-      doc._id,
-      "content",
-      doc.content,
-      "markup"
-    )
 
     const root = markupToJSON(rawMarkup)
     const extracted = extractInlineComments(root)

--- a/src/huly/operations/documents-shared.ts
+++ b/src/huly/operations/documents-shared.ts
@@ -7,16 +7,18 @@
  *
  * @module
  */
+import type { MarkupFormat } from "@hcengineering/api-client"
+import type { Blob } from "@hcengineering/core"
 import type { Document as HulyDocument, Teamspace as HulyTeamspace } from "@hcengineering/document"
 import { Effect } from "effect"
 
 import type { DocumentIdentifier, TeamspaceIdentifier } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
-import { DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
-import { findByNameOrId, type StrictDocumentQuery } from "./query-helpers.js"
+import { DocumentContentCorruptedError, DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
+import { findByNameOrId, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
-import { documentPlugin } from "../huly-plugins.js"
+import { core, documentPlugin } from "../huly-plugins.js"
 
 export const findTeamspace = (
   identifier: TeamspaceIdentifier,
@@ -79,3 +81,54 @@ export const findTeamspaceAndDocument = (
 
     return { client, teamspace, doc }
   })
+
+const documentContentAttr = "content"
+const documentContentCorrupted = (
+  identifier: DocumentIdentifier,
+  causeMessage: string
+): DocumentContentCorruptedError => new DocumentContentCorruptedError({ identifier, causeMessage })
+
+const documentContentBlobExists = (
+  client: HulyClient["Type"],
+  contentRef: NonNullable<HulyDocument["content"]>
+): Effect.Effect<boolean, HulyClientError> =>
+  client.findOne<Blob>(
+    core.class.Blob,
+    hulyQuery<Blob>({ _id: toRef<Blob>(contentRef) })
+  ).pipe(Effect.map((blob) => blob !== undefined))
+
+export const fetchReadableDocumentContent = (
+  params: {
+    readonly client: HulyClient["Type"]
+    readonly doc: HulyDocument
+    readonly identifier: DocumentIdentifier
+    readonly format: MarkupFormat
+  }
+): Effect.Effect<string | undefined, HulyClientError | DocumentContentCorruptedError> => {
+  if (!params.doc.content) {
+    return Effect.succeed(undefined)
+  }
+  const contentRef = params.doc.content
+
+  return params.client.fetchMarkup(
+    params.doc._class,
+    params.doc._id,
+    documentContentAttr,
+    contentRef,
+    params.format
+  ).pipe(
+    Effect.flatMap((content) =>
+      content === ""
+        ? documentContentBlobExists(params.client, contentRef).pipe(
+          Effect.flatMap((exists) =>
+            exists
+              ? Effect.succeed(content)
+              : Effect.fail(
+                documentContentCorrupted(params.identifier, "Document.content references a missing markup blob.")
+              )
+          )
+        )
+        : Effect.succeed(content)
+    )
+  )
+}

--- a/src/huly/operations/documents.ts
+++ b/src/huly/operations/documents.ts
@@ -42,9 +42,14 @@ import type {
 import { UPDATE_TEAMSPACE_FIELDS } from "../../domain/schemas/documents.js"
 import { DocumentId, TeamspaceId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
-import { DocumentNotFoundError, type NoUpdateFieldsError, type TeamspaceNotFoundError } from "../errors.js"
+import {
+  type DocumentContentCorruptedError,
+  DocumentNotFoundError,
+  type NoUpdateFieldsError,
+  type TeamspaceNotFoundError
+} from "../errors.js"
 import { buildDocumentUrlFromConfig } from "../url-builders.js"
-import { findTeamspace, findTeamspaceAndDocument } from "./documents-shared.js"
+import { fetchReadableDocumentContent, findTeamspace, findTeamspaceAndDocument } from "./documents-shared.js"
 import {
   clampLimit,
   escapeLikeWildcards,
@@ -85,6 +90,7 @@ type GetDocumentError =
   | HulyClientError
   | TeamspaceNotFoundError
   | DocumentNotFoundError
+  | DocumentContentCorruptedError
 
 type CreateDocumentError =
   | HulyClientError
@@ -338,15 +344,12 @@ export const getDocument = (
       document: params.document
     })
 
-    const content: string | undefined = doc.content
-      ? yield* client.fetchMarkup(
-        doc._class,
-        doc._id,
-        "content",
-        doc.content,
-        "markdown"
-      )
-      : undefined
+    const content: string | undefined = yield* fetchReadableDocumentContent({
+      client,
+      doc,
+      format: "markdown",
+      identifier: params.document
+    })
 
     const result: Document = {
       id: DocumentId.make(doc._id),

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -87,6 +87,7 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "DocumentTextNotFoundError",
   "DocumentTextMultipleMatchesError",
   "DocumentEmptyContentError",
+  "DocumentContentCorruptedError",
   "DocumentEditModeError",
   "CommentNotFoundError",
   "MilestoneNotFoundError",

--- a/test/huly/errors-extended.test.ts
+++ b/test/huly/errors-extended.test.ts
@@ -20,6 +20,7 @@ import {
   CardSpaceNotFoundError,
   CustomFieldNotFoundError,
   CustomFieldObjectNotFoundError,
+  DocumentContentCorruptedError,
   DocumentEditModeError,
   DocumentEmptyContentError,
   DocumentTextMultipleMatchesError,
@@ -172,6 +173,12 @@ describe("Extended Huly error message getters", () => {
         error: new DocumentEmptyContentError({ identifier: "doc-1" }),
         tag: "DocumentEmptyContentError",
         message: "Document 'doc-1' has no content. Use 'content' mode or create_document to set initial content."
+      },
+      {
+        error: new DocumentContentCorruptedError({ identifier: "doc-1", causeMessage: "missing markup blob" }),
+        tag: "DocumentContentCorruptedError",
+        message:
+          "Document content is unreadable or corrupted. Use edit_document with the full content field to replace and repair it."
       },
       {
         error: new DocumentEditModeError({ reason: "mixed modes" }),
@@ -349,7 +356,8 @@ describe("Extended Huly error message getters", () => {
           relationCount: 1,
           sampleRelationIds: [RelationId.make("rel-1")]
         }),
-        new ProcessExecutionNotFoundError({ executionId: ProcessExecutionId.make("exec-1") })
+        new ProcessExecutionNotFoundError({ executionId: ProcessExecutionId.make("exec-1") }),
+        new DocumentContentCorruptedError({ identifier: "doc-1" })
       ]
 
       for (const sample of samples) {

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -20,6 +20,7 @@ import {
   ComponentNotFoundError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
+  DocumentContentCorruptedError,
   DocumentEditModeError,
   DocumentNotFoundError,
   EventNotFoundError,
@@ -707,6 +708,8 @@ describe("Huly Errors", () => {
               return `docmulti:${error.matchCount}`
             case "DocumentEmptyContentError":
               return `docempty:${error.identifier}`
+            case "DocumentContentCorruptedError":
+              return `doccorrupt:${error.identifier}:${error.causeMessage ?? ""}`
             case "DocumentEditModeError":
               return `doceditmode:${error.reason}`
             case "CommentNotFoundError":
@@ -871,6 +874,9 @@ describe("Huly Errors", () => {
         expect(matchError(new HulyError({ message: "oops" }))).toBe("generic")
         expect(matchError(new TeamspaceNotFoundError({ identifier: "ts-1" }))).toBe("teamspace:ts-1")
         expect(matchError(new DocumentNotFoundError({ identifier: "doc-1", teamspace: "eng" }))).toBe("document:doc-1")
+        expect(
+          matchError(new DocumentContentCorruptedError({ identifier: "doc-1", causeMessage: "missing markup blob" }))
+        ).toBe("doccorrupt:doc-1:missing markup blob")
         expect(matchError(new DocumentEditModeError({ reason: "bad mode" }))).toBe("doceditmode:bad mode")
         expect(
           matchError(new CommentNotFoundError({ commentId: "c-1", issueIdentifier: "H-1", project: "P" }))

--- a/test/huly/operations/documents-inline-comments.test.ts
+++ b/test/huly/operations/documents-inline-comments.test.ts
@@ -2,13 +2,14 @@
 import { describe, it } from "@effect/vitest"
 import type { ThreadMessage as HulyThreadMessage } from "@hcengineering/chunter"
 import type { Person, SocialIdentity } from "@hcengineering/contact"
-import { type MarkupBlobRef, type PersonId, type Ref, toFindResult } from "@hcengineering/core"
+import { type Blob, type MarkupBlobRef, type PersonId, type Ref, toFindResult } from "@hcengineering/core"
 import type { Document as HulyDocument, Teamspace as HulyTeamspace } from "@hcengineering/document"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
-import { chunter, contact, documentPlugin } from "../../../src/huly/huly-plugins.js"
+import { HulyConnectionError } from "../../../src/huly/errors.js"
+import { chunter, contact, core, documentPlugin } from "../../../src/huly/huly-plugins.js"
 import { listInlineComments } from "../../../src/huly/operations/documents-inline-comments.js"
 import { INLINE_COMMENT_MARK_TYPE } from "../../../src/huly/operations/inline-comment-mark.js"
 import { documentIdentifier, teamspaceIdentifier } from "../../helpers/brands.js"
@@ -31,11 +32,17 @@ const makeDocument = (overrides?: Partial<HulyDocument>): HulyDocument =>
     _class: documentPlugin.class.Document,
     space: TEAMSPACE_ID,
     title: "Spec",
-    content: "content-blob" as MarkupBlobRef,
+    content: "doc-1-content-1700000000000" as MarkupBlobRef,
     modifiedOn: 0,
     createdOn: 0,
     ...overrides
   }) as unknown as HulyDocument
+
+const makeBlob = (id: string): Blob =>
+  ({
+    _id: id as Ref<Blob>,
+    _class: core.class.Blob
+  }) as unknown as Blob
 
 const markupText = (text: string): string =>
   JSON.stringify({ type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] })
@@ -62,7 +69,9 @@ const makeReply = (id: string, thread: string, createdBy: string | undefined, me
 interface InlineMock {
   teamspaces?: ReadonlyArray<HulyTeamspace>
   documents?: ReadonlyArray<HulyDocument>
+  blobs?: ReadonlyArray<Blob>
   markup?: string
+  fetchMarkupError?: HulyConnectionError
   replies?: ReadonlyArray<HulyThreadMessage>
   socialIdentities?: ReadonlyArray<SocialIdentity>
   persons?: ReadonlyArray<Person>
@@ -82,6 +91,9 @@ const buildLayer = (m: InlineMock) => {
         documents.find((d) => (d.space === q.space && d.title === q.title) || (d.space === q.space && d._id === q._id))
       )
     }
+    if (_class === core.class.Blob) {
+      return Effect.succeed((m.blobs ?? []).find((blob) => blob._id === q._id))
+    }
     return Effect.succeed(undefined)
   }) as HulyClientOperations["findOne"]
 
@@ -92,8 +104,10 @@ const buildLayer = (m: InlineMock) => {
     return Effect.succeed(toFindResult([]))
   }) as HulyClientOperations["findAll"]
 
-  const fetchMarkupImpl: HulyClientOperations["fetchMarkup"] =
-    (() => Effect.succeed(m.markup ?? "")) as HulyClientOperations["fetchMarkup"]
+  const fetchMarkupImpl: HulyClientOperations["fetchMarkup"] = (() =>
+    m.fetchMarkupError === undefined
+      ? Effect.succeed(m.markup ?? "")
+      : Effect.fail(m.fetchMarkupError)) as HulyClientOperations["fetchMarkup"]
 
   return HulyClient.testLayer({ findOne: findOneImpl, findAll: findAllImpl, fetchMarkup: fetchMarkupImpl })
 }
@@ -121,6 +135,45 @@ describe("listInlineComments", () => {
     Effect.gen(function*() {
       const result = yield* listInlineComments(PARAMS).pipe(
         Effect.provide(buildLayer({ documents: [makeDocument({ content: null })] }))
+      )
+      expect(result).toEqual({ comments: [], total: 0 })
+    }))
+
+  it.effect("preserves fetchMarkup failures as HulyConnectionError", () =>
+    Effect.gen(function*() {
+      const err = yield* Effect.flip(
+        listInlineComments(PARAMS).pipe(
+          Effect.provide(buildLayer({
+            documents: [makeDocument()],
+            fetchMarkupError: new HulyConnectionError({ message: "fetchMarkup failed: HTTP error 500" })
+          }))
+        )
+      )
+      expect(err).toBeInstanceOf(HulyConnectionError)
+      expect(err.message).toBe("fetchMarkup failed: HTTP error 500")
+    }))
+
+  it.effect("maps empty content from a missing blob to DocumentContentCorruptedError", () =>
+    Effect.gen(function*() {
+      const err = yield* Effect.flip(
+        listInlineComments(PARAMS).pipe(
+          Effect.provide(buildLayer({
+            documents: [makeDocument()],
+            markup: ""
+          }))
+        )
+      )
+      expect(err._tag).toBe("DocumentContentCorruptedError")
+    }))
+
+  it.effect("returns empty when readable stored content is empty", () =>
+    Effect.gen(function*() {
+      const result = yield* listInlineComments(PARAMS).pipe(
+        Effect.provide(buildLayer({
+          documents: [makeDocument()],
+          blobs: [makeBlob("doc-1-content-1700000000000")],
+          markup: ""
+        }))
       )
       expect(result).toEqual({ comments: [], total: 0 })
     }))

--- a/test/huly/operations/documents.test.ts
+++ b/test/huly/operations/documents.test.ts
@@ -1,15 +1,25 @@
 import { describe, it } from "@effect/vitest"
-import { type Doc, type MarkupBlobRef, type PersonId, type Ref, type Space, toFindResult } from "@hcengineering/core"
+import {
+  type Blob,
+  type Doc,
+  type MarkupBlobRef,
+  type PersonId,
+  type Ref,
+  type Space,
+  toFindResult
+} from "@hcengineering/core"
 import type { Document as HulyDocument, Teamspace as HulyTeamspace } from "@hcengineering/document"
 import { Effect } from "effect"
 import { expect } from "vitest"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
-import type {
-  DocumentEmptyContentError,
-  DocumentNotFoundError,
-  DocumentTextMultipleMatchesError,
-  DocumentTextNotFoundError,
-  TeamspaceNotFoundError
+import {
+  type DocumentContentCorruptedError,
+  type DocumentEmptyContentError,
+  type DocumentNotFoundError,
+  type DocumentTextMultipleMatchesError,
+  type DocumentTextNotFoundError,
+  HulyConnectionError,
+  type TeamspaceNotFoundError
 } from "../../../src/huly/errors.js"
 import {
   createDocument,
@@ -25,7 +35,7 @@ import {
 } from "../../../src/huly/operations/documents.js"
 import { documentIdentifier, teamspaceIdentifier } from "../../helpers/brands.js"
 
-import { documentPlugin } from "../../../src/huly/huly-plugins.js"
+import { core, documentPlugin } from "../../../src/huly/huly-plugins.js"
 
 // --- Mock Data Builders ---
 
@@ -63,12 +73,30 @@ const makeDocument = (overrides?: Partial<HulyDocument>): HulyDocument => {
   return result
 }
 
+const makeBlob = (overrides?: Partial<Blob>): Blob => ({
+  _id: "blob-1" as Ref<Blob>,
+  _class: core.class.Blob,
+  space: "space-1" as Ref<Space>,
+  provider: "test",
+  contentType: "application/json",
+  etag: "etag",
+  version: null,
+  size: 0,
+  modifiedBy: "user-1" as PersonId,
+  modifiedOn: 0,
+  createdBy: "user-1" as PersonId,
+  createdOn: 0,
+  ...overrides
+})
+
 // --- Test Helpers ---
 
 interface MockConfig {
   teamspaces?: Array<HulyTeamspace>
   documents?: Array<HulyDocument>
+  blobs?: Array<Blob>
   markupContent?: Record<string, string>
+  fetchMarkupError?: HulyConnectionError
   captureDocumentQuery?: { query?: Record<string, unknown>; options?: Record<string, unknown> }
   captureCreateDoc?: { attributes?: Record<string, unknown>; id?: string }
   captureUpdateDoc?: { operations?: Record<string, unknown> }
@@ -80,6 +108,7 @@ interface MockConfig {
 const createTestLayerWithMocks = (config: MockConfig) => {
   const teamspaces = config.teamspaces ?? []
   const documents = config.documents ?? []
+  const blobs = config.blobs ?? []
 
   const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown, options: unknown) => {
     if (_class === documentPlugin.class.Teamspace) {
@@ -133,12 +162,20 @@ const createTestLayerWithMocks = (config: MockConfig) => {
       )
       return Effect.succeed(found)
     }
+    if (_class === core.class.Blob) {
+      const q = query as Record<string, unknown>
+      const found = blobs.find(blob => blob._id === q._id)
+      return Effect.succeed(found)
+    }
     return Effect.succeed(undefined)
   }) as HulyClientOperations["findOne"]
 
   const markupContent = config.markupContent ?? {}
   const fetchMarkupImpl: HulyClientOperations["fetchMarkup"] = (
     (_objectClass: unknown, _objectId: unknown, _objectAttr: unknown, id: unknown) => {
+      if (config.fetchMarkupError !== undefined) {
+        return Effect.fail(config.fetchMarkupError)
+      }
       const content = markupContent[id as string] ?? ""
       return Effect.succeed(content)
     }
@@ -367,13 +404,13 @@ describe("getDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-123" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-123": "# Hello World" }
+          markupContent: { "doc-1-content-1700000000000": "# Hello World" }
         })
 
         const result = yield* getDocument({
@@ -432,6 +469,140 @@ describe("getDocument", () => {
         )
 
         expect(result.content).toBeUndefined()
+      }))
+
+    it.effect("preserves fetchMarkup failures as HulyConnectionError", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Corrupted Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
+        })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          fetchMarkupError: new HulyConnectionError({ message: "fetchMarkup failed: HTTP error 500" })
+        })
+
+        const error = yield* Effect.flip(
+          getDocument({
+            teamspace: teamspaceIdentifier("My Docs"),
+            document: documentIdentifier("Corrupted Doc")
+          }).pipe(Effect.provide(testLayer))
+        )
+
+        expect(error).toBeInstanceOf(HulyConnectionError)
+        expect(error.message).toBe("fetchMarkup failed: HTTP error 500")
+      }))
+
+    it.effect("maps obvious raw markdown content refs to DocumentContentCorruptedError", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Raw Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "raw-markdown-that-is-not-a-blob-ref" as MarkupBlobRef
+        })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc]
+        })
+
+        const error = yield* Effect.flip(
+          getDocument({
+            teamspace: teamspaceIdentifier("My Docs"),
+            document: documentIdentifier("Raw Doc")
+          }).pipe(Effect.provide(testLayer))
+        )
+
+        expect(error._tag).toBe("DocumentContentCorruptedError")
+        expect((error as DocumentContentCorruptedError).causeMessage).toBe(
+          "Document.content references a missing markup blob."
+        )
+      }))
+
+    it.effect("maps empty content from a missing shaped blob to DocumentContentCorruptedError", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Missing Blob Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
+        })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          markupContent: { "doc-1-content-1700000000000": "" }
+        })
+
+        const error = yield* Effect.flip(
+          getDocument({
+            teamspace: teamspaceIdentifier("My Docs"),
+            document: documentIdentifier("Missing Blob Doc")
+          }).pipe(Effect.provide(testLayer))
+        )
+
+        expect(error._tag).toBe("DocumentContentCorruptedError")
+        expect((error as DocumentContentCorruptedError).causeMessage).toBe(
+          "Document.content references a missing markup blob."
+        )
+      }))
+
+    it.effect("returns content from non-standard refs when Huly can read them", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Legacy Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "legacy-markup-ref" as MarkupBlobRef
+        })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          markupContent: { "legacy-markup-ref": "# Legacy Content" }
+        })
+
+        const result = yield* getDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          document: documentIdentifier("Legacy Doc")
+        }).pipe(Effect.provide(testLayer))
+
+        expect(result.content).toBe("# Legacy Content")
+      }))
+
+    it.effect("returns empty content from non-standard refs when the blob exists", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Empty Legacy Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "legacy-content-ref" as MarkupBlobRef
+        })
+        const blob = makeBlob({ _id: "legacy-content-ref" as Ref<Blob> })
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          blobs: [blob],
+          markupContent: { "legacy-content-ref": "" }
+        })
+
+        const result = yield* getDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          document: documentIdentifier("Empty Legacy Doc")
+        }).pipe(Effect.provide(testLayer))
+
+        expect(result.content).toBe("")
       }))
   })
 
@@ -513,9 +684,8 @@ describe("createDocument", () => {
         expect(result.id).toBeDefined()
         expect(captureUploadMarkup.markup).toBe("# Heading\n\nSome content here.")
         expect(captureCreateDoc.attributes?.title).toBe("Doc with Content")
-        // uploadMarkup was called (markup captured) and its return value flows into createDoc
-        expect(captureCreateDoc.attributes?.content).not.toBeNull()
-        expect(typeof captureCreateDoc.attributes?.content).toBe("string")
+        expect(captureCreateDoc.attributes?.content).toBe("markup-ref-123")
+        expect(captureCreateDoc.attributes?.content).not.toBe("# Heading\n\nSome content here.")
       }))
     it.effect("calculates rank for new document", () =>
       Effect.gen(function*() {
@@ -741,7 +911,7 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-old" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
         const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
 
@@ -758,6 +928,66 @@ describe("editDocument", () => {
         }).pipe(Effect.provide(testLayer))
 
         expect(captureUpdateDoc.operations?.content).toBeNull()
+      }))
+
+    it.effect("updates existing content through updateMarkup without writing raw markdown to updateDoc", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Test Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
+        })
+        const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
+        const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          captureUpdateDoc,
+          captureUpdateMarkup
+        })
+
+        yield* editDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          document: documentIdentifier("Test Doc"),
+          content: "# Updated Content"
+        }).pipe(Effect.provide(testLayer))
+
+        expect(captureUpdateMarkup.markup).toBe("# Updated Content")
+        expect(captureUpdateDoc.operations?.content).toBeUndefined()
+        expect(captureUpdateDoc.operations).toBeUndefined()
+      }))
+
+    it.effect("full replace repairs raw-corrupted document content through updateMarkup", () =>
+      Effect.gen(function*() {
+        const teamspace = makeTeamspace({ _id: "ts-1" as Ref<HulyTeamspace>, name: "My Docs" })
+        const doc = makeDocument({
+          _id: "doc-1" as Ref<HulyDocument>,
+          title: "Corrupted Doc",
+          space: "ts-1" as Ref<HulyTeamspace>,
+          content: "# Raw markdown stored in Document.content" as MarkupBlobRef
+        })
+        const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
+        const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          teamspaces: [teamspace],
+          documents: [doc],
+          captureUpdateDoc,
+          captureUpdateMarkup
+        })
+
+        yield* editDocument({
+          teamspace: teamspaceIdentifier("My Docs"),
+          document: documentIdentifier("Corrupted Doc"),
+          content: "# Repaired"
+        }).pipe(Effect.provide(testLayer))
+
+        expect(captureUpdateMarkup.markup).toBe("# Repaired")
+        expect(captureUpdateDoc.operations?.content).toBeUndefined()
+        expect(captureUpdateDoc.operations).toBeUndefined()
       }))
 
     it.effect("fails when no fields provided", () =>
@@ -819,13 +1049,13 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "old content" }
+          markupContent: { "doc-1-content-1700000000000": "old content" }
         })
 
         const error = yield* Effect.flip(
@@ -880,13 +1110,13 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "content" }
+          markupContent: { "doc-1-content-1700000000000": "content" }
         })
 
         const error = yield* Effect.flip(
@@ -945,14 +1175,14 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
         const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "Hello world, this is a test." },
+          markupContent: { "doc-1-content-1700000000000": "Hello world, this is a test." },
           captureUpdateMarkup
         })
 
@@ -974,14 +1204,14 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
         const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "Remove this section please." },
+          markupContent: { "doc-1-content-1700000000000": "Remove this section please." },
           captureUpdateMarkup
         })
 
@@ -1003,14 +1233,14 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
         const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "foo bar foo baz foo" },
+          markupContent: { "doc-1-content-1700000000000": "foo bar foo baz foo" },
           captureUpdateMarkup
         })
 
@@ -1033,7 +1263,7 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Old Title",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
         const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
         const captureUpdateMarkup: MockConfig["captureUpdateMarkup"] = {}
@@ -1041,7 +1271,7 @@ describe("editDocument", () => {
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "Some content here." },
+          markupContent: { "doc-1-content-1700000000000": "Some content here." },
           captureUpdateDoc,
           captureUpdateMarkup
         })
@@ -1068,13 +1298,13 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "Hello world." }
+          markupContent: { "doc-1-content-1700000000000": "Hello world." }
         })
 
         const error = yield* Effect.flip(
@@ -1097,13 +1327,13 @@ describe("editDocument", () => {
           _id: "doc-1" as Ref<HulyDocument>,
           title: "Test Doc",
           space: "ts-1" as Ref<HulyTeamspace>,
-          content: "markup-id-1" as MarkupBlobRef
+          content: "doc-1-content-1700000000000" as MarkupBlobRef
         })
 
         const testLayer = createTestLayerWithMocks({
           teamspaces: [teamspace],
           documents: [doc],
-          markupContent: { "markup-id-1": "foo bar foo baz foo" }
+          markupContent: { "doc-1-content-1700000000000": "foo bar foo baz foo" }
         })
 
         const error = yield* Effect.flip(

--- a/test/huly/operations/generic-associations.test.ts
+++ b/test/huly/operations/generic-associations.test.ts
@@ -27,6 +27,7 @@ import {
   AssociationConflictError,
   AssociationIdentifierAmbiguousError,
   AssociationInUseError,
+  AssociationNotFoundError,
   AssociationSystemClassUnsupportedError,
   GenericObjectIdentifierAmbiguousError,
   GenericObjectLocatorInvalidError,
@@ -1203,6 +1204,142 @@ describe("association mutations", () => {
       expect(result.deleted).toBe(true)
       expect(result.associationId).toBe("assoc-1")
     }))
+
+  it.effect("createAssociation fails when ifExists is fail and an identical association exists", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        createAssociation({
+          sourceClass: issueClass,
+          targetClass: issueClass,
+          sourceRole: AssociationRoleName.make("relates"),
+          targetRole: AssociationRoleName.make("relates"),
+          cardinality: "many-to-many",
+          ifExists: "fail"
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+      expect(error).toBeInstanceOf(AssociationConflictError)
+      expect((error as AssociationConflictError).reason).toContain("ifExists=fail")
+    }))
+
+  it.effect("createAssociation fails when automationOnly differs from an existing association", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        createAssociation({
+          sourceClass: issueClass,
+          targetClass: issueClass,
+          sourceRole: AssociationRoleName.make("relates"),
+          targetRole: AssociationRoleName.make("relates"),
+          cardinality: "many-to-many",
+          automationOnly: true
+        }).pipe(Effect.provide(testLayer({ associations: [association({})] })))
+      )
+      expect(error).toBeInstanceOf(AssociationConflictError)
+      expect((error as AssociationConflictError).reason).toContain("automationOnly")
+    }))
+
+  it.effect("deleteAssociation rejects an association whose source is a core system class", () =>
+    Effect.gen(function*() {
+      const system = association({
+        _id: "assoc-sys" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: tracker.class.Issue
+      })
+      const error = yield* Effect.flip(
+        deleteAssociation({ association: AssociationIdentifier.make("assoc-sys") }).pipe(
+          Effect.provide(testLayer({ associations: [system] }))
+        )
+      )
+      expect(error).toBeInstanceOf(AssociationSystemClassUnsupportedError)
+    }))
+
+  it.effect("deleteAssociation rejects an association whose target is a core system class", () =>
+    Effect.gen(function*() {
+      const system = association({
+        _id: "assoc-sys" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: core.class.Doc
+      })
+      const error = yield* Effect.flip(
+        deleteAssociation({ association: AssociationIdentifier.make("assoc-sys") }).pipe(
+          Effect.provide(testLayer({ associations: [system] }))
+        )
+      )
+      expect(error).toBeInstanceOf(AssociationSystemClassUnsupportedError)
+    }))
+
+  it.effect("deleteAssociation resolves an association by its target role name", () =>
+    Effect.gen(function*() {
+      const assoc = association({
+        _id: "assoc-roles" as Ref<HulyAssociation>,
+        nameA: "references",
+        nameB: "referenced by"
+      })
+      const result = yield* deleteAssociation({ association: AssociationIdentifier.make("referenced by") }).pipe(
+        Effect.provide(testLayer({ associations: [assoc] }))
+      )
+      expect(result.deleted).toBe(true)
+      expect(result.associationId).toBe("assoc-roles")
+    }))
+
+  it.effect("deleteAssociation resolves an association by its 'source -> target' role pair", () =>
+    Effect.gen(function*() {
+      const assoc = association({
+        _id: "assoc-roles" as Ref<HulyAssociation>,
+        nameA: "references",
+        nameB: "referenced by"
+      })
+      const result = yield* deleteAssociation({
+        association: AssociationIdentifier.make("references -> referenced by")
+      }).pipe(Effect.provide(testLayer({ associations: [assoc] })))
+      expect(result.deleted).toBe(true)
+      expect(result.associationId).toBe("assoc-roles")
+    }))
+})
+
+describe("listAssociations branch coverage", () => {
+  it.effect("summarizes a system association with an unsupported-write reason when included", () =>
+    Effect.gen(function*() {
+      const system = association({
+        _id: "assoc-sys" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const result = yield* listAssociations({ includeSystem: true }).pipe(
+        Effect.provide(testLayer({ associations: [system] }))
+      )
+      const summary = result.associations.find((item) => item.associationId === "assoc-sys")
+      expect(summary?.system).toBe(true)
+      expect(summary?.canCreateRelation).toBe(false)
+      expect(summary?.unsupportedReason).toContain("system class")
+    }))
+
+  it.effect("filters association discovery by source and target class", () =>
+    Effect.gen(function*() {
+      const match = association({
+        _id: "assoc-it" as Ref<HulyAssociation>,
+        classA: tracker.class.Issue,
+        classB: documentPlugin.class.Document
+      })
+      const result = yield* listAssociations({ sourceClass: issueClass, targetClass: documentClass }).pipe(
+        Effect.provide(testLayer({ associations: [match] }))
+      )
+      expect(result.associations.map((item) => item.associationId)).toEqual(["assoc-it"])
+    }))
+
+  it.effect("reports a system association as not found when system classes are excluded", () =>
+    Effect.gen(function*() {
+      const system = association({
+        _id: "assoc-sys" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: core.class.Doc
+      })
+      const error = yield* Effect.flip(
+        listAssociations({ association: AssociationIdentifier.make("assoc-sys") }).pipe(
+          Effect.provide(testLayer({ associations: [system] }))
+        )
+      )
+      expect(error).toBeInstanceOf(AssociationNotFoundError)
+    }))
 })
 
 describe("relation mutations", () => {
@@ -1350,5 +1487,168 @@ describe("relation mutations", () => {
       )
 
       expect(error).toBeInstanceOf(RelationIdentifierAmbiguousError)
+    }))
+})
+
+describe("generic-associations resolver and mutation branch coverage", () => {
+  it.effect("createRelation rejects associations on a core system class", () =>
+    Effect.gen(function*() {
+      const system = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: core.class.Doc,
+        classB: tracker.class.Issue
+      })
+      const error = yield* Effect.flip(
+        createRelation({
+          association: assocId,
+          source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+          target: { kind: "raw", id: docId("issue-2"), class: issueClass }
+        }).pipe(Effect.provide(testLayer({
+          associations: [system],
+          issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+        })))
+      )
+      expect(error).toBeInstanceOf(AssociationSystemClassUnsupportedError)
+    }))
+
+  it.effect("createAssociation conflict reason defaults a missing automationOnly to false", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        createAssociation({
+          sourceClass: issueClass,
+          targetClass: issueClass,
+          sourceRole: AssociationRoleName.make("relates"),
+          targetRole: AssociationRoleName.make("relates"),
+          cardinality: "many-to-many"
+        }).pipe(Effect.provide(testLayer({ associations: [association({ automationOnly: true })] })))
+      )
+      expect(error).toBeInstanceOf(AssociationConflictError)
+      expect((error as AssociationConflictError).reason).toContain("requested false")
+    }))
+
+  it.effect("deleteRelation by triple is idempotent when no relation matches", () =>
+    Effect.gen(function*() {
+      const result = yield* deleteRelation({
+        association: assocId,
+        source: { kind: "raw", id: docId("issue-1"), class: issueClass },
+        target: { kind: "raw", id: docId("issue-2"), class: issueClass }
+      }).pipe(Effect.provide(testLayer({
+        associations: [association({ _id: "assoc-1" as Ref<HulyAssociation> })],
+        issues: [issue("issue-1", "HULY-1"), issue("issue-2", "HULY-2")]
+      })))
+      expect(result.deleted).toBe(false)
+      expect(result.reason).toBe("not_found")
+    }))
+
+  it.effect("resolves a document endpoint by its id", () =>
+    Effect.gen(function*() {
+      const docToIssue = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: documentPlugin.class.Document,
+        classB: tracker.class.Issue,
+        nameA: "document",
+        nameB: "issue"
+      })
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "document", document: documentIdentifier("doc-1") },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass }
+      }).pipe(Effect.provide(testLayer({
+        associations: [docToIssue],
+        relations: [relation({ docA: "doc-1" as Ref<Doc>, docB: "issue-1" as Ref<Doc> })],
+        documents: [documentDoc("doc-1", "Spec")],
+        issues: [issue("issue-1", "HULY-1")]
+      })))
+      expect(result.total).toBe(1)
+      expect(result.relations[0].source.display).toBe("Spec")
+    }))
+
+  it.effect("fails on ambiguous document titles without a teamspace", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: { kind: "document", document: documentIdentifier("Shared Title") }
+        }).pipe(Effect.provide(testLayer({
+          associations: [association({})],
+          documents: [documentDoc("doc-1", "Shared Title"), documentDoc("doc-2", "Shared Title")]
+        })))
+      )
+      expect(error).toBeInstanceOf(GenericObjectIdentifierAmbiguousError)
+    }))
+
+  it.effect("resolves a card endpoint by id within a card space resolved by id", () =>
+    Effect.gen(function*() {
+      const cardToIssue = association({
+        _id: "assoc-1" as Ref<HulyAssociation>,
+        classA: contractAssociationClassRef,
+        classB: tracker.class.Issue,
+        nameA: "card",
+        nameB: "issue"
+      })
+      const result = yield* listRelations({
+        association: assocId,
+        source: { kind: "card", card: CardIdentifier.make("card-1"), cardSpace: CardSpaceIdentifier.make("cards-1") },
+        target: { kind: "raw", id: docId("issue-1"), class: issueClass }
+      }).pipe(Effect.provide(testLayer({
+        associations: [cardToIssue],
+        relations: [relation({ docA: "card-1" as Ref<Doc>, docB: "issue-1" as Ref<Doc> })],
+        cardSpaces: [cardSpaceDoc("cards-1", "Contracts")],
+        cards: [cardDoc("card-1", "Contract")],
+        issues: [issue("issue-1", "HULY-1")]
+      })))
+      expect(result.total).toBe(1)
+    }))
+
+  it.effect("fails when the referenced card space does not exist", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: {
+            kind: "card",
+            card: CardIdentifier.make("Contract"),
+            cardSpace: CardSpaceIdentifier.make("Nonexistent")
+          }
+        }).pipe(Effect.provide(testLayer({
+          associations: [association({})],
+          cards: [cardDoc("card-1", "Contract")]
+        })))
+      )
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
+    }))
+
+  it.effect("fails on an ambiguous card space name", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: {
+            kind: "card",
+            card: CardIdentifier.make("Contract"),
+            cardSpace: CardSpaceIdentifier.make("Contracts")
+          }
+        }).pipe(Effect.provide(testLayer({
+          associations: [association({})],
+          cardSpaces: [cardSpaceDoc("cards-1", "Contracts"), cardSpaceDoc("cards-2", "Contracts")],
+          cards: [cardDoc("card-1", "Contract")]
+        })))
+      )
+      expect(error).toBeInstanceOf(GenericObjectIdentifierAmbiguousError)
+    }))
+
+  it.effect("fails when a card title is missing inside the selected card space", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(
+        listRelations({
+          source: {
+            kind: "card",
+            card: CardIdentifier.make("Missing Card"),
+            cardSpace: CardSpaceIdentifier.make("Contracts")
+          }
+        }).pipe(Effect.provide(testLayer({
+          associations: [association({})],
+          cardSpaces: [cardSpaceDoc("cards-1", "Contracts")],
+          cards: [cardDoc("card-1", "Contract")]
+        })))
+      )
+      expect(error).toBeInstanceOf(GenericObjectNotFoundError)
     }))
 })

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -19,6 +19,7 @@ import {
   CalendarNotAccessibleError,
   DirectMessageIdentifierAmbiguousError,
   DirectMessageNotFoundError,
+  DocumentContentCorruptedError,
   FileFetchError,
   FileNotFoundError,
   FileUploadError,
@@ -348,6 +349,22 @@ describe("Error Mapping to MCP", () => {
             expect(response._meta.errorTag).toBeUndefined()
             expect(response.content[0].text).toBe(error.message)
           }
+        }))
+
+      it.effect("maps DocumentContentCorruptedError with repair instruction", () =>
+        Effect.gen(function*() {
+          const error = new DocumentContentCorruptedError({
+            identifier: "Spec",
+            causeMessage: "missing markup blob"
+          })
+          const response = mapDomainErrorToMcp(error)
+
+          expect(response.isError).toBe(true)
+          expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+          expect(response._meta.errorTag).toBeUndefined()
+          expect(response.content[0].text).toBe(
+            "Document content is unreadable or corrupted. Use edit_document with the full content field to replace and repair it."
+          )
         }))
     })
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/dearlordylord/huly-mcp/issues/79.

- adds `DocumentContentCorruptedError` and maps it to MCP `InvalidParams` with repair guidance
- routes `get_document` and `list_inline_comments` through a shared defensive document-content read helper
- classifies document content as corrupted only when `Document.content` resolves to an empty markup read and the backing markup blob is missing
- preserves ordinary `fetchMarkup` failures as Huly client errors instead of misreporting them as document corruption
- preserves current `create_document` / `edit_document(content=...)` write behavior
- adds integration coverage for markdown round-trip, full replacement, raw content corruption, and repair
- includes generic-associations branch coverage tests in `test/huly/operations/generic-associations.test.ts`

## Review Loop

Ran reviewer agents until the final pass returned no findings before opening the PR. After follow-up review, corrected the over-broad `fetchMarkup` error mapping so transport/auth/collaborator failures are not reported as corrupted document content.

## Verification

- `pnpm check-all` passed on this branch: 128 test files, 2510 tests
- local Huly integration passed on this branch: 234 passed, 0 failed, 38 skipped