### PR TITLE
Fix document browse links being converted to Huly references

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -45,7 +45,12 @@ import { type Auth, HulyConfigService } from "../config/config.js"
 import { UrlString, WorkspaceUrlSlug } from "../domain/schemas/shared.js"
 import { concatLink } from "../utils/url.js"
 import { HulyAuthError, HulyConnectionError } from "./errors.js"
-import { markupNodeToMarkdownString, type MarkupUrlConfig, testMarkupUrlConfig } from "./operations/markup.js"
+import {
+  MARKDOWN_INPUT_REF_URL,
+  markupNodeToMarkdownString,
+  type MarkupUrlConfig,
+  testMarkupUrlConfig
+} from "./operations/markup.js"
 import { HulySdk, type HulySdkDependencies } from "./sdk-deps.js"
 import { testWorkbenchUrlConfig, type WorkbenchUrlConfig } from "./url-builders.js"
 
@@ -138,6 +143,11 @@ interface MarkupConvertOptions {
   readonly imageUrl: string
 }
 
+const markdownInputOptions = (opts: MarkupConvertOptions): MarkupConvertOptions => ({
+  refUrl: MARKDOWN_INPUT_REF_URL,
+  imageUrl: opts.imageUrl
+})
+
 function toInternalMarkup(
   value: string,
   format: MarkupFormat,
@@ -150,7 +160,7 @@ function toInternalMarkup(
     case "html":
       return sdk.jsonToMarkup(sdk.htmlToJSON(value))
     case "markdown":
-      return sdk.jsonToMarkup(sdk.markdownToMarkup(value, opts))
+      return sdk.jsonToMarkup(sdk.markdownToMarkup(value, markdownInputOptions(opts)))
     default:
       absurd(format)
       throw new Error(`Invalid format: ${format}`)

--- a/src/huly/operations/markup.ts
+++ b/src/huly/operations/markup.ts
@@ -22,6 +22,18 @@ export interface MarkupUrlConfig {
   readonly imageUrl: UrlString
 }
 
+// Sent to markdownToMarkup as a fake "home" URL so Huly browse links in MCP
+// markdown input stay plain links instead of auto-converting to reference nodes.
+// This URL is not used for read serialization or image handling.
+export const MARKDOWN_INPUT_REF_URL = "https://huly-mcp.invalid/no-reference-conversion"
+
+const markdownInputRefUrl = UrlStringSchema.make(MARKDOWN_INPUT_REF_URL)
+
+const markdownInputUrlConfig = (urls: MarkupUrlConfig): MarkupUrlConfig => ({
+  refUrl: markdownInputRefUrl,
+  imageUrl: urls.imageUrl
+})
+
 // Mirrors @hcengineering/text-markdown's serializer options; callers use branded MarkupUrlConfig.
 interface MarkupMarkdownOptions {
   readonly refUrl: string
@@ -99,7 +111,7 @@ export const markupToMarkdownString = (markup: Markup, urls: MarkupUrlConfig): s
 }
 
 export const markdownToMarkupString = (markdown: string, urls: MarkupUrlConfig): Markup => {
-  const json = markdownToMarkup(markdown, urls)
+  const json = markdownToMarkup(markdown, markdownInputUrlConfig(urls))
   return jsonAsMarkup(json)
 }
 

--- a/test/huly/client.test.ts
+++ b/test/huly/client.test.ts
@@ -27,6 +27,7 @@ import { HulyConfigService } from "../../src/config/config.js"
 import { HulyClient, type HulyClientError } from "../../src/huly/client.js"
 import { HulyAuthError, HulyConnectionError } from "../../src/huly/errors.js"
 import { INLINE_COMMENT_MARK_TYPE } from "../../src/huly/operations/inline-comment-mark.js"
+import { MARKDOWN_INPUT_REF_URL } from "../../src/huly/operations/markup.js"
 import { HulySdk, type HulySdkDependencies } from "../../src/huly/sdk-deps.js"
 import { mockFn } from "../helpers/mock-fn.js"
 
@@ -60,6 +61,7 @@ const mockTxOperations = {
 const mockGetMarkup = mockFn()
 const mockCreateMarkup = mockFn()
 const mockUpdateMarkup = mockFn()
+const mockMarkdownToMarkup = mockFn().mockImplementation((md: string) => ({ type: "md-parsed", content: md }))
 
 const clearAllMockFns = () => {
   mockFindAll.mockClear()
@@ -76,6 +78,7 @@ const clearAllMockFns = () => {
   mockGetMarkup.mockClear()
   mockCreateMarkup.mockClear()
   mockUpdateMarkup.mockClear()
+  mockMarkdownToMarkup.mockClear()
 }
 
 const mockCollaboratorClient = {
@@ -104,7 +107,7 @@ const testSdk: HulySdkDependencies = {
   htmlToJSON: mockFn().mockImplementation((html: string) => ({ type: "html-parsed", content: html })),
   jsonToHTML: mockFn().mockImplementation((json: unknown) => `<html>${JSON.stringify(json)}</html>`),
   jsonToMarkup: mockFn().mockImplementation((json: unknown) => `markup:${JSON.stringify(json)}`),
-  markdownToMarkup: mockFn().mockImplementation((md: string) => ({ type: "md-parsed", content: md })),
+  markdownToMarkup: mockMarkdownToMarkup,
   markupToJSON: mockFn().mockImplementation((markup: string) => ({
     type: "doc",
     content: [{
@@ -1029,6 +1032,10 @@ describe("HulyClient.layer (live layer with mocked externals)", () => {
 
         expect(result).toBe("ref-md")
         expect(mockCreateMarkup.mock.calls).toHaveLength(1)
+        expect(mockMarkdownToMarkup.mock.calls[0][1]).toEqual({
+          refUrl: MARKDOWN_INPUT_REF_URL,
+          imageUrl: "http://localhost:8080/files?workspace=ws-123&file="
+        })
         const uploadedValue = mockCreateMarkup.mock.calls[0][1] as string
         expect(uploadedValue).toContain("md-parsed")
       }))
@@ -1198,6 +1205,10 @@ describe("HulyClient.layer (live layer with mocked externals)", () => {
         )
 
         expect(mockUpdateMarkup.mock.calls).toHaveLength(1)
+        expect(mockMarkdownToMarkup.mock.calls[0][1]).toEqual({
+          refUrl: MARKDOWN_INPUT_REF_URL,
+          imageUrl: "http://localhost:8080/files?workspace=ws-123&file="
+        })
         const uploadedValue = mockUpdateMarkup.mock.calls[0][1] as string
         expect(uploadedValue).toContain("md-parsed")
       }))

--- a/test/huly/operations/markup.test.ts
+++ b/test/huly/operations/markup.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from "@effect/vitest"
-import { markupToJSON } from "@hcengineering/text"
+import { MarkupMarkType, MarkupNodeType, markupToJSON } from "@hcengineering/text"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
 import { INLINE_COMMENT_MARK_TYPE } from "../../../src/huly/operations/inline-comment-mark.js"
 import {
+  markdownToMarkupString,
   markupToMarkdownString,
   optionalMarkupToMarkdown,
   sanitizeNodeForMarkdown,
@@ -31,6 +32,58 @@ describe("markupToMarkdownString", () => {
       expect(markdown.trim()).toBe("highlighted text")
       expect(markdown).not.toContain(INLINE_COMMENT_MARK_TYPE)
       expect(markdown).not.toContain("thread-1")
+    }))
+
+  it.effect("serializes existing Huly reference nodes as browse links", () =>
+    Effect.gen(function*() {
+      const referenceMarkup = JSON.stringify({
+        type: MarkupNodeType.doc,
+        content: [{
+          type: MarkupNodeType.paragraph,
+          content: [
+            { type: MarkupNodeType.text, text: "I meant " },
+            {
+              type: MarkupNodeType.reference,
+              attrs: {
+                id: "doc-1",
+                label: "Test Document",
+                objectclass: "document:class:Document"
+              }
+            },
+            { type: MarkupNodeType.text, text: " like this" }
+          ]
+        }]
+      })
+
+      const markdown = markupToMarkdownString(referenceMarkup, testMarkupUrlConfig)
+
+      expect(markdown).toContain("[Test Document](")
+      expect(markdown).toContain("_class=document%3Aclass%3ADocument")
+      expect(markdown).toContain("_id=doc-1")
+    }))
+})
+
+describe("markdownToMarkupString", () => {
+  it.effect("keeps matching Huly browse URLs as markdown links instead of editor reference nodes", () =>
+    Effect.gen(function*() {
+      const markdown =
+        "I meant [Test Document](https://test.invalid/browse?workspace=test&_class=document%3Aclass%3ADocument&_id=doc-1&label=Test%20Document) like this"
+
+      const markup = markdownToMarkupString(markdown, testMarkupUrlConfig)
+      const root = markupToJSON(markup)
+      const paragraph = root.content?.[0]
+      const content = paragraph?.content ?? []
+      const linkedText = content.find((node) => node.type === MarkupNodeType.text && node.text === "Test Document")
+
+      expect(content.some((node) => node.type === MarkupNodeType.reference)).toBe(false)
+      expect(linkedText).toBeDefined()
+      expect(linkedText?.marks).toContainEqual({
+        type: MarkupMarkType.link,
+        attrs: {
+          href:
+            "https://test.invalid/browse?workspace=test&_class=document%3Aclass%3ADocument&_id=doc-1&label=Test%20Document"
+        }
+      })
     }))
 })
 


### PR DESCRIPTION
codex 55

## Summary

Fixes document markdown writes so Huly browse URLs passed by MCP callers remain ordinary markdown links instead of being converted into Huly internal `reference` nodes.

The issue is that `@hcengineering/text-markdown` treats links starting with the active Huly `refUrl` as internal references. That is useful when serializing existing Huly reference nodes, but it is surprising and unsafe for MCP markdown input: `[text](url)` should preserve a normal link mark.

## Root cause / proof

Local repro on issue #79 showed this sequence:

1. `edit_document` with a local Huly browse link returned `updated: true`.
2. Raw collaborator markup initially contained a `reference` node for the linked text.
3. After opening/refreshing the Huly UI, raw collaborator markup had removed that node, leaving `I meant  like this`.
4. `get_document` then returned the same blank content.

After this change, the same edit stores the linked text as a normal text node with a `link` mark (`hasReference: false`, `hasLink: true`) and `get_document` returns the full markdown link.

## Changes

- Use a non-matching sentinel `refUrl` for markdown input conversion so browse URLs stay as normal links.
- Keep normal read behavior: existing Huly reference nodes still serialize as browse links.
- Add focused tests for both shared markup conversion and collaborator upload/update conversion.

## Verification

- `pnpm test test/huly/client.test.ts`
- `pnpm test test/huly/operations/markup.test.ts`
- `pnpm typecheck`
- `pnpm check-all`

Full gate passed: 128 test files, 2715 tests, coverage above 99% thresholds.

Closes #79
