### PR TITLE
Add WebSite structured data for Google site name

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -46,6 +46,15 @@
       ]
     }
   </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Huly MCP",
+      "alternateName": "Huly MCP Server",
+      "url": "https://huly-mcp.dearlordylord.com/"
+    }
+  </script>
   <style>
     :root {
       color-scheme: dark;


### PR DESCRIPTION
## Problem
Google search shows the bold site-name line as `dearlordylord.com` instead of `Huly MCP` for https://huly-mcp.dearlordylord.com.

## Cause
The page already sets `og:site_name`, `application-name`, and `<title>` to "Huly MCP", but the only JSON-LD is `@type: SoftwareApplication`. Google's site-name algorithm reads `@type: WebSite` `name` for that line and ignores `SoftwareApplication.name`, so it falls back to the domain.

## Change
Add a `WebSite` JSON-LD block (`name: Huly MCP`, `alternateName: Huly MCP Server`) alongside the existing `SoftwareApplication` block in `site/index.html`.

## Caveats
- Site name is a hint, not a command. Outcome depends on re-crawl and Google's subdomain-vs-parent-domain judgment.
- After deploy, request indexing on the subdomain root in Search Console. Expect days-to-weeks.