### PR TITLE
Fix derived card master tag resolution

### DIFF
--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -128,7 +128,7 @@ For HTTP header mode, send the same JSON-RPC methods to `/mcp` with `x-huly-url`
 
 **Coverage**: 120+ tool calls across 22 domains. Self-cleaning: all created entities are deleted at the end of each section. Tools that would leak data (no delete counterpart) are skipped. Run time: ~3 minutes.
 
-**Last verified**: 2026-06-06 — 282 passed, 0 failed, 38 skipped (of 320 total).
+**Last verified**: 2026-06-07 — 286 passed, 0 failed, 35 skipped (of 321 total).
 
 ### How to Run
 
@@ -164,7 +164,7 @@ The full suite tests CRUD lifecycles with cleanup for all domains:
 | 13a. SDK Discovery | list_huly_classes, get_huly_class, list_huly_attributes, list_huly_enums | Read-only model discovery for class IDs, attributes, inherited fields, purpose-built tool hints, and enum totals |
 | 13b. Spaces | list_spaces, get_space, list_space_types, get_space_type, list_space_permissions, update_space, add_space_members, remove_space_members, set_space_owners | Generic space discovery plus safe metadata/member/owner updates against a disposable teamspace, verified through module-specific teamspace reads |
 | 13c. Generic Associations | list_associations, create_association, delete_association, list_relations, create_relation, delete_relation | Disposable association + relation lifecycle, including idempotency, in-use association delete rejection, public association cleanup, cardinality violation, and card endpoint locators by ID and title |
-| 14. Cards | list_card_spaces, list_master_tags, list_cards | Read operations with cardSpace |
+| 14. Cards | list_card_spaces, list_master_tags, list_cards, create_card, get_card, delete_card | Read operations plus derived master-tag create/get/delete coverage with cardSpace |
 | 15. Activity | list_mentions, list_saved_messages | Read operations |
 | 16. Workspace | get_workspace_info, list_workspace_members | Read-only (management tools skipped) |
 | 17. Attachments | add_issue_attachment, list/get/pin/update/download/delete attachment | Full CRUD (upload_file standalone skipped — no blob delete) |
@@ -172,9 +172,9 @@ The full suite tests CRUD lifecycles with cleanup for all domains:
 | 19. Processes | list_processes, get_process, list_process_executions, start_process, cancel_execution | Read/write; write checks run only when the workspace has a process with an initial state and a matching safe card fixture, then cancel the created execution |
 | 20. User Statuses | list_user_statuses | Read-only presence records; filtered call runs when at least one row exists |
 
-### Intentionally Skipped (22 fixed + up to 14 conditional)
+### Intentionally Skipped (19 fixed + up to 15 conditional)
 
-**Always skipped (22):**
+**Always skipped (19):**
 - **create/update/delete_project** (3): Would pollute workspace
 - **Workspace management** (6): list_workspaces, create/delete_workspace, get_regions, update_member_role, update_guest_settings — dangerous
 - **update_user_profile** (1): Would modify test user
@@ -183,7 +183,7 @@ The full suite tests CRUD lifecycles with cleanup for all domains:
 - **upload_file(standalone)** (1): No blob delete tool — would leak data
 - **create_work_slot** (1): Requires existing planner task (todoId)
 - **get_person** (1): Covered by create+update cycle
-- **Cards section CRUD** (4): create/get/update/delete_card — section-level lifecycle is skipped; create_card/delete_card are exercised by the generic association card locator smoke
+- **update_card** (1): Card update lifecycle is skipped; create/get/delete_card are exercised by the derived master-tag card lifecycle and the generic association card locator smoke
 - **add_attachment, add_document_attachment** (2): Covered by add_issue_attachment
 
 **Conditionally skipped (up to 15):**

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -2349,15 +2349,79 @@ echo ""
 echo "=== 14. Cards ==="
 run_test "list_card_spaces" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_card_spaces","arguments":{}},"id":2}'
-run_test "list_master_tags(Default)" \
-  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_master_tags","arguments":{"cardSpace":"Default"}},"id":2}'
+CARDS_MASTER_TEXT=$(run_capture "list_master_tags(Default)" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_master_tags","arguments":{"cardSpace":"Default"}},"id":2}')
 run_test "list_cards(Default)" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_cards","arguments":{"cardSpace":"Default","limit":3}},"id":2}'
-# Card CRUD requires a master tag; skip
-skip_test "create_card" "requires master tag"
-skip_test "get_card" "requires card"
+DERIVED_CARD_TYPE_NAME="Character"
+DERIVED_CARD_TYPE_ID=$(printf '%s\n' "$CARDS_MASTER_TEXT" | jq -r --arg name "$DERIVED_CARD_TYPE_NAME" \
+  '.masterTags[]? | select(.name == $name) | .id' 2>/dev/null | head -n 1)
+if [ -n "$DERIVED_CARD_TYPE_ID" ]; then
+  DERIVED_CARD_TYPE_NAME_JSON=$(json_string "$DERIVED_CARD_TYPE_NAME")
+  DERIVED_CARD_TYPE_ID_JSON=$(json_string "$DERIVED_CARD_TYPE_ID")
+  DERIVED_CARD_LABEL_TITLE="IntTest Derived Label Card $RUN_ID"
+  DERIVED_CARD_ID_TITLE="IntTest Derived Id Card $RUN_ID"
+  DERIVED_CARD_LABEL_TITLE_JSON=$(json_string "$DERIVED_CARD_LABEL_TITLE")
+  DERIVED_CARD_ID_TITLE_JSON=$(json_string "$DERIVED_CARD_ID_TITLE")
+
+  DERIVED_CARD_LABEL_TEXT=$(run_capture "create_card(derived label:$DERIVED_CARD_TYPE_NAME)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_card\",\"arguments\":{\"cardSpace\":\"Default\",\"type\":$DERIVED_CARD_TYPE_NAME_JSON,\"title\":$DERIVED_CARD_LABEL_TITLE_JSON,\"content\":\"Temporary derived card created by label.\"}},\"id\":2}")
+  if [ $? -eq 0 ]; then
+    DERIVED_CARD_LABEL_ID=$(printf '%s\n' "$DERIVED_CARD_LABEL_TEXT" | jq -r '.id // empty' 2>/dev/null)
+  else
+    DERIVED_CARD_LABEL_ID=""
+  fi
+  if [ -n "$DERIVED_CARD_LABEL_ID" ]; then
+    DERIVED_CARD_LABEL_ID_JSON=$(json_string "$DERIVED_CARD_LABEL_ID")
+    DERIVED_CARD_LABEL_GET_TEXT=$(run_capture "get_card(derived label:$DERIVED_CARD_LABEL_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_card\",\"arguments\":{\"cardSpace\":\"Default\",\"card\":$DERIVED_CARD_LABEL_ID_JSON}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_equals "get_card derived label keeps type" "$DERIVED_CARD_LABEL_GET_TEXT" ".type" "$DERIVED_CARD_TYPE_ID"
+    fi
+    DERIVED_CARD_LIST_TEXT=$(run_capture "list_cards(Default,type:$DERIVED_CARD_TYPE_NAME)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_cards\",\"arguments\":{\"cardSpace\":\"Default\",\"type\":$DERIVED_CARD_TYPE_NAME_JSON,\"limit\":10}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_array_contains "list_cards derived label includes card" "$DERIVED_CARD_LIST_TEXT" ".cards | map(.id)" "$DERIVED_CARD_LABEL_ID"
+    fi
+  else
+    fail_test "create_card(derived label:$DERIVED_CARD_TYPE_NAME) returns id" "missing id"
+  fi
+
+  DERIVED_CARD_ID_TEXT=$(run_capture "create_card(derived id:$DERIVED_CARD_TYPE_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"create_card\",\"arguments\":{\"cardSpace\":\"Default\",\"type\":$DERIVED_CARD_TYPE_ID_JSON,\"title\":$DERIVED_CARD_ID_TITLE_JSON,\"content\":\"Temporary derived card created by id.\"}},\"id\":2}")
+  if [ $? -eq 0 ]; then
+    DERIVED_CARD_ID_ID=$(printf '%s\n' "$DERIVED_CARD_ID_TEXT" | jq -r '.id // empty' 2>/dev/null)
+  else
+    DERIVED_CARD_ID_ID=""
+  fi
+  if [ -n "$DERIVED_CARD_ID_ID" ]; then
+    DERIVED_CARD_ID_ID_JSON=$(json_string "$DERIVED_CARD_ID_ID")
+    DERIVED_CARD_ID_GET_TEXT=$(run_capture "get_card(derived id:$DERIVED_CARD_ID_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_card\",\"arguments\":{\"cardSpace\":\"Default\",\"card\":$DERIVED_CARD_ID_ID_JSON}},\"id\":2}")
+    if [ $? -eq 0 ]; then
+      assert_json_field_equals "get_card derived id keeps type" "$DERIVED_CARD_ID_GET_TEXT" ".type" "$DERIVED_CARD_TYPE_ID"
+    fi
+  else
+    fail_test "create_card(derived id:$DERIVED_CARD_TYPE_ID) returns id" "missing id"
+  fi
+
+  if [ -n "$DERIVED_CARD_LABEL_ID" ]; then
+    run_test "delete_card(derived label:$DERIVED_CARD_LABEL_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_card\",\"arguments\":{\"cardSpace\":\"Default\",\"card\":\"$DERIVED_CARD_LABEL_ID\"}},\"id\":2}"
+  fi
+  if [ -n "$DERIVED_CARD_ID_ID" ]; then
+    run_test "delete_card(derived id:$DERIVED_CARD_ID_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_card\",\"arguments\":{\"cardSpace\":\"Default\",\"card\":\"$DERIVED_CARD_ID_ID\"}},\"id\":2}"
+  fi
+else
+  skip_test "create_card(derived label:Character)" "Default card space has no Character master tag"
+  skip_test "get_card(derived label)" "Default card space has no Character master tag"
+  skip_test "list_cards(Default,type:Character)" "Default card space has no Character master tag"
+  skip_test "create_card(derived id)" "Default card space has no Character master tag"
+  skip_test "get_card(derived id)" "Default card space has no Character master tag"
+  skip_test "delete_card(derived cards)" "Default card space has no Character master tag"
+fi
 skip_test "update_card" "requires card"
-skip_test "delete_card" "requires card"
 echo ""
 
 ##############################

--- a/src/huly/operations/card-master-tags.ts
+++ b/src/huly/operations/card-master-tags.ts
@@ -1,0 +1,135 @@
+import type { CardSpace as HulyCardSpace, MasterTag as HulyMasterTag } from "@hcengineering/card"
+import { type Class, ClassifierKind, type Ref, SortingOrder } from "@hcengineering/core"
+import { Effect, Either } from "effect"
+
+import {
+  MasterTagIdentifier,
+  type MasterTagIdentifier as MasterTagIdentifierValue,
+  ObjectClassName
+} from "../../domain/schemas/shared.js"
+import type { HulyClient, HulyClientError } from "../client.js"
+import { MasterTagNotFoundError } from "../errors.js"
+import { decodeHulyModelLabelTail } from "../huly-labels.js"
+import { cardPlugin, core } from "../huly-plugins.js"
+import { hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { type DirectAncestorRef, directAncestorRefs, type MetadataClassDoc } from "./sdk-discovery-mappers.js"
+
+type CardMasterTagDoc = HulyMasterTag & MetadataClassDoc
+type CardClassId = ObjectClassName
+type DescendantsByAncestor = ReadonlyMap<CardClassId, ReadonlySet<CardClassId>>
+type MutableDescendantsByAncestor = Map<CardClassId, Set<CardClassId>>
+
+// core.class.Class is the SDK class registry; the generic narrows the returned class docs.
+// eslint-disable-next-line no-restricted-syntax -- SDK boundary cast for class model queries
+const classRef = core.class.Class as Ref<Class<CardMasterTagDoc>>
+
+const cardClassId = (value: DirectAncestorRef | Ref<HulyMasterTag>): CardClassId => ObjectClassName.make(String(value))
+
+const masterTagLookupCandidate = (
+  value: HulyMasterTag["label"] | Ref<HulyMasterTag> | string
+): MasterTagIdentifierValue => MasterTagIdentifier.make(String(value))
+
+export const masterTagDisplayName = (tag: CardMasterTagDoc): string =>
+  Either.getOrElse(
+    decodeHulyModelLabelTail(tag.label),
+    () => String(tag.label)
+  )
+
+const matchesMasterTagIdentifier = (tag: CardMasterTagDoc, identifier: MasterTagIdentifierValue): boolean =>
+  masterTagLookupCandidate(tag._id) === identifier
+  || masterTagLookupCandidate(tag.label) === identifier
+  || masterTagLookupCandidate(masterTagDisplayName(tag)) === identifier
+
+const addDescendant = (
+  descendants: MutableDescendantsByAncestor,
+  ancestorId: CardClassId,
+  childId: CardClassId
+): void => {
+  const existing = descendants.get(ancestorId) ?? new Set<CardClassId>()
+  // Local graph-index state keeps descendant expansion linear; the mutable collections do not escape as mutable types.
+  // eslint-disable-next-line functional/immutable-data
+  existing.add(childId)
+  // eslint-disable-next-line functional/immutable-data
+  descendants.set(ancestorId, existing)
+}
+
+const buildDescendantsByAncestor = (classes: ReadonlyArray<CardMasterTagDoc>): DescendantsByAncestor => {
+  const descendants = new Map<CardClassId, Set<CardClassId>>()
+  classes.forEach((tag) => {
+    const childId = cardClassId(tag._id)
+    directAncestorRefs(tag).forEach((ancestor) => {
+      addDescendant(descendants, cardClassId(ancestor), childId)
+    })
+  })
+  return descendants
+}
+
+const collectDescendants = (
+  rootIds: ReadonlySet<CardClassId>,
+  descendantsByAncestor: DescendantsByAncestor
+): ReadonlySet<CardClassId> => {
+  const visited = new Set<CardClassId>(rootIds)
+  const pending = [...rootIds]
+  let nextIndex = 0
+  while (nextIndex < pending.length) {
+    const current = pending[nextIndex]
+    const unvisitedChildren = [...(descendantsByAncestor.get(current) ?? [])].filter((childId) => !visited.has(childId))
+    unvisitedChildren.forEach((childId) => {
+      // Local traversal state keeps descendant expansion linear; the mutable collections do not escape as mutable types.
+      // eslint-disable-next-line functional/immutable-data
+      visited.add(childId)
+      // eslint-disable-next-line functional/immutable-data
+      pending.push(childId)
+    })
+    nextIndex += 1
+  }
+  return visited
+}
+
+export const fetchMasterTagsForSpace = (
+  client: HulyClient["Type"],
+  cardSpace: HulyCardSpace
+): Effect.Effect<ReadonlyArray<CardMasterTagDoc>, HulyClientError> =>
+  Effect.gen(function*() {
+    const typeRefs = cardSpace.types
+    if (typeRefs.length === 0) return []
+
+    const query: StrictDocumentQuery<CardMasterTagDoc> = { kind: ClassifierKind.CLASS }
+    const allClasses = yield* client.findAll<CardMasterTagDoc>(
+      classRef,
+      hulyQuery(query),
+      { sort: { _id: SortingOrder.Ascending } }
+    )
+    const descendantsByAncestor = buildDescendantsByAncestor(allClasses)
+    const spaceTypeIds = collectDescendants(new Set(typeRefs.map(cardClassId)), descendantsByAncestor)
+    const cardRootIds = collectDescendants(new Set([cardClassId(cardPlugin.class.Card)]), descendantsByAncestor)
+
+    return allClasses.filter((tag) =>
+      tag._id !== cardPlugin.class.Card
+      && spaceTypeIds.has(cardClassId(tag._id))
+      && cardRootIds.has(cardClassId(tag._id))
+    )
+  })
+
+export const findMasterTag = (
+  client: HulyClient["Type"],
+  cardSpace: HulyCardSpace,
+  identifier: MasterTagIdentifierValue
+): Effect.Effect<CardMasterTagDoc, MasterTagNotFoundError | HulyClientError> =>
+  Effect.gen(function*() {
+    const masterTags = yield* fetchMasterTagsForSpace(client, cardSpace)
+    if (masterTags.length === 0) {
+      return yield* new MasterTagNotFoundError({
+        identifier,
+        cardSpace: cardSpace.name
+      })
+    }
+
+    const masterTag = masterTags.find((tag) => matchesMasterTagIdentifier(tag, identifier))
+    if (masterTag !== undefined) return masterTag
+
+    return yield* new MasterTagNotFoundError({
+      identifier,
+      cardSpace: cardSpace.name
+    })
+  })

--- a/src/huly/operations/cards.ts
+++ b/src/huly/operations/cards.ts
@@ -32,13 +32,10 @@ import type {
 import { UPDATE_CARD_FIELDS } from "../../domain/schemas/cards.js"
 import { CardId, CardSpaceId, MasterTagId } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
-import {
-  CardNotFoundError,
-  CardSpaceNotFoundError,
-  MasterTagNotFoundError,
-  type NoUpdateFieldsError
-} from "../errors.js"
+import { CardNotFoundError, CardSpaceNotFoundError } from "../errors.js"
+import type { MasterTagNotFoundError, NoUpdateFieldsError } from "../errors.js"
 import { cardPlugin } from "../huly-plugins.js"
+import { fetchMasterTagsForSpace, findMasterTag, masterTagDisplayName } from "./card-master-tags.js"
 import { clearTextAsEmptyString } from "./clear-field-updates.js"
 import { listTotal, optionalCount } from "./counts.js"
 import { clampLimit, escapeLikeWildcards, findByNameOrId } from "./query-helpers.js"
@@ -131,37 +128,6 @@ const findCardSpaceAndCard = (
     return { card, cardSpace, client }
   })
 
-const findMasterTag = (
-  client: HulyClient["Type"],
-  cardSpace: HulyCardSpace,
-  identifier: string
-): Effect.Effect<HulyMasterTag, MasterTagNotFoundError | HulyClientError> =>
-  Effect.gen(function*() {
-    const typeRefs = cardSpace.types
-    if (typeRefs.length === 0) {
-      return yield* new MasterTagNotFoundError({
-        identifier,
-        cardSpace: cardSpace.name
-      })
-    }
-
-    const allTags = yield* client.findAll<HulyMasterTag>(
-      cardPlugin.class.MasterTag,
-      { _id: { $in: typeRefs } }
-    )
-
-    const byName = allTags.find((t) => t.label === identifier)
-    if (byName !== undefined) return byName
-
-    const byId = allTags.find((t) => t._id === identifier)
-    if (byId !== undefined) return byId
-
-    return yield* new MasterTagNotFoundError({
-      identifier,
-      cardSpace: cardSpace.name
-    })
-  })
-
 // --- Operations ---
 
 export const listCardSpaces = (
@@ -207,24 +173,16 @@ export const listMasterTags = (
   Effect.gen(function*() {
     const { cardSpace, client } = yield* findCardSpace(params.cardSpace)
 
-    const typeRefs = cardSpace.types
-    if (typeRefs.length === 0) {
-      return { masterTags: [], total: listTotal(0) }
-    }
-
-    const tags = yield* client.findAll<HulyMasterTag>(
-      cardPlugin.class.MasterTag,
-      { _id: { $in: typeRefs } }
-    )
+    const tags = yield* fetchMasterTagsForSpace(client, cardSpace)
 
     const summaries: Array<MasterTagSummary> = tags.map((t) => ({
       id: MasterTagId.make(t._id),
-      name: t.label
+      name: masterTagDisplayName(t)
     }))
 
     return {
       masterTags: summaries,
-      total: listTotal(tags.total)
+      total: listTotal(summaries.length)
     }
   })
 

--- a/test/huly/operations/cards.test.ts
+++ b/test/huly/operations/cards.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-restricted-syntax -- test fixtures build Huly SDK docs whose nominal types are not structurally compatible with plain object literals, and branded refs have no runtime constructors */
 import { describe, it } from "@effect/vitest"
 import type { Card as HulyCard, CardSpace as HulyCardSpace, MasterTag as HulyMasterTag } from "@hcengineering/card"
-import { type Doc, type Ref, toFindResult } from "@hcengineering/core"
+import { ClassifierKind, type Doc, type Ref, toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
 import { CardIdentifier, CardSpaceIdentifier, MasterTagIdentifier } from "../../../src/domain/schemas/shared.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
-import { cardPlugin } from "../../../src/huly/huly-plugins.js"
+import { cardPlugin, core } from "../../../src/huly/huly-plugins.js"
 import {
   createCard,
   deleteCard,
@@ -20,6 +20,10 @@ import {
 
 const SPACE_ID = "space-1" as Ref<HulyCardSpace>
 const TAG_ID = "tag-1" as Ref<HulyMasterTag>
+const CHILD_TAG_ID = "tag-child-1" as Ref<HulyMasterTag>
+const OTHER_TAG_ID = "tag-other-1" as Ref<HulyMasterTag>
+
+const tagLabel = (value: string): HulyMasterTag["label"] => value as HulyMasterTag["label"]
 
 const makeSpace = (overrides?: Partial<HulyCardSpace>): HulyCardSpace =>
   ({
@@ -41,6 +45,8 @@ const makeTag = (overrides?: Partial<HulyMasterTag>): HulyMasterTag =>
     _id: TAG_ID,
     _class: cardPlugin.class.MasterTag,
     label: "Document",
+    kind: ClassifierKind.CLASS,
+    extends: cardPlugin.class.Card,
     ...overrides
   }) as unknown as HulyMasterTag
 
@@ -59,6 +65,17 @@ const makeCard = (overrides?: Partial<HulyCard>): HulyCard =>
     createdOn: 150,
     ...overrides
   }) as unknown as HulyCard
+
+const idMatches = (actual: unknown, query: unknown): boolean => {
+  if (query === undefined) return true
+  if (typeof query === "object" && query !== null && "$in" in query) {
+    return Array.isArray(query.$in) && query.$in.includes(actual)
+  }
+  return actual === query
+}
+
+const docMatches = (doc: object, query: Record<string, unknown>): boolean =>
+  Object.entries(query).every(([key, value]) => idMatches(Reflect.get(doc, key), value))
 
 interface Captures {
   findAll?: { class?: unknown; query?: Record<string, unknown> }
@@ -89,10 +106,14 @@ const buildLayer = (m: CardsMock) => {
       cap.findAll.class = _class
       cap.findAll.query = q
     }
-    if (_class === cardPlugin.class.CardSpace) return Effect.succeed(toFindResult([...spaces]))
-    if (_class === cardPlugin.class.MasterTag) return Effect.succeed(toFindResult([...masterTags]))
+    if (_class === cardPlugin.class.CardSpace) {
+      return Effect.succeed(toFindResult(spaces.filter((space) => docMatches(space, q))))
+    }
+    if (_class === cardPlugin.class.MasterTag || _class === core.class.Class) {
+      return Effect.succeed(toFindResult(masterTags.filter((tag) => docMatches(tag, q))))
+    }
     if (_class === cardPlugin.class.Card) {
-      return Effect.succeed(toFindResult(cards.filter((c) => c.space === q.space)))
+      return Effect.succeed(toFindResult(cards.filter((card) => docMatches(card, q))))
     }
     return Effect.succeed(toFindResult([]))
   }) as HulyClientOperations["findAll"]
@@ -248,6 +269,55 @@ describe("listMasterTags", () => {
       expect(result.total).toBe(1)
       expect(result.masterTags[0]).toEqual({ id: "tag-1", name: "Document" })
     }))
+
+  it.effect("includes master tags derived from the space's top-level types", () =>
+    Effect.gen(function*() {
+      const result = yield* listMasterTags({ cardSpace: SPACE }).pipe(
+        Effect.provide(buildLayer({
+          spaces: [makeSpace()],
+          masterTags: [
+            makeTag(),
+            makeTag({ _id: CHILD_TAG_ID, label: tagLabel("Character"), extends: TAG_ID })
+          ]
+        }))
+      )
+
+      expect(result.masterTags).toContainEqual({ id: "tag-child-1", name: "Character" })
+      expect(result.total).toBe(2)
+    }))
+
+  it.effect("falls back to the raw master tag label when the display label is empty", () =>
+    Effect.gen(function*() {
+      const result = yield* listMasterTags({ cardSpace: SPACE }).pipe(
+        Effect.provide(buildLayer({ spaces: [makeSpace()], masterTags: [makeTag({ label: tagLabel("") })] }))
+      )
+
+      expect(result.masterTags[0]).toEqual({ id: "tag-1", name: "" })
+    }))
+
+  it.effect("excludes classes outside the space type ancestry", () =>
+    Effect.gen(function*() {
+      const cycleA = "cycle-a" as Ref<HulyMasterTag>
+      const cycleB = "cycle-b" as Ref<HulyMasterTag>
+      const result = yield* listMasterTags({ cardSpace: SPACE }).pipe(
+        Effect.provide(buildLayer({
+          spaces: [makeSpace()],
+          masterTags: [
+            makeTag(),
+            makeTag({ _id: OTHER_TAG_ID, label: tagLabel("Other"), extends: cardPlugin.class.Card }),
+            makeTag({
+              _id: "missing-parent" as Ref<HulyMasterTag>,
+              label: tagLabel("Missing"),
+              extends: "missing" as never
+            }),
+            makeTag({ _id: cycleA, label: tagLabel("Cycle A"), extends: cycleB }),
+            makeTag({ _id: cycleB, label: tagLabel("Cycle B"), extends: cycleA })
+          ]
+        }))
+      )
+
+      expect(result.masterTags).toEqual([{ id: "tag-1", name: "Document" }])
+    }))
 })
 
 describe("listCards", () => {
@@ -307,6 +377,23 @@ describe("listCards", () => {
         Effect.provide(buildLayer({ spaces: [makeSpace()], masterTags: [makeTag()], cards: [makeCard()], captures }))
       )
       expect(captures.findAll?.query?._class).toBe(TAG_ID)
+    }))
+
+  it.effect("resolves the type filter by a derived master tag label", () =>
+    Effect.gen(function*() {
+      const captures: Captures = { findAll: {} }
+      yield* listCards({ cardSpace: SPACE, type: MasterTagIdentifier.make("Character") }).pipe(
+        Effect.provide(buildLayer({
+          spaces: [makeSpace()],
+          masterTags: [
+            makeTag(),
+            makeTag({ _id: CHILD_TAG_ID, label: tagLabel("Character"), extends: TAG_ID })
+          ],
+          cards: [makeCard({ _class: CHILD_TAG_ID })],
+          captures
+        }))
+      )
+      expect(captures.findAll?.query?._class).toBe(CHILD_TAG_ID)
     }))
 
   it.effect("applies a titleSearch (LIKE) filter, escaping wildcards", () =>
@@ -413,6 +500,26 @@ describe("createCard", () => {
       expect(captures.createDoc?.attributes?.parent).toBeNull()
       expect(captures.createDoc?.attributes?.parentInfo).toEqual([])
       expect(captures.uploadMarkup?.value).toBe("hello")
+    }))
+
+  it.effect("creates a card using a derived master tag id", () =>
+    Effect.gen(function*() {
+      const captures: Captures = { createDoc: {}, uploadMarkup: {} }
+      yield* createCard({
+        cardSpace: SPACE,
+        type: MasterTagIdentifier.make("tag-child-1"),
+        title: "New character"
+      }).pipe(Effect.provide(buildLayer({
+        spaces: [makeSpace()],
+        masterTags: [
+          makeTag(),
+          makeTag({ _id: CHILD_TAG_ID, label: tagLabel("Character"), extends: TAG_ID })
+        ],
+        captures
+      })))
+
+      expect(captures.createDoc?.class).toBe(CHILD_TAG_ID)
+      expect(captures.uploadMarkup?.value).toBe("")
     }))
 
   it.effect("creates a child card under a parent, threading parentInfo", () =>


### PR DESCRIPTION
codex 55

## Summary

Fixes #86.

This updates card master-tag resolution so LLM callers can use derived card types such as `Character`, not only the top-level master tags stored directly on `CardSpace.types`.

## Root Cause

`create_card` and card type filtering only queried master tags whose IDs were listed directly in the card space. Huly stores child card types as class descendants of those top-level types, so UI-created derived types were valid in Huly but invisible to this MCP resolver.

## Changes

- Added a shared card master-tag resolver that expands from a card space's top-level type refs to descendant classes that also descend from `card:class:Card`.
- Reused that resolver for `list_master_tags`, `create_card`, and typed `list_cards` filtering.
- Decoded Huly model labels for returned master-tag names so derived types appear as caller-facing labels like `Character`.
- Replaced the original per-class recursive ancestor walk with a reverse descendant graph using domain-typed `ObjectClassName` IDs.
- Added unit coverage for derived tags, missing ancestors, cycles, raw-label fallback, type filtering, and create-by-derived-ID.
- Added full Docker Huly integration coverage for the reported `Character` use case: create by label, get/type assertion, list by label, create by derived ID, get/type assertion, cleanup deletes.

## Validation

- `pnpm check-all`
- Full local Docker Huly integration suite: `286 passed, 0 failed, 35 skipped (of 321)`
- Targeted local repro against Docker Huly:
  - pre-fix `create_card` rejected `type: "Character"` and `type: "69a70f265423908262d44692"`
  - post-fix `list_master_tags Default` includes `Character`
  - post-fix `create_card` succeeds by `Character` label and by derived master-tag ID, `get_card` confirms `type: "69a70f265423908262d44692"`, cleanup deletes both cards

## Review Notes

- Manual review pass checked `.claude/review-rules.md` gates after implementation.
- Follow-up review removed bare primitive class-ID sets and the depth-limited recursive walk.
- Final helper lint has no warnings in the touched resolver; existing project-wide lint warnings remain non-fatal.