### PR TITLE
Close tracker/document parity gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ Planned feature surfaces:
 - Notifications and activity: browser/push subscription internals, provider defaults, UI presenter/viewlet metadata, and activity control/extension metadata.
 - Attachments and media: previews/preview metadata and friendly wrappers for additional object types beyond issue/document.
 - Core schema and workspace administration: attribute/property create/update/delete/hide, enum CRUD/options, sequence management, role assignment mutations, role/permission definition writes, generic space creation, global space admins, integrations registry, invite settings, role capability settings, and workspace setting metadata.
-- Integrations: GitHub repository/project mappings and sync metadata, Google Calendar connect/configure/sync controls, Bitrix entity/field mappings and sync status, Gmail/email channel messages, Telegram messages, Huly Mail/Mail plugin behavior, AI assistant integration state, and AI bot configuration if server-side APIs expose stable behavior.
+- Integrations: GitHub repository/project mappings and sync metadata (deferred), Google Calendar connect/configure/sync controls, Bitrix entity/field mappings and sync status, Gmail/email channel messages, Telegram messages, Huly Mail/Mail plugin behavior, AI assistant integration state, and AI bot configuration if server-side APIs expose stable behavior.
 - Templates, rating, support, billing, analytics, views, workbench, and preferences: message templates/categories/fields, document/person rating data blocked by unpublished `@hcengineering/rating` SDK package (#90), support conversations, billing tier/status discovery, onboarding channels, saved filtered views, user view preferences, tabs/widgets/apps, and module preference discovery/update.
-- Document-specific gaps: document snapshots/history, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships, and document printing/export once SDK support is safe.
+- Document-specific gaps: snapshot restore, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships, and document printing/export once SDK support is safe.
 
 MCP resource roadmap:
 
@@ -328,6 +328,8 @@ SDK upgrade revisit:
 
 | Tool | Description |
 |------|-------------|
+| `list_project_target_preferences` | List low-level per-project tracker target preference records. These Huly ProjectTargetPreference records are attached to projects and used by tracker UI/workflows to remember target-related preference props. Omit project to list recent preferences across projects, or pass a project identifier to inspect one project's preference. Props are SDK-open key/value payloads. |
+| `upsert_project_target_preference` | Create or update the low-level ProjectTargetPreference record for a project. This refreshes usedOn and merges SDK-open target preference props by key. Use for tracker SDK parity or advanced administration; ordinary project and issue workflows usually do not need this tool. |
 | `list_projects` | List all Huly projects. Returns projects sorted by name. Supports filtering by archived status. |
 | `get_project` | Get full details of a Huly project including its statuses. Returns project name, description, archived flag, default status, and all available statuses. |
 | `list_statuses` | List all issue statuses for a Huly project with workflow category and default info. Returns status name, category, and isDefault. Use this to discover valid statuses before creating or updating issues. |
@@ -367,6 +369,9 @@ SDK upgrade revisit:
 | `list_issue_relations` | List all relations of an issue. Returns blockedBy (issues blocking this one), blocks (issues this one blocks), relations (bidirectional issue links), and documents (linked documents with title/teamspace). |
 | `link_document_to_issue` | Link a Huly document to an issue. The link appears in the issue's Relations panel in the UI. Idempotent: no-op if the document is already linked. Use list_issue_relations to see linked documents. |
 | `unlink_document_from_issue` | Remove a document link from an issue. Idempotent: no-op if the document is not linked. |
+| `list_related_issue_targets` | List rules that choose the default destination project for related issues. A spaceRule says related issues from one space default to targetProject. A classRule says related issues for one object class default to targetProject. targetProject is a project identifier, or null for no default destination project. |
+| `set_related_issue_target` | Set the default destination project for related issues from a space or object class. For space, creates or updates a spaceRule. For objectClass, only updates an existing classRule; this tool never creates classRule targets. Pass targetProject as a project identifier, or null to clear the default destination project. |
+| `delete_related_issue_space_target` | Delete the spaceRule that chooses the default destination project for related issues from one space. This only deletes spaceRule targets; classRule deletion is intentionally unsupported because class rules may be model-provided. |
 
 ### Comments
 
@@ -392,6 +397,8 @@ SDK upgrade revisit:
 
 | Tool | Description |
 |------|-------------|
+| `list_document_snapshots` | List version-history snapshots for one Huly document. A snapshot is a saved point-in-time copy from the document's change history. Resolve the document by teamspace plus document title or ID. Returns snapshotId, documentId, teamspaceId, title, parentDocumentId, and timestamps; markdown content is intentionally omitted. Use get_document_snapshot with snapshotId when reading content. |
+| `get_document_snapshot` | Get one point-in-time Huly document history snapshot and return markdown content. Resolve the document by teamspace plus document title or ID; resolve the snapshot by snapshotId, exact snapshot title, or exact createdOn timestamp. Prefer snapshotId from list_document_snapshots when titles or dates may collide. Restore is out of scope. |
 | `list_teamspaces` | List all Huly document teamspaces. Returns teamspaces sorted by name. Supports filtering by archived status. |
 | `get_teamspace` | Get details for a Huly document teamspace including document count. Finds by name or ID, including archived teamspaces. |
 | `create_teamspace` | Create a new Huly document teamspace. Idempotent: returns existing teamspace if one with the same name exists. |

--- a/plans/huly-sdk-gap-matrix.md
+++ b/plans/huly-sdk-gap-matrix.md
@@ -60,7 +60,7 @@ Current high-level MCP categories:
 | View / saved filtered views | `.reference/platform/models/view/src/index.ts`: `FilteredView`, `Viewlet`, actions, view preferences | No saved-view tools; list tools accept ad hoc filters | Saved filtered views, user view preferences, viewlet descriptors, reusable filters/sorts/groups |
 | Workbench tabs/widgets/apps | `.reference/platform/models/workbench/src/index.ts`: `Application`, `ApplicationNavModel`, `HiddenApplication`, `Widget`, `WidgetPreference`, `WorkbenchTab` | No workbench UI state tools | List/hide apps, tabs, widgets, widget prefs. Mostly UI state, lower MCP priority |
 | Preference model | `.reference/platform/models/preference`; many modules store preferences | No generic preference tools | User preferences discovery/update for modules with preference-backed settings |
-| Document preferences and history | Installed `@hcengineering/document`; `node_modules/@hcengineering/document/types/types.d.ts` still exposes stale `SavedDocument extends Preference` plus `DocumentSnapshot`. Current platform source removed the `SavedDocument` model in hcengineering/platform#10124 and replaced document stars with rating-backed `DocReaction` / `ReactionKind.Star` | Document tools cover teamspaces, document CRUD, content edit, inline comments, relations, and deletion; no snapshot/history tools | List/read document snapshots/history before considering restore semantics. Do not implement `SavedDocument` as SDK parity unless the platform model is restored; current document stars belong to the Rating / reputation row |
+| Document preferences and history | Installed `@hcengineering/document`; `node_modules/@hcengineering/document/types/types.d.ts` still exposes stale `SavedDocument extends Preference` plus `DocumentSnapshot`. Current platform source removed the `SavedDocument` model in hcengineering/platform#10124 and replaced document stars with rating-backed `DocReaction` / `ReactionKind.Star` | Document tools cover teamspaces, document CRUD, content edit, inline comments, relations, deletion, and read-only snapshot/history list/get. | Snapshot restore remains deferred until restore semantics are proven. Do not implement `SavedDocument` as SDK parity unless the platform model is restored; current document stars belong to the Rating / reputation row |
 
 ## Installed SDK Packages With Partial MCP Coverage
 
@@ -74,12 +74,12 @@ Current high-level MCP categories:
 | `@hcengineering/chunter` | Partial | Group DMs, channel membership, join/leave, pin/star/archive semantics, message attachments/translation |
 | `@hcengineering/contact` | Partial | Person channels/social identities, employee invite/kick/reinvite, merge contacts, contact statuses |
 | `@hcengineering/core` | Partial | Attribute/enum writes, role assignment mutations, role/permission definition writes, generic space creation, collaborators, sequences |
-| `@hcengineering/document` | Partial | Snapshots/history, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships |
+| `@hcengineering/document` | Partial | Snapshot restore, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships |
 | `@hcengineering/notification` | Partial | Mute contexts, notification type settings, collaborators |
 | `@hcengineering/tags` | SDK-level covered; module wrappers partial | Module-specific wrappers for tag-backed concepts such as recruiting skills, board labels, controlled-doc labels, and contact tags |
 | `@hcengineering/task` | Partial | Generic task/project abstractions beyond tracker, reusable task workflows |
 | `@hcengineering/time` | Partial | ToDo/action item lifecycle, personal planner, visibility, schedule reports |
-| `@hcengineering/tracker` | Strong but partial | GitHub pull-request task type/sync details, PDF export, saved views, some workflow automation behavior |
+| `@hcengineering/tracker` | Strong but partial | GitHub pull-request task type/sync details, PDF export, saved views beyond ProjectTargetPreference, tracker-local Document support type, and broader workflow automation behavior |
 
 ## Highest-Value Additions For LLM Agents
 

--- a/plans/sdk-parity-ledger.json
+++ b/plans/sdk-parity-ledger.json
@@ -370,19 +370,11 @@
       "package": "@hcengineering/document",
       "status": "covered",
       "matrixLocation": "Document preferences and history",
-      "rationale": "Current document tools cover non-controlled document teamspaces and document CRUD/content operations.",
+      "rationale": "Current document tools cover non-controlled document teamspaces, document CRUD/content operations, and read-only snapshot/history listing plus markdown retrieval. Snapshot restore and document PDF/export remain deferred.",
       "exports": [
         "Document",
+        "DocumentSnapshot",
         "Teamspace"
-      ]
-    },
-    {
-      "package": "@hcengineering/document",
-      "status": "gap",
-      "matrixLocation": "Document preferences and history",
-      "rationale": "Document snapshots/history are represented in the matrix but not yet first-class MCP tools.",
-      "exports": [
-        "DocumentSnapshot"
       ]
     },
     {
@@ -513,7 +505,7 @@
       "package": "@hcengineering/tracker",
       "status": "covered",
       "matrixLocation": "`@hcengineering/tracker` package row",
-      "rationale": "Current project, issue, component, milestone, issue-template, status, relation, and time-reporting tools cover core tracker resources.",
+      "rationale": "Current project, issue, component, milestone, issue-template, status, relation, related-issue target, project target preference, and time-reporting tools cover core tracker resources. GitHub sync metadata, PDF export, saved views, and broader workflow automation remain deferred.",
       "exports": [
         "Component",
         "Issue",
@@ -521,17 +513,9 @@
         "IssueTemplate",
         "Milestone",
         "Project",
+        "ProjectTargetPreference",
         "RelatedIssueTarget",
         "TimeSpendReport"
-      ]
-    },
-    {
-      "package": "@hcengineering/tracker",
-      "status": "gap",
-      "matrixLocation": "`@hcengineering/tracker` package row",
-      "rationale": "Tracker preference/saved-view and workflow automation behavior remains partial in the matrix.",
-      "exports": [
-        "ProjectTargetPreference"
       ]
     },
     {

--- a/src/domain/schemas/document-snapshots.ts
+++ b/src/domain/schemas/document-snapshots.ts
@@ -1,0 +1,101 @@
+import { JSONSchema, Schema } from "effect"
+
+import type { ListTotal } from "./shared.js"
+import {
+  DEFAULT_LIMIT,
+  DocId,
+  DocumentId,
+  DocumentIdentifier,
+  LimitParam,
+  NonEmptyString,
+  TeamspaceId,
+  TeamspaceIdentifier,
+  Timestamp
+} from "./shared.js"
+
+export const DocumentSnapshotId = DocId.pipe(Schema.brand("DocumentSnapshotId"))
+export type DocumentSnapshotId = Schema.Schema.Type<typeof DocumentSnapshotId>
+
+export const DocumentSnapshotIdentifier = NonEmptyString.pipe(Schema.brand("DocumentSnapshotIdentifier"))
+export type DocumentSnapshotIdentifier = Schema.Schema.Type<typeof DocumentSnapshotIdentifier>
+
+export const DocumentSnapshotTitle = NonEmptyString.pipe(Schema.brand("DocumentSnapshotTitle"))
+export type DocumentSnapshotTitle = Schema.Schema.Type<typeof DocumentSnapshotTitle>
+
+export const DocumentMarkdown = Schema.String.pipe(Schema.brand("DocumentMarkdown")).annotations({
+  identifier: "DocumentMarkdown",
+  title: "DocumentMarkdown",
+  description: "Markdown document content. Empty string is valid for an empty Huly document body."
+})
+export type DocumentMarkdown = Schema.Schema.Type<typeof DocumentMarkdown>
+
+export const ListDocumentSnapshotsParamsSchema = Schema.Struct({
+  teamspace: TeamspaceIdentifier.annotations({
+    description: "Document teamspace name or ID."
+  }),
+  document: DocumentIdentifier.annotations({
+    description: "Document title or ID within the teamspace."
+  }),
+  limit: Schema.optional(
+    LimitParam.annotations({
+      description: `Maximum number of snapshots to return (default: ${DEFAULT_LIMIT}).`
+    })
+  )
+}).annotations({
+  title: "ListDocumentSnapshotsParams",
+  description: "List version-history snapshots for one Huly document. Each snapshot is a point-in-time copy."
+})
+export type ListDocumentSnapshotsParams = Schema.Schema.Type<typeof ListDocumentSnapshotsParamsSchema>
+
+export const GetDocumentSnapshotParamsSchema = Schema.Struct({
+  teamspace: TeamspaceIdentifier.annotations({
+    description: "Document teamspace name or ID."
+  }),
+  document: DocumentIdentifier.annotations({
+    description: "Document title or ID within the teamspace."
+  }),
+  snapshot: DocumentSnapshotIdentifier.annotations({
+    description:
+      "Snapshot ID, exact snapshot title, or exact createdOn timestamp in milliseconds. Use list_document_snapshots first when unsure."
+  })
+}).annotations({
+  title: "GetDocumentSnapshotParams",
+  description: "Get one point-in-time document history snapshot and return its markdown content."
+})
+export type GetDocumentSnapshotParams = Schema.Schema.Type<typeof GetDocumentSnapshotParamsSchema>
+
+export const DocumentSnapshotSummarySchema = Schema.Struct({
+  snapshotId: DocumentSnapshotId,
+  documentId: DocumentId,
+  teamspaceId: TeamspaceId,
+  title: DocumentSnapshotTitle,
+  parentDocumentId: DocumentId,
+  createdOn: Schema.optional(Timestamp),
+  modifiedOn: Schema.optional(Timestamp)
+}).annotations({
+  title: "DocumentSnapshotSummary",
+  description: "Point-in-time document history snapshot metadata without content."
+})
+export type DocumentSnapshotSummary = Schema.Schema.Type<typeof DocumentSnapshotSummarySchema>
+
+export const DocumentSnapshotSchema = Schema.Struct({
+  ...DocumentSnapshotSummarySchema.fields,
+  markdown: Schema.optional(DocumentMarkdown)
+}).annotations({
+  title: "DocumentSnapshot",
+  description: "Point-in-time document history snapshot metadata with markdown content."
+})
+export type DocumentSnapshot = Schema.Schema.Type<typeof DocumentSnapshotSchema>
+
+export interface ListDocumentSnapshotsResult {
+  readonly snapshots: ReadonlyArray<DocumentSnapshotSummary>
+  readonly total: ListTotal
+}
+
+export type GetDocumentSnapshotResult = DocumentSnapshot
+
+export const listDocumentSnapshotsParamsJsonSchema = JSONSchema.make(ListDocumentSnapshotsParamsSchema)
+export const getDocumentSnapshotParamsJsonSchema = JSONSchema.make(GetDocumentSnapshotParamsSchema)
+
+export const parseListDocumentSnapshotsParams = Schema.decodeUnknown(ListDocumentSnapshotsParamsSchema)
+export const parseGetDocumentSnapshotParams = Schema.decodeUnknown(GetDocumentSnapshotParamsSchema)

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -268,6 +268,25 @@ export {
 } from "./projects.js"
 
 export {
+  type ListProjectTargetPreferencesParams,
+  listProjectTargetPreferencesParamsJsonSchema,
+  ListProjectTargetPreferencesParamsSchema,
+  type ListProjectTargetPreferencesResult,
+  parseListProjectTargetPreferencesParams,
+  parseUpsertProjectTargetPreferenceParams,
+  type ProjectTargetPreference,
+  ProjectTargetPreferenceId,
+  type ProjectTargetPreferenceProperty,
+  ProjectTargetPreferencePropertySchema,
+  ProjectTargetPreferenceSchema,
+  TrackerPreferencePropertyKey,
+  type UpsertProjectTargetPreferenceParams,
+  upsertProjectTargetPreferenceParamsJsonSchema,
+  UpsertProjectTargetPreferenceParamsSchema,
+  type UpsertProjectTargetPreferenceResult
+} from "./project-target-preferences.js"
+
+export {
   type CreateIssueStatusParams,
   createIssueStatusParamsJsonSchema,
   CreateIssueStatusParamsSchema,
@@ -511,6 +530,29 @@ export {
 } from "./issues.js"
 
 export {
+  type DeleteRelatedIssueSpaceTargetParams,
+  deleteRelatedIssueSpaceTargetParamsJsonSchema,
+  DeleteRelatedIssueSpaceTargetParamsSchema,
+  type DeleteRelatedIssueSpaceTargetResult,
+  type ListRelatedIssueTargetsParams,
+  listRelatedIssueTargetsParamsJsonSchema,
+  ListRelatedIssueTargetsParamsSchema,
+  type ListRelatedIssueTargetsResult,
+  parseDeleteRelatedIssueSpaceTargetParams,
+  parseListRelatedIssueTargetsParams,
+  parseSetRelatedIssueTargetParams,
+  type RelatedIssueTarget,
+  RelatedIssueTargetId,
+  type RelatedIssueTargetRule,
+  RelatedIssueTargetRuleSchema,
+  RelatedIssueTargetSchema,
+  type SetRelatedIssueTargetParams,
+  setRelatedIssueTargetParamsJsonSchema,
+  SetRelatedIssueTargetParamsSchema,
+  type SetRelatedIssueTargetResult
+} from "./related-issue-targets.js"
+
+export {
   type Component,
   ComponentSchema,
   type ComponentSummary,
@@ -710,6 +752,27 @@ export {
   DOCUMENT_NATIVE_REFERENCE_LINK_USAGE,
   DOCUMENT_NATIVE_REFERENCE_TOOL_USAGE
 } from "./document-native-references.js"
+
+export {
+  DocumentMarkdown,
+  type DocumentSnapshot,
+  DocumentSnapshotId,
+  DocumentSnapshotIdentifier,
+  DocumentSnapshotSchema,
+  type DocumentSnapshotSummary,
+  DocumentSnapshotSummarySchema,
+  DocumentSnapshotTitle,
+  type GetDocumentSnapshotParams,
+  getDocumentSnapshotParamsJsonSchema,
+  GetDocumentSnapshotParamsSchema,
+  type GetDocumentSnapshotResult,
+  type ListDocumentSnapshotsParams,
+  listDocumentSnapshotsParamsJsonSchema,
+  ListDocumentSnapshotsParamsSchema,
+  type ListDocumentSnapshotsResult,
+  parseGetDocumentSnapshotParams,
+  parseListDocumentSnapshotsParams
+} from "./document-snapshots.js"
 
 export {
   type CreateDocumentParams,

--- a/src/domain/schemas/project-target-preferences.ts
+++ b/src/domain/schemas/project-target-preferences.ts
@@ -1,0 +1,87 @@
+import { JSONSchema, Schema } from "effect"
+
+import type { ListTotal } from "./shared.js"
+import { DEFAULT_LIMIT, DocId, LimitParam, NonEmptyString, ProjectIdentifier, SpaceId, Timestamp } from "./shared.js"
+
+export const ProjectTargetPreferenceId = DocId.pipe(Schema.brand("ProjectTargetPreferenceId"))
+export type ProjectTargetPreferenceId = Schema.Schema.Type<typeof ProjectTargetPreferenceId>
+
+export const TrackerPreferencePropertyKey = NonEmptyString.pipe(Schema.brand("TrackerPreferencePropertyKey"))
+export type TrackerPreferencePropertyKey = Schema.Schema.Type<typeof TrackerPreferencePropertyKey>
+
+export const ProjectTargetPreferencePropertySchema = Schema.Struct({
+  key: TrackerPreferencePropertyKey.annotations({
+    description: "Low-level tracker target preference property key. Huly stores arbitrary preference keys here."
+  }),
+  value: Schema.Unknown.annotations({
+    description: "SDK-open target preference property value. Passed through to Huly without narrowing."
+  })
+}).annotations({
+  title: "ProjectTargetPreferenceProperty",
+  description: "One SDK-open low-level ProjectTargetPreference props entry."
+})
+export type ProjectTargetPreferenceProperty = Schema.Schema.Type<typeof ProjectTargetPreferencePropertySchema>
+
+export const ListProjectTargetPreferencesParamsSchema = Schema.Struct({
+  project: Schema.optional(ProjectIdentifier.annotations({
+    description:
+      "Optional project identifier. Omit to list recent low-level project target preference records across projects."
+  })),
+  limit: Schema.optional(
+    LimitParam.annotations({
+      description: `Maximum number of preferences to return (default: ${DEFAULT_LIMIT}).`
+    })
+  )
+}).annotations({
+  title: "ListProjectTargetPreferencesParams",
+  description: "List low-level Huly tracker ProjectTargetPreference records, sorted by most recently used."
+})
+export type ListProjectTargetPreferencesParams = Schema.Schema.Type<typeof ListProjectTargetPreferencesParamsSchema>
+
+export const UpsertProjectTargetPreferenceParamsSchema = Schema.Struct({
+  project: ProjectIdentifier.annotations({
+    description: "Project identifier whose low-level ProjectTargetPreference record should be created or updated."
+  }),
+  props: Schema.optional(
+    Schema.Array(ProjectTargetPreferencePropertySchema).annotations({
+      description:
+        "Optional SDK-open target preference props to merge by key. Existing keys are replaced; other existing props are preserved."
+    })
+  )
+}).annotations({
+  title: "UpsertProjectTargetPreferenceParams",
+  description:
+    "Create or update the low-level ProjectTargetPreference record for a project. The operation always refreshes usedOn from Effect.Clock."
+})
+export type UpsertProjectTargetPreferenceParams = Schema.Schema.Type<typeof UpsertProjectTargetPreferenceParamsSchema>
+
+export const ProjectTargetPreferenceSchema = Schema.Struct({
+  preferenceId: ProjectTargetPreferenceId,
+  attachedTo: SpaceId.annotations({
+    description: "Raw project space ID stored in low-level ProjectTargetPreference.attachedTo."
+  }),
+  project: Schema.optional(ProjectIdentifier),
+  usedOn: Timestamp,
+  props: Schema.Array(ProjectTargetPreferencePropertySchema)
+}).annotations({
+  title: "ProjectTargetPreference",
+  description:
+    "Low-level Huly tracker ProjectTargetPreference record used by tracker UI/workflows to remember target-related preference props."
+})
+export type ProjectTargetPreference = Schema.Schema.Type<typeof ProjectTargetPreferenceSchema>
+
+export interface ListProjectTargetPreferencesResult {
+  readonly preferences: ReadonlyArray<ProjectTargetPreference>
+  readonly total: ListTotal
+}
+
+export interface UpsertProjectTargetPreferenceResult {
+  readonly preference: ProjectTargetPreference
+  readonly created: boolean
+}
+
+export const listProjectTargetPreferencesParamsJsonSchema = JSONSchema.make(ListProjectTargetPreferencesParamsSchema)
+export const upsertProjectTargetPreferenceParamsJsonSchema = JSONSchema.make(UpsertProjectTargetPreferenceParamsSchema)
+
+export const parseListProjectTargetPreferencesParams = Schema.decodeUnknown(ListProjectTargetPreferencesParamsSchema)
+export const parseUpsertProjectTargetPreferenceParams = Schema.decodeUnknown(UpsertProjectTargetPreferenceParamsSchema)

--- a/src/domain/schemas/related-issue-targets.ts
+++ b/src/domain/schemas/related-issue-targets.ts
@@ -1,0 +1,146 @@
+import { JSONSchema, Schema } from "effect"
+
+import type { ListTotal } from "./shared.js"
+import {
+  DEFAULT_LIMIT,
+  DocId,
+  hasAtLeastOneDefined,
+  hasMutuallyExclusiveFields,
+  LimitParam,
+  ObjectClassName,
+  ProjectIdentifier,
+  SpaceId,
+  SpaceIdentifier,
+  Timestamp
+} from "./shared.js"
+
+export const RelatedIssueTargetId = DocId.pipe(Schema.brand("RelatedIssueTargetId"))
+export type RelatedIssueTargetId = Schema.Schema.Type<typeof RelatedIssueTargetId>
+
+export const RelatedIssueTargetRuleSchema = Schema.Union(
+  Schema.Struct({
+    kind: Schema.Literal("spaceRule"),
+    spaceId: SpaceId,
+    spaceName: Schema.optional(SpaceIdentifier),
+    spaceClass: Schema.optional(ObjectClassName)
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("classRule"),
+    objectClass: ObjectClassName
+  })
+).annotations({
+  title: "RelatedIssueTargetRule",
+  description: "Rule that selects which source objects use a default destination project for related issues."
+})
+export type RelatedIssueTargetRule = Schema.Schema.Type<typeof RelatedIssueTargetRuleSchema>
+
+export const RelatedIssueTargetSchema = Schema.Struct({
+  targetId: RelatedIssueTargetId,
+  rule: RelatedIssueTargetRuleSchema,
+  targetProject: Schema.NullOr(ProjectIdentifier),
+  createdOn: Schema.optional(Timestamp),
+  modifiedOn: Schema.optional(Timestamp)
+}).annotations({
+  title: "RelatedIssueTarget",
+  description: "Huly tracker rule for choosing the default destination project for related issues."
+})
+export type RelatedIssueTarget = Schema.Schema.Type<typeof RelatedIssueTargetSchema>
+
+export const ListRelatedIssueTargetsParamsSchema = Schema.Struct({
+  space: Schema.optional(SpaceIdentifier.annotations({
+    description:
+      "Optional source space name or ID. When provided, returns only the spaceRule that sets that space's default related-issue destination project."
+  })),
+  objectClass: Schema.optional(ObjectClassName.annotations({
+    description:
+      "Optional exact Huly object class ID. When provided, returns only the classRule that sets that class's default related-issue destination project."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: `Maximum number of related issue targets to return (default: ${DEFAULT_LIMIT}).`
+  }))
+}).pipe(
+  Schema.filter((params) =>
+    hasMutuallyExclusiveFields(params, ["space", "objectClass"])
+      ? "Provide only one of space or objectClass."
+      : undefined
+  )
+).annotations({
+  title: "ListRelatedIssueTargetsParams",
+  description:
+    "List rules that choose the default destination project for related issues. Filter by either a source space locator or an exact object class ID."
+})
+export type ListRelatedIssueTargetsParams = Schema.Schema.Type<typeof ListRelatedIssueTargetsParamsSchema>
+
+const RelatedIssueTargetLocatorFields = {
+  space: Schema.optional(SpaceIdentifier.annotations({
+    description:
+      "Source space name or ID for a spaceRule. Space rules set the default destination project for related issues from that space and can be created or updated by this tool."
+  })),
+  objectClass: Schema.optional(ObjectClassName.annotations({
+    description:
+      "Exact Huly object class ID for an existing classRule. Class rules set the default destination project for related issues from that object class and can only have their targetProject updated."
+  }))
+}
+
+const validateRelatedIssueTargetLocator = (
+  params: { readonly space?: unknown; readonly objectClass?: unknown }
+): string | undefined => {
+  if (!hasAtLeastOneDefined(params, ["space", "objectClass"])) {
+    return "Provide one of space or objectClass."
+  }
+  if (hasMutuallyExclusiveFields(params, ["space", "objectClass"])) {
+    return "Provide only one of space or objectClass."
+  }
+  return undefined
+}
+
+export const SetRelatedIssueTargetParamsSchema = Schema.Struct({
+  ...RelatedIssueTargetLocatorFields,
+  targetProject: Schema.NullOr(ProjectIdentifier).annotations({
+    description:
+      "Default destination project identifier for related issues from the selected space or object class, or null to clear the default destination project."
+  })
+}).pipe(
+  Schema.filter(validateRelatedIssueTargetLocator)
+).annotations({
+  title: "SetRelatedIssueTargetParams",
+  description:
+    "Create/update a spaceRule or update an existing classRule that chooses the default destination project for related issues. Class rules are not created by this tool."
+})
+export type SetRelatedIssueTargetParams = Schema.Schema.Type<typeof SetRelatedIssueTargetParamsSchema>
+
+export const DeleteRelatedIssueSpaceTargetParamsSchema = Schema.Struct({
+  space: SpaceIdentifier.annotations({
+    description: "Source space name or ID whose spaceRule default related-issue destination project should be deleted."
+  })
+}).annotations({
+  title: "DeleteRelatedIssueSpaceTargetParams",
+  description:
+    "Delete a spaceRule that chooses the default destination project for related issues from one space. Class rules cannot be deleted by this tool."
+})
+export type DeleteRelatedIssueSpaceTargetParams = Schema.Schema.Type<typeof DeleteRelatedIssueSpaceTargetParamsSchema>
+
+export interface ListRelatedIssueTargetsResult {
+  readonly targets: ReadonlyArray<RelatedIssueTarget>
+  readonly total: ListTotal
+}
+
+export interface SetRelatedIssueTargetResult {
+  readonly target: RelatedIssueTarget
+  readonly created: boolean
+}
+
+export interface DeleteRelatedIssueSpaceTargetResult {
+  readonly targetId: RelatedIssueTargetId
+  readonly deleted: boolean
+}
+
+export const listRelatedIssueTargetsParamsJsonSchema = JSONSchema.make(ListRelatedIssueTargetsParamsSchema)
+export const setRelatedIssueTargetParamsJsonSchema = JSONSchema.make(SetRelatedIssueTargetParamsSchema)
+export const deleteRelatedIssueSpaceTargetParamsJsonSchema = JSONSchema.make(DeleteRelatedIssueSpaceTargetParamsSchema)
+
+export const parseListRelatedIssueTargetsParams = Schema.decodeUnknown(ListRelatedIssueTargetsParamsSchema)
+export const parseSetRelatedIssueTargetParams = Schema.decodeUnknown(SetRelatedIssueTargetParamsSchema)
+export const parseDeleteRelatedIssueSpaceTargetParams = Schema.decodeUnknown(
+  DeleteRelatedIssueSpaceTargetParamsSchema
+)

--- a/src/huly/operations/document-snapshots.ts
+++ b/src/huly/operations/document-snapshots.ts
@@ -1,0 +1,146 @@
+import { type Ref, SortingOrder } from "@hcengineering/core"
+import type {
+  Document as HulyDocument,
+  DocumentSnapshot as HulyDocumentSnapshot,
+  Teamspace as HulyTeamspace
+} from "@hcengineering/document"
+import { Effect } from "effect"
+
+import type {
+  DocumentSnapshot,
+  DocumentSnapshotSummary,
+  GetDocumentSnapshotParams,
+  GetDocumentSnapshotResult,
+  ListDocumentSnapshotsParams,
+  ListDocumentSnapshotsResult
+} from "../../domain/schemas/document-snapshots.js"
+import { DocumentMarkdown, DocumentSnapshotId, DocumentSnapshotTitle } from "../../domain/schemas/document-snapshots.js"
+import { DocumentId, TeamspaceId, Timestamp } from "../../domain/schemas/shared.js"
+import type { HulyClient, HulyClientError } from "../client.js"
+import type { DocumentContentCorruptedError, DocumentNotFoundError, TeamspaceNotFoundError } from "../errors.js"
+import { HulyError } from "../errors.js"
+import { documentPlugin } from "../huly-plugins.js"
+import { listTotal } from "./counts.js"
+import { findTeamspaceAndDocument } from "./documents-shared.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { toRef } from "./sdk-boundary.js"
+
+type DocumentSnapshotDoc = HulyDocumentSnapshot & {
+  readonly attachedTo: Ref<HulyDocument>
+}
+
+type ListDocumentSnapshotsError =
+  | HulyClientError
+  | TeamspaceNotFoundError
+  | DocumentNotFoundError
+
+type GetDocumentSnapshotError =
+  | ListDocumentSnapshotsError
+  | DocumentContentCorruptedError
+  | HulyError
+
+const snapshotSummary = (
+  snapshot: DocumentSnapshotDoc,
+  doc: HulyDocument,
+  teamspaceId: Ref<HulyTeamspace>
+): DocumentSnapshotSummary => ({
+  snapshotId: DocumentSnapshotId.make(snapshot._id),
+  documentId: DocumentId.make(doc._id),
+  teamspaceId: TeamspaceId.make(teamspaceId),
+  title: DocumentSnapshotTitle.make(snapshot.title),
+  parentDocumentId: DocumentId.make(snapshot.parent),
+  createdOn: snapshot.createdOn === undefined ? undefined : Timestamp.make(snapshot.createdOn),
+  modifiedOn: Timestamp.make(snapshot.modifiedOn)
+})
+
+const snapshotResult = (
+  snapshot: DocumentSnapshotDoc,
+  doc: HulyDocument,
+  teamspaceId: Ref<HulyTeamspace>,
+  markdown: string
+): DocumentSnapshot => ({
+  ...snapshotSummary(snapshot, doc, teamspaceId),
+  markdown: DocumentMarkdown.make(markdown)
+})
+
+const findSnapshotByIdentifier = (
+  client: HulyClient["Type"],
+  doc: HulyDocument,
+  identifier: GetDocumentSnapshotParams["snapshot"]
+): Effect.Effect<DocumentSnapshotDoc, HulyClientError | HulyError> =>
+  Effect.gen(function*() {
+    const byId = yield* client.findOne<DocumentSnapshotDoc>(
+      documentPlugin.class.DocumentSnapshot,
+      hulyQuery<DocumentSnapshotDoc>({ attachedTo: doc._id, _id: toRef<DocumentSnapshotDoc>(identifier) })
+    )
+    if (byId !== undefined) return byId
+
+    const titleMatches = yield* client.findAll<DocumentSnapshotDoc>(
+      documentPlugin.class.DocumentSnapshot,
+      hulyQuery<DocumentSnapshotDoc>({ attachedTo: doc._id, title: identifier }),
+      { limit: 2 }
+    )
+    if (titleMatches.length === 1) return titleMatches[0]
+    if (titleMatches.length > 1) {
+      return yield* new HulyError({
+        message:
+          `Multiple snapshots on document '${doc.title}' have title '${identifier}'. Use the snapshotId from list_document_snapshots.`
+      })
+    }
+
+    const createdOn = Number(identifier)
+    const dateMatches = Number.isSafeInteger(createdOn)
+      ? yield* client.findAll<DocumentSnapshotDoc>(
+        documentPlugin.class.DocumentSnapshot,
+        hulyQuery<DocumentSnapshotDoc>({ attachedTo: doc._id, createdOn }),
+        { limit: 2 }
+      )
+      : []
+    if (dateMatches.length === 1) return dateMatches[0]
+    if (dateMatches.length > 1) {
+      return yield* new HulyError({
+        message:
+          `Multiple snapshots on document '${doc.title}' have createdOn '${identifier}'. Use the snapshotId from list_document_snapshots.`
+      })
+    }
+
+    return yield* new HulyError({
+      message: `Snapshot '${identifier}' was not found on document '${doc.title}'.`
+    })
+  })
+
+export const listDocumentSnapshots = (
+  params: ListDocumentSnapshotsParams
+): Effect.Effect<ListDocumentSnapshotsResult, ListDocumentSnapshotsError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, doc, teamspace } = yield* findTeamspaceAndDocument(params)
+    const limit = clampLimit(params.limit)
+    const query: StrictDocumentQuery<DocumentSnapshotDoc> = { attachedTo: doc._id }
+    const snapshots = yield* client.findAll<DocumentSnapshotDoc>(
+      documentPlugin.class.DocumentSnapshot,
+      hulyQuery(query),
+      { limit, sort: { createdOn: SortingOrder.Descending }, total: true }
+    )
+
+    return {
+      snapshots: snapshots.map((snapshot) => snapshotSummary(snapshot, doc, teamspace._id)),
+      total: listTotal(snapshots.total)
+    }
+  })
+
+export const getDocumentSnapshot = (
+  params: GetDocumentSnapshotParams
+): Effect.Effect<GetDocumentSnapshotResult, GetDocumentSnapshotError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, doc, teamspace } = yield* findTeamspaceAndDocument(params)
+    const snapshot = yield* findSnapshotByIdentifier(client, doc, params.snapshot)
+    const markdown = yield* client.fetchMarkup(
+      documentPlugin.class.DocumentSnapshot,
+      snapshot._id,
+      "content",
+      snapshot.content,
+      "markdown"
+    )
+
+    return snapshotResult(snapshot, doc, teamspace._id, markdown)
+  })

--- a/src/huly/operations/project-target-preferences.ts
+++ b/src/huly/operations/project-target-preferences.ts
@@ -1,0 +1,150 @@
+import { Clock, Effect } from "effect"
+
+import { type Data, type DocumentUpdate, generateId, type Ref, SortingOrder, type Space } from "@hcengineering/core"
+import type {
+  Project as HulyProject,
+  ProjectTargetPreference as HulyProjectTargetPreference
+} from "@hcengineering/tracker"
+
+import type {
+  ListProjectTargetPreferencesParams,
+  ListProjectTargetPreferencesResult,
+  ProjectTargetPreference,
+  ProjectTargetPreferenceProperty,
+  UpsertProjectTargetPreferenceParams,
+  UpsertProjectTargetPreferenceResult
+} from "../../domain/schemas/project-target-preferences.js"
+import {
+  ProjectTargetPreferenceId,
+  TrackerPreferencePropertyKey
+} from "../../domain/schemas/project-target-preferences.js"
+import { ProjectIdentifier, SpaceId, Timestamp } from "../../domain/schemas/shared.js"
+import { HulyClient, type HulyClientError } from "../client.js"
+import type { ProjectNotFoundError } from "../errors.js"
+import { tracker } from "../huly-plugins.js"
+import { listTotal } from "./counts.js"
+import { findProject } from "./issues-shared.js"
+import { clampLimit, hulyQuery } from "./query-helpers.js"
+import { toRef } from "./sdk-boundary.js"
+
+type ListProjectTargetPreferencesError = HulyClientError | ProjectNotFoundError
+type UpsertProjectTargetPreferenceError = HulyClientError | ProjectNotFoundError
+
+type ProjectTargetPreferenceProjection =
+  & Pick<HulyProjectTargetPreference, "_id" | "attachedTo" | "usedOn">
+  & {
+    readonly props?: HulyProjectTargetPreference["props"] | undefined
+  }
+
+const projectMapById = (
+  client: HulyClient["Type"],
+  ids: ReadonlyArray<Ref<HulyProject>>
+): Effect.Effect<ReadonlyMap<Ref<HulyProject>, HulyProject>, HulyClientError> =>
+  Effect.gen(function*() {
+    const uniqueIds = [...new Set(ids)]
+    if (uniqueIds.length === 0) return new Map<Ref<HulyProject>, HulyProject>()
+
+    const projects = yield* client.findAll<HulyProject>(
+      tracker.class.Project,
+      hulyQuery<HulyProject>({ _id: { $in: uniqueIds } }),
+      { limit: uniqueIds.length }
+    )
+
+    const entries = projects.map((project): readonly [Ref<HulyProject>, HulyProject] => [project._id, project])
+    return new Map<Ref<HulyProject>, HulyProject>(entries)
+  })
+
+const preferenceResult = (
+  preference: ProjectTargetPreferenceProjection,
+  project: HulyProject | undefined
+): ProjectTargetPreference => ({
+  preferenceId: ProjectTargetPreferenceId.make(preference._id),
+  attachedTo: SpaceId.make(preference.attachedTo),
+  project: project === undefined ? undefined : ProjectIdentifier.make(project.identifier),
+  usedOn: Timestamp.make(preference.usedOn),
+  props: (preference.props ?? []).map((prop) => ({
+    key: TrackerPreferencePropertyKey.make(prop.key),
+    value: prop.value
+  }))
+})
+
+const propertyKey = (property: ProjectTargetPreferenceProperty): string => property.key
+
+const mergeProps = (
+  current: ReadonlyArray<{ readonly key: string; readonly value: unknown }> | undefined,
+  updates: ReadonlyArray<ProjectTargetPreferenceProperty> | undefined
+): Array<{ readonly key: string; readonly value: unknown }> => {
+  if (updates === undefined) return [...(current ?? [])]
+  const updateByKey = new Map(updates.map((property) => [propertyKey(property), property.value]))
+  const preserved = (current ?? []).filter((property) => !updateByKey.has(property.key))
+  const replacements = updates.map((property) => ({ key: property.key, value: property.value }))
+  return [...preserved, ...replacements]
+}
+
+export const listProjectTargetPreferences = (
+  params: ListProjectTargetPreferencesParams
+): Effect.Effect<ListProjectTargetPreferencesResult, ListProjectTargetPreferencesError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const project = params.project === undefined ? undefined : (yield* findProject(params.project)).project
+    const preferences = yield* client.findAll<HulyProjectTargetPreference>(
+      tracker.class.ProjectTargetPreference,
+      hulyQuery<HulyProjectTargetPreference>(
+        project === undefined ? {} : { attachedTo: project._id }
+      ),
+      { limit: clampLimit(params.limit), sort: { usedOn: SortingOrder.Descending }, total: true }
+    )
+    const projects = yield* projectMapById(client, preferences.map((preference) => preference.attachedTo))
+
+    return {
+      preferences: preferences.map((preference) => preferenceResult(preference, projects.get(preference.attachedTo))),
+      total: listTotal(preferences.total)
+    }
+  })
+
+export const upsertProjectTargetPreference = (
+  params: UpsertProjectTargetPreferenceParams
+): Effect.Effect<UpsertProjectTargetPreferenceResult, UpsertProjectTargetPreferenceError, HulyClient> =>
+  Effect.gen(function*() {
+    const { client, project } = yield* findProject(params.project)
+    const usedOn = yield* Clock.currentTimeMillis
+    const existing = yield* client.findOne<HulyProjectTargetPreference>(
+      tracker.class.ProjectTargetPreference,
+      hulyQuery<HulyProjectTargetPreference>({ attachedTo: project._id })
+    )
+
+    if (existing === undefined) {
+      const preferenceId: Ref<HulyProjectTargetPreference> = generateId()
+      const data: Data<HulyProjectTargetPreference> = {
+        attachedTo: project._id,
+        usedOn,
+        props: mergeProps(undefined, params.props)
+      }
+      yield* client.createDoc(
+        tracker.class.ProjectTargetPreference,
+        toRef<Space>(project._id),
+        data,
+        preferenceId
+      )
+      return {
+        preference: preferenceResult({ ...data, _id: preferenceId }, project),
+        created: true
+      }
+    }
+
+    const update: DocumentUpdate<HulyProjectTargetPreference> = {
+      usedOn,
+      props: mergeProps(existing.props, params.props)
+    }
+    yield* client.updateDoc(
+      tracker.class.ProjectTargetPreference,
+      toRef<Space>(existing.space),
+      existing._id,
+      update
+    )
+
+    return {
+      preference: preferenceResult({ ...existing, ...update }, project),
+      created: false
+    }
+  })

--- a/src/huly/operations/related-issue-targets.ts
+++ b/src/huly/operations/related-issue-targets.ts
@@ -1,0 +1,258 @@
+import type { Class, Data, Doc, DocumentUpdate, Ref, Space } from "@hcengineering/core"
+import { generateId, SortingOrder } from "@hcengineering/core"
+import type { Project as HulyProject, RelatedIssueTarget as HulyRelatedIssueTarget } from "@hcengineering/tracker"
+import { Effect } from "effect"
+
+import type {
+  DeleteRelatedIssueSpaceTargetParams,
+  DeleteRelatedIssueSpaceTargetResult,
+  ListRelatedIssueTargetsParams,
+  ListRelatedIssueTargetsResult,
+  RelatedIssueTarget,
+  RelatedIssueTargetRule,
+  SetRelatedIssueTargetParams,
+  SetRelatedIssueTargetResult
+} from "../../domain/schemas/related-issue-targets.js"
+import { RelatedIssueTargetId } from "../../domain/schemas/related-issue-targets.js"
+import { ObjectClassName, ProjectIdentifier, SpaceId, SpaceIdentifier, Timestamp } from "../../domain/schemas/shared.js"
+import { HulyClient, type HulyClientError } from "../client.js"
+import type { ProjectNotFoundError, SpaceIdentifierAmbiguousError, SpaceNotFoundError } from "../errors.js"
+import { HulyError } from "../errors.js"
+import { tracker } from "../huly-plugins.js"
+import { listTotal } from "./counts.js"
+import { findProject } from "./issues-shared.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { toClassRef, toRef } from "./sdk-boundary.js"
+import { findSpace, type GenericSpace, spaceClass } from "./spaces-shared.js"
+
+type RelatedIssueTargetError =
+  | HulyClientError
+  | ProjectNotFoundError
+  | SpaceIdentifierAmbiguousError
+  | SpaceNotFoundError
+  | HulyError
+
+type RelatedIssueTargetProjection =
+  & Pick<HulyRelatedIssueTarget, "_id" | "rule" | "space" | "modifiedOn">
+  & {
+    readonly target?: HulyRelatedIssueTarget["target"] | undefined
+    readonly createdOn?: HulyRelatedIssueTarget["createdOn"] | undefined
+  }
+
+type RelatedIssueTargetQuery = StrictDocumentQuery<HulyRelatedIssueTarget> & {
+  "rule.kind"?: HulyRelatedIssueTarget["rule"]["kind"]
+  "rule.space"?: Ref<Space>
+  "rule.ofClass"?: Ref<Class<Doc>>
+}
+
+const projectMapById = (
+  client: HulyClient["Type"],
+  ids: ReadonlyArray<Ref<HulyProject>>
+): Effect.Effect<ReadonlyMap<Ref<HulyProject>, HulyProject>, HulyClientError> =>
+  Effect.gen(function*() {
+    const uniqueIds = [...new Set(ids)]
+    if (uniqueIds.length === 0) return new Map<Ref<HulyProject>, HulyProject>()
+    const projects = yield* client.findAll<HulyProject>(
+      tracker.class.Project,
+      hulyQuery<HulyProject>({ _id: { $in: uniqueIds } }),
+      { limit: uniqueIds.length }
+    )
+    const entries = projects.map((project): readonly [Ref<HulyProject>, HulyProject] => [project._id, project])
+    return new Map<Ref<HulyProject>, HulyProject>(entries)
+  })
+
+const spaceMapById = (
+  client: HulyClient["Type"],
+  ids: ReadonlyArray<Ref<Space>>
+): Effect.Effect<ReadonlyMap<Ref<Space>, GenericSpace>, HulyClientError> =>
+  Effect.gen(function*() {
+    const uniqueIds = [...new Set(ids)]
+    if (uniqueIds.length === 0) return new Map<Ref<Space>, GenericSpace>()
+    const spaces = yield* client.findAll<GenericSpace>(
+      spaceClass,
+      hulyQuery<GenericSpace>({ _id: { $in: uniqueIds.map(toRef<GenericSpace>) } }),
+      { limit: uniqueIds.length }
+    )
+    const entries = spaces.map((space): readonly [Ref<Space>, GenericSpace] => [toRef<Space>(space._id), space])
+    return new Map<Ref<Space>, GenericSpace>(entries)
+  })
+
+const ruleResult = (
+  target: RelatedIssueTargetProjection,
+  spaces: ReadonlyMap<Ref<Space>, GenericSpace>
+): RelatedIssueTargetRule => {
+  if (target.rule.kind === "classRule") {
+    return {
+      kind: "classRule",
+      objectClass: ObjectClassName.make(target.rule.ofClass)
+    }
+  }
+
+  const space = spaces.get(target.rule.space)
+  return {
+    kind: "spaceRule",
+    spaceId: SpaceId.make(target.rule.space),
+    spaceName: space === undefined ? undefined : SpaceIdentifier.make(space.name),
+    spaceClass: space === undefined ? undefined : ObjectClassName.make(space._class)
+  }
+}
+
+const targetResult = (
+  target: RelatedIssueTargetProjection,
+  projects: ReadonlyMap<Ref<HulyProject>, HulyProject>,
+  spaces: ReadonlyMap<Ref<Space>, GenericSpace>
+): RelatedIssueTarget => ({
+  targetId: RelatedIssueTargetId.make(target._id),
+  rule: ruleResult(target, spaces),
+  targetProject: target.target === undefined || target.target === null
+    ? null
+    : ProjectIdentifier.make(projects.get(target.target)?.identifier ?? String(target.target)),
+  createdOn: target.createdOn === undefined ? undefined : Timestamp.make(target.createdOn),
+  modifiedOn: Timestamp.make(target.modifiedOn)
+})
+
+const resolveTargetProject = (
+  project: ProjectIdentifier | null
+): Effect.Effect<Ref<HulyProject> | null, ProjectNotFoundError | HulyClientError, HulyClient> =>
+  project === null
+    ? Effect.succeed(null)
+    : findProject(project).pipe(Effect.map(({ project: resolved }) => resolved._id))
+
+const findSpaceRule = (
+  client: HulyClient["Type"],
+  space: Ref<Space>
+): Effect.Effect<HulyRelatedIssueTarget | undefined, HulyClientError> => {
+  // Huly document queries support dot-path predicates for nested object fields.
+  const query: RelatedIssueTargetQuery = { "rule.kind": "spaceRule", "rule.space": space }
+  return client.findOne<HulyRelatedIssueTarget>(
+    tracker.class.RelatedIssueTarget,
+    hulyQuery<HulyRelatedIssueTarget>(query)
+  )
+}
+
+const findClassRule = (
+  client: HulyClient["Type"],
+  objectClass: Ref<Class<Doc>>
+): Effect.Effect<HulyRelatedIssueTarget | undefined, HulyClientError> => {
+  // Huly document queries support dot-path predicates for nested object fields.
+  const query: RelatedIssueTargetQuery = { "rule.kind": "classRule", "rule.ofClass": objectClass }
+  return client.findOne<HulyRelatedIssueTarget>(
+    tracker.class.RelatedIssueTarget,
+    hulyQuery<HulyRelatedIssueTarget>(query)
+  )
+}
+
+const renderSingleTarget = (
+  client: HulyClient["Type"],
+  target: RelatedIssueTargetProjection
+): Effect.Effect<RelatedIssueTarget, HulyClientError> =>
+  Effect.gen(function*() {
+    const projects = yield* projectMapById(
+      client,
+      target.target === undefined || target.target === null ? [] : [target.target]
+    )
+    const spaces = yield* spaceMapById(client, target.rule.kind === "spaceRule" ? [target.rule.space] : [])
+    return targetResult(target, projects, spaces)
+  })
+
+export const listRelatedIssueTargets = (
+  params: ListRelatedIssueTargetsParams
+): Effect.Effect<ListRelatedIssueTargetsResult, RelatedIssueTargetError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const query: RelatedIssueTargetQuery = {}
+    if (params.space !== undefined) {
+      const space = yield* findSpace(client, { space: params.space, includeArchived: true })
+      query["rule.kind"] = "spaceRule"
+      query["rule.space"] = toRef<Space>(space._id)
+    }
+    if (params.objectClass !== undefined) {
+      query["rule.kind"] = "classRule"
+      query["rule.ofClass"] = toClassRef<Doc>(params.objectClass)
+    }
+
+    const targets = yield* client.findAll<HulyRelatedIssueTarget>(
+      tracker.class.RelatedIssueTarget,
+      hulyQuery<HulyRelatedIssueTarget>(query),
+      { limit: clampLimit(params.limit), sort: { modifiedOn: SortingOrder.Descending }, total: true }
+    )
+    const targetProjectIds = targets.flatMap((target) =>
+      target.target === undefined || target.target === null ? [] : [target.target]
+    )
+    const spaceIds = targets.flatMap((target) => target.rule.kind === "spaceRule" ? [target.rule.space] : [])
+    const projects = yield* projectMapById(client, targetProjectIds)
+    const spaces = yield* spaceMapById(client, spaceIds)
+
+    return {
+      targets: targets.map((target) => targetResult(target, projects, spaces)),
+      total: listTotal(targets.total)
+    }
+  })
+
+export const setRelatedIssueTarget = (
+  params: SetRelatedIssueTargetParams
+): Effect.Effect<SetRelatedIssueTargetResult, RelatedIssueTargetError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const targetProject = yield* resolveTargetProject(params.targetProject)
+    if (params.space !== undefined) {
+      const space = yield* findSpace(client, { space: params.space, includeArchived: true })
+      const existing = yield* findSpaceRule(client, toRef<Space>(space._id))
+      if (existing === undefined) {
+        const targetId: Ref<HulyRelatedIssueTarget> = generateId()
+        const data: Data<HulyRelatedIssueTarget> = {
+          target: targetProject,
+          rule: { kind: "spaceRule", space: toRef<Space>(space._id) }
+        }
+        yield* client.createDoc(tracker.class.RelatedIssueTarget, toRef<Space>(space._id), data, targetId)
+        const createdTarget: RelatedIssueTargetProjection = {
+          _id: targetId,
+          modifiedOn: 0,
+          rule: data.rule,
+          space: toRef<Space>(space._id),
+          target: data.target
+        }
+        return {
+          target: yield* renderSingleTarget(client, createdTarget),
+          created: true
+        }
+      }
+
+      const update: DocumentUpdate<HulyRelatedIssueTarget> = { target: targetProject }
+      yield* client.updateDoc(tracker.class.RelatedIssueTarget, toRef<Space>(existing.space), existing._id, update)
+      return { target: yield* renderSingleTarget(client, { ...existing, ...update }), created: false }
+    }
+
+    const objectClassParam = params.objectClass
+    /* v8 ignore next -- defensive only: SetRelatedIssueTargetParamsSchema requires space or objectClass. */
+    if (objectClassParam === undefined) {
+      return yield* new HulyError({ message: "Provide one of space or objectClass." })
+    }
+    const objectClass = toClassRef<Doc>(objectClassParam)
+    const existing = yield* findClassRule(client, objectClass)
+    if (existing === undefined) {
+      return yield* new HulyError({
+        message:
+          `Related issue classRule for '${objectClassParam}' was not found. This tool does not create classRule targets.`
+      })
+    }
+    const update: DocumentUpdate<HulyRelatedIssueTarget> = { target: targetProject }
+    yield* client.updateDoc(tracker.class.RelatedIssueTarget, toRef<Space>(existing.space), existing._id, update)
+    return { target: yield* renderSingleTarget(client, { ...existing, ...update }), created: false }
+  })
+
+export const deleteRelatedIssueSpaceTarget = (
+  params: DeleteRelatedIssueSpaceTargetParams
+): Effect.Effect<DeleteRelatedIssueSpaceTargetResult, RelatedIssueTargetError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const space = yield* findSpace(client, { space: params.space, includeArchived: true })
+    const existing = yield* findSpaceRule(client, toRef<Space>(space._id))
+    if (existing === undefined) {
+      return yield* new HulyError({
+        message: `Related issue spaceRule for space '${params.space}' was not found.`
+      })
+    }
+    yield* client.removeDoc(tracker.class.RelatedIssueTarget, toRef<Space>(existing.space), existing._id)
+    return { targetId: RelatedIssueTargetId.make(existing._id), deleted: true }
+  })

--- a/src/mcp/tools/document-snapshots.ts
+++ b/src/mcp/tools/document-snapshots.ts
@@ -1,0 +1,37 @@
+import {
+  getDocumentSnapshotParamsJsonSchema,
+  listDocumentSnapshotsParamsJsonSchema,
+  parseGetDocumentSnapshotParams,
+  parseListDocumentSnapshotsParams
+} from "../../domain/schemas/document-snapshots.js"
+import { getDocumentSnapshot, listDocumentSnapshots } from "../../huly/operations/document-snapshots.js"
+import { createToolHandler, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "documents" as const
+
+export const documentSnapshotTools: ReadonlyArray<RegisteredTool> = [
+  {
+    name: "list_document_snapshots",
+    description:
+      "List version-history snapshots for one Huly document. A snapshot is a saved point-in-time copy from the document's change history. Resolve the document by teamspace plus document title or ID. Returns snapshotId, documentId, teamspaceId, title, parentDocumentId, and timestamps; markdown content is intentionally omitted. Use get_document_snapshot with snapshotId when reading content.",
+    category: CATEGORY,
+    inputSchema: listDocumentSnapshotsParamsJsonSchema,
+    handler: createToolHandler(
+      "list_document_snapshots",
+      parseListDocumentSnapshotsParams,
+      listDocumentSnapshots
+    )
+  },
+  {
+    name: "get_document_snapshot",
+    description:
+      "Get one point-in-time Huly document history snapshot and return markdown content. Resolve the document by teamspace plus document title or ID; resolve the snapshot by snapshotId, exact snapshot title, or exact createdOn timestamp. Prefer snapshotId from list_document_snapshots when titles or dates may collide. Restore is out of scope.",
+    category: CATEGORY,
+    inputSchema: getDocumentSnapshotParamsJsonSchema,
+    handler: createToolHandler(
+      "get_document_snapshot",
+      parseGetDocumentSnapshotParams,
+      getDocumentSnapshot
+    )
+  }
+]

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -12,6 +12,7 @@ import { commentTools } from "./comments.js"
 import { contactTools } from "./contacts.js"
 import { customFieldTools } from "./custom-fields.js"
 import { deletionTools } from "./deletion.js"
+import { documentSnapshotTools } from "./document-snapshots.js"
 import { documentTools } from "./documents.js"
 import { driveTools } from "./drive.js"
 import { genericAssociationTools } from "./generic-associations.js"
@@ -22,6 +23,7 @@ import { milestoneTools } from "./milestones.js"
 import { notificationTools } from "./notifications.js"
 import { plannerTools } from "./planner.js"
 import { processTools } from "./processes.js"
+import { projectTargetPreferenceTools } from "./project-target-preferences.js"
 import { projectTools } from "./projects.js"
 import type { RegisteredTool, ToolDefinition } from "./registry.js"
 import {
@@ -32,6 +34,7 @@ import {
   requiresArgumentsObject,
   resolveAnnotations
 } from "./registry.js"
+import { relatedIssueTargetTools } from "./related-issue-targets.js"
 import { sdkDiscoveryTools } from "./sdk-discovery.js"
 import { searchTools } from "./search.js"
 import { spaceTools } from "./spaces.js"
@@ -48,7 +51,9 @@ import { workspaceTools } from "./workspace.js"
 
 const allTools: ReadonlyArray<RegisteredTool> = [
   ...projectTools,
+  ...projectTargetPreferenceTools,
   ...issueTools,
+  ...relatedIssueTargetTools,
   ...labelTools,
   ...tagTools,
   ...tagCategoryTools,
@@ -57,6 +62,7 @@ const allTools: ReadonlyArray<RegisteredTool> = [
   ...deletionTools,
   ...milestoneTools,
   ...documentTools,
+  ...documentSnapshotTools,
   ...driveTools,
   ...genericAssociationTools,
   ...spaceTools,

--- a/src/mcp/tools/project-target-preferences.ts
+++ b/src/mcp/tools/project-target-preferences.ts
@@ -1,0 +1,40 @@
+import {
+  listProjectTargetPreferencesParamsJsonSchema,
+  parseListProjectTargetPreferencesParams,
+  parseUpsertProjectTargetPreferenceParams,
+  upsertProjectTargetPreferenceParamsJsonSchema
+} from "../../domain/schemas/project-target-preferences.js"
+import {
+  listProjectTargetPreferences,
+  upsertProjectTargetPreference
+} from "../../huly/operations/project-target-preferences.js"
+import { createToolHandler, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "projects" as const
+
+export const projectTargetPreferenceTools: ReadonlyArray<RegisteredTool> = [
+  {
+    name: "list_project_target_preferences",
+    description:
+      "List low-level per-project tracker target preference records. These Huly ProjectTargetPreference records are attached to projects and used by tracker UI/workflows to remember target-related preference props. Omit project to list recent preferences across projects, or pass a project identifier to inspect one project's preference. Props are SDK-open key/value payloads.",
+    category: CATEGORY,
+    inputSchema: listProjectTargetPreferencesParamsJsonSchema,
+    handler: createToolHandler(
+      "list_project_target_preferences",
+      parseListProjectTargetPreferencesParams,
+      listProjectTargetPreferences
+    )
+  },
+  {
+    name: "upsert_project_target_preference",
+    description:
+      "Create or update the low-level ProjectTargetPreference record for a project. This refreshes usedOn and merges SDK-open target preference props by key. Use for tracker SDK parity or advanced administration; ordinary project and issue workflows usually do not need this tool.",
+    category: CATEGORY,
+    inputSchema: upsertProjectTargetPreferenceParamsJsonSchema,
+    handler: createToolHandler(
+      "upsert_project_target_preference",
+      parseUpsertProjectTargetPreferenceParams,
+      upsertProjectTargetPreference
+    )
+  }
+]

--- a/src/mcp/tools/related-issue-targets.ts
+++ b/src/mcp/tools/related-issue-targets.ts
@@ -1,0 +1,55 @@
+import {
+  deleteRelatedIssueSpaceTargetParamsJsonSchema,
+  listRelatedIssueTargetsParamsJsonSchema,
+  parseDeleteRelatedIssueSpaceTargetParams,
+  parseListRelatedIssueTargetsParams,
+  parseSetRelatedIssueTargetParams,
+  setRelatedIssueTargetParamsJsonSchema
+} from "../../domain/schemas/related-issue-targets.js"
+import {
+  deleteRelatedIssueSpaceTarget,
+  listRelatedIssueTargets,
+  setRelatedIssueTarget
+} from "../../huly/operations/related-issue-targets.js"
+import { createToolHandler, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "issues" as const
+
+export const relatedIssueTargetTools: ReadonlyArray<RegisteredTool> = [
+  {
+    name: "list_related_issue_targets",
+    description:
+      "List rules that choose the default destination project for related issues. A spaceRule says related issues from one space default to targetProject. A classRule says related issues for one object class default to targetProject. targetProject is a project identifier, or null for no default destination project.",
+    category: CATEGORY,
+    inputSchema: listRelatedIssueTargetsParamsJsonSchema,
+    handler: createToolHandler(
+      "list_related_issue_targets",
+      parseListRelatedIssueTargetsParams,
+      listRelatedIssueTargets
+    )
+  },
+  {
+    name: "set_related_issue_target",
+    description:
+      "Set the default destination project for related issues from a space or object class. For space, creates or updates a spaceRule. For objectClass, only updates an existing classRule; this tool never creates classRule targets. Pass targetProject as a project identifier, or null to clear the default destination project.",
+    category: CATEGORY,
+    inputSchema: setRelatedIssueTargetParamsJsonSchema,
+    handler: createToolHandler(
+      "set_related_issue_target",
+      parseSetRelatedIssueTargetParams,
+      setRelatedIssueTarget
+    )
+  },
+  {
+    name: "delete_related_issue_space_target",
+    description:
+      "Delete the spaceRule that chooses the default destination project for related issues from one space. This only deletes spaceRule targets; classRule deletion is intentionally unsupported because class rules may be model-provided.",
+    category: CATEGORY,
+    inputSchema: deleteRelatedIssueSpaceTargetParamsJsonSchema,
+    handler: createToolHandler(
+      "delete_related_issue_space_target",
+      parseDeleteRelatedIssueSpaceTargetParams,
+      deleteRelatedIssueSpaceTarget
+    )
+  }
+]

--- a/test/domain/schemas.issue-102-closeout.test.ts
+++ b/test/domain/schemas.issue-102-closeout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "@effect/vitest"
+import { Effect, Exit } from "effect"
+import { expect } from "vitest"
+
+import {
+  parseGetDocumentSnapshotParams,
+  parseSetRelatedIssueTargetParams,
+  parseUpsertProjectTargetPreferenceParams
+} from "../../src/domain/schemas.js"
+
+describe("issue #102 schemas", () => {
+  it.effect("accepts document snapshot lookup by teamspace, document, and snapshot identifier", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseGetDocumentSnapshotParams({
+        document: "Spec",
+        snapshot: "snapshot-1",
+        teamspace: "Docs"
+      })
+
+      expect(parsed).toEqual({
+        document: "Spec",
+        snapshot: "snapshot-1",
+        teamspace: "Docs"
+      })
+    }))
+
+  it.effect("keeps ProjectTargetPreference props SDK-open", () =>
+    Effect.gen(function*() {
+      const parsed = yield* parseUpsertProjectTargetPreferenceParams({
+        project: "PRJ",
+        props: [{ key: "github:repo", value: { id: 123, enabled: true } }]
+      })
+
+      expect(parsed.props?.[0]?.value).toEqual({ id: 123, enabled: true })
+    }))
+
+  it.effect("requires exactly one related issue target locator", () =>
+    Effect.gen(function*() {
+      const missing = yield* Effect.exit(parseSetRelatedIssueTargetParams({ targetProject: null }))
+      const both = yield* Effect.exit(parseSetRelatedIssueTargetParams({
+        objectClass: "document:class:Document",
+        space: "Docs",
+        targetProject: "PRJ"
+      }))
+      const valid = yield* parseSetRelatedIssueTargetParams({
+        space: "Docs",
+        targetProject: null
+      })
+
+      expect(Exit.isFailure(missing)).toBe(true)
+      expect(Exit.isFailure(both)).toBe(true)
+      expect(valid).toEqual({ space: "Docs", targetProject: null })
+    }))
+})

--- a/test/huly/operations/issue-102-closeout.test.ts
+++ b/test/huly/operations/issue-102-closeout.test.ts
@@ -1,0 +1,608 @@
+import { describe, it } from "@effect/vitest"
+import type { Doc, MarkupBlobRef, PersonId, Ref, Space } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import type {
+  Document as HulyDocument,
+  DocumentSnapshot as HulyDocumentSnapshot,
+  Teamspace as HulyTeamspace
+} from "@hcengineering/document"
+import type {
+  IssueStatus,
+  Project as HulyProject,
+  ProjectTargetPreference,
+  RelatedIssueTarget as HulyRelatedIssueTarget
+} from "@hcengineering/tracker"
+import { TimeReportDayType } from "@hcengineering/tracker"
+import { Effect, Exit, TestClock } from "effect"
+import { expect } from "vitest"
+
+import { DocumentSnapshotIdentifier } from "../../../src/domain/schemas/document-snapshots.js"
+import { TrackerPreferencePropertyKey } from "../../../src/domain/schemas/project-target-preferences.js"
+import {
+  parseListRelatedIssueTargetsParams,
+  parseSetRelatedIssueTargetParams
+} from "../../../src/domain/schemas/related-issue-targets.js"
+import {
+  DocumentIdentifier,
+  ObjectClassName,
+  ProjectIdentifier,
+  SpaceIdentifier,
+  TeamspaceIdentifier
+} from "../../../src/domain/schemas/shared.js"
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import { core, documentPlugin, tracker } from "../../../src/huly/huly-plugins.js"
+import { getDocumentSnapshot, listDocumentSnapshots } from "../../../src/huly/operations/document-snapshots.js"
+import {
+  listProjectTargetPreferences,
+  upsertProjectTargetPreference
+} from "../../../src/huly/operations/project-target-preferences.js"
+import {
+  deleteRelatedIssueSpaceTarget,
+  listRelatedIssueTargets,
+  setRelatedIssueTarget
+} from "../../../src/huly/operations/related-issue-targets.js"
+
+// Brands and SDK refs are erased at runtime. Test fixtures use literal strings to model
+// documents returned by the Huly SDK, so these casts only restore phantom SDK brands.
+const ref = <T extends Doc>(value: string): Ref<T> => value as Ref<T>
+const personId = (value: string): PersonId => value as PersonId
+const markupBlobRef = (value: string): MarkupBlobRef => value as MarkupBlobRef
+
+// The test Huly port receives already-decoded query/update objects from operation code.
+// This narrows unknown port payloads to inspect captured fields without changing behavior.
+const recordFromPort = (value: unknown): Record<string, unknown> => value as Record<string, unknown>
+const arrayFromPort = (value: unknown): ReadonlyArray<unknown> => Array.isArray(value) ? value : []
+const idInFilter = (value: unknown): ReadonlyArray<unknown> =>
+  value === undefined ? [] : arrayFromPort(recordFromPort(value).$in)
+const userId: PersonId = personId("user-1")
+
+const makeTeamspace = (): HulyTeamspace => ({
+  _id: ref<HulyTeamspace>("teamspace-1"),
+  _class: documentPlugin.class.Teamspace,
+  space: ref<Space>("space-1"),
+  name: "Docs",
+  description: "",
+  archived: false,
+  private: false,
+  members: [],
+  type: documentPlugin.spaceType.DefaultTeamspaceType,
+  modifiedBy: userId,
+  modifiedOn: 1
+})
+
+const makeDocument = (): HulyDocument => ({
+  _id: ref<HulyDocument>("doc-1"),
+  _class: documentPlugin.class.Document,
+  space: ref<HulyTeamspace>("teamspace-1"),
+  title: "Spec",
+  content: null,
+  parent: documentPlugin.ids.NoParent,
+  rank: "0|aaa",
+  modifiedBy: userId,
+  modifiedOn: 2
+})
+
+type SnapshotDoc = HulyDocumentSnapshot & { readonly attachedTo: Ref<HulyDocument> }
+
+const makeSnapshot = (overrides: Partial<SnapshotDoc> = {}): SnapshotDoc => ({
+  _id: ref<SnapshotDoc>("snapshot-1"),
+  _class: documentPlugin.class.DocumentSnapshot,
+  space: ref<Space>("teamspace-1"),
+  title: "Before release",
+  content: markupBlobRef("markup-1"),
+  parent: ref<HulyDocument>("doc-parent"),
+  attachedTo: ref<HulyDocument>("doc-1"),
+  modifiedBy: userId,
+  modifiedOn: 20,
+  createdBy: userId,
+  createdOn: 10,
+  ...overrides
+})
+
+const makeProject = (): HulyProject => ({
+  _id: ref<HulyProject>("project-1"),
+  _class: tracker.class.Project,
+  space: ref<Space>("project-1"),
+  identifier: "PRJ",
+  name: "Project",
+  description: "",
+  private: false,
+  archived: false,
+  members: [],
+  type: tracker.ids.ClassingProjectType,
+  sequence: 1,
+  defaultIssueStatus: ref<IssueStatus>("status-1"),
+  defaultTimeReportDay: TimeReportDayType.CurrentWorkDay,
+  modifiedBy: userId,
+  modifiedOn: 1
+})
+
+const makePreference = (overrides: Partial<ProjectTargetPreference> = {}): ProjectTargetPreference => ({
+  _id: ref<ProjectTargetPreference>("pref-1"),
+  _class: tracker.class.ProjectTargetPreference,
+  space: ref<Space>("project-1"),
+  attachedTo: ref<HulyProject>("project-1"),
+  usedOn: 25,
+  props: [{ key: "github:repo", value: "repo-1" }],
+  modifiedBy: userId,
+  modifiedOn: 25,
+  ...overrides
+})
+
+const makeSpace = (): Space => ({
+  _id: ref<Space>("space-1"),
+  _class: core.class.Space,
+  space: core.space.Space,
+  name: "Source Space",
+  description: "",
+  private: false,
+  archived: false,
+  members: [],
+  modifiedBy: userId,
+  modifiedOn: 1
+})
+
+const makeRelatedSpaceTarget = (overrides: Partial<HulyRelatedIssueTarget> = {}): HulyRelatedIssueTarget => ({
+  _id: ref<HulyRelatedIssueTarget>("related-target-1"),
+  _class: tracker.class.RelatedIssueTarget,
+  space: ref<Space>("space-1"),
+  rule: { kind: "spaceRule", space: ref<Space>("space-1") },
+  target: ref<HulyProject>("project-1"),
+  modifiedBy: userId,
+  modifiedOn: 30,
+  createdBy: userId,
+  createdOn: 20,
+  ...overrides
+})
+
+const makeRelatedClassTarget = (overrides: Partial<HulyRelatedIssueTarget> = {}): HulyRelatedIssueTarget =>
+  makeRelatedSpaceTarget({
+    _id: ref<HulyRelatedIssueTarget>("related-class-target-1"),
+    rule: { kind: "classRule", ofClass: ref("document:class:Document") },
+    ...overrides
+  })
+
+interface Captures {
+  readonly createDoc?: { attributes?: Record<string, unknown>; space?: unknown }
+  readonly removeDoc?: { id?: unknown; space?: unknown }
+  readonly updateDoc?: { operations?: Record<string, unknown> }
+}
+
+interface TestFixtures {
+  readonly preference?: ProjectTargetPreference | undefined
+  readonly relatedTargets?: ReadonlyArray<HulyRelatedIssueTarget>
+  readonly snapshots?: ReadonlyArray<SnapshotDoc>
+}
+
+const testLayer = (captures: Captures = {}, fixtures: TestFixtures = {}) => {
+  const teamspace = makeTeamspace()
+  const document = makeDocument()
+  const snapshots = fixtures.snapshots ?? [makeSnapshot()]
+  const project = makeProject()
+  const preference = "preference" in fixtures ? fixtures.preference : makePreference()
+  const space = makeSpace()
+  const relatedTargets = fixtures.relatedTargets ?? []
+
+  // HulyClientOperations methods are generic SDK ports. The fixture branches by class and returns
+  // matching SDK-shaped documents; the cast seals the generic method signature for the test layer.
+  const findAll: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown) => {
+    const q = recordFromPort(query)
+    if (_class === documentPlugin.class.DocumentSnapshot) {
+      const filtered = snapshots.filter((snapshot) =>
+        q.attachedTo === snapshot.attachedTo
+        && (q.title === undefined || q.title === snapshot.title)
+        && (q.createdOn === undefined || q.createdOn === snapshot.createdOn)
+      )
+      return Effect.succeed(toFindResult(filtered))
+    }
+    if (_class === tracker.class.ProjectTargetPreference) {
+      return Effect.succeed(
+        toFindResult(
+          preference !== undefined && (q.attachedTo === project._id || q.attachedTo === undefined) ? [preference] : []
+        )
+      )
+    }
+    if (_class === tracker.class.Project) {
+      const queriedIds = idInFilter(q._id)
+      const matchesId = q._id === undefined || queriedIds.length === 0 || queriedIds.includes(project._id)
+      return Effect.succeed(toFindResult(matchesId ? [project] : []))
+    }
+    if (_class === core.class.Space) {
+      return Effect.succeed(toFindResult([space]))
+    }
+    if (_class === tracker.class.RelatedIssueTarget) {
+      const filtered = relatedTargets.filter((target) =>
+        (q["rule.kind"] === undefined || q["rule.kind"] === target.rule.kind)
+        && (q["rule.space"] === undefined || target.rule.kind === "spaceRule" && q["rule.space"] === target.rule.space)
+        && (q["rule.ofClass"] === undefined
+          || target.rule.kind === "classRule" && q["rule.ofClass"] === target.rule.ofClass)
+      )
+      return Effect.succeed(toFindResult(filtered))
+    }
+    return Effect.succeed(toFindResult([]))
+  }) as HulyClientOperations["findAll"]
+
+  // See findAll above: the implementation is class-dispatched and satisfies the generic port.
+  const findOne: HulyClientOperations["findOne"] = ((_class: unknown, query: unknown) => {
+    const q = recordFromPort(query)
+    if (_class === documentPlugin.class.Teamspace) {
+      return Effect.succeed(q.name === teamspace.name || q._id === teamspace._id ? teamspace : undefined)
+    }
+    if (_class === documentPlugin.class.Document) {
+      return Effect.succeed(q.title === document.title || q._id === document._id ? document : undefined)
+    }
+    if (_class === documentPlugin.class.DocumentSnapshot) {
+      return Effect.succeed(
+        snapshots.find((snapshot) =>
+          q.attachedTo === snapshot.attachedTo
+          && (q._id === undefined || q._id === snapshot._id)
+          && (q.title === undefined || q.title === snapshot.title)
+        )
+      )
+    }
+    if (_class === tracker.class.Project) {
+      return Effect.succeed(q.identifier === project.identifier || q._id === project._id ? project : undefined)
+    }
+    if (_class === tracker.class.ProjectTargetPreference) {
+      return Effect.succeed(preference !== undefined && q.attachedTo === project._id ? preference : undefined)
+    }
+    if (_class === tracker.class.RelatedIssueTarget) {
+      return Effect.succeed(
+        relatedTargets.find((target) =>
+          (q["rule.kind"] === undefined || q["rule.kind"] === target.rule.kind)
+          && (q["rule.space"] === undefined
+            || target.rule.kind === "spaceRule" && q["rule.space"] === target.rule.space)
+          && (q["rule.ofClass"] === undefined
+            || target.rule.kind === "classRule" && q["rule.ofClass"] === target.rule.ofClass)
+        )
+      )
+    }
+    if (_class === core.class.Space) {
+      return Effect.succeed(q._id === space._id ? space : undefined)
+    }
+    return Effect.succeed(undefined)
+  }) as HulyClientOperations["findOne"]
+
+  // See findAll above: the implementation captures writes and returns a valid SDK ref.
+  const createDoc: HulyClientOperations["createDoc"] = ((_class: unknown, docSpace: unknown, attributes: unknown) => {
+    if (captures.createDoc !== undefined) {
+      captures.createDoc.attributes = recordFromPort(attributes)
+      captures.createDoc.space = docSpace
+    }
+    return Effect.succeed(ref<Doc>("created-id"))
+  }) as HulyClientOperations["createDoc"]
+
+  // See findAll above: the implementation captures the generic update document payload.
+  const updateDoc: HulyClientOperations["updateDoc"] =
+    ((_class: unknown, _space: unknown, _id: unknown, operations: unknown) => {
+      if (captures.updateDoc !== undefined) {
+        captures.updateDoc.operations = recordFromPort(operations)
+      }
+      return Effect.succeed({} as never)
+    }) as HulyClientOperations["updateDoc"]
+
+  const removeDoc: HulyClientOperations["removeDoc"] = ((_class: unknown, docSpace: unknown, id: unknown) => {
+    if (captures.removeDoc !== undefined) {
+      captures.removeDoc.id = id
+      captures.removeDoc.space = docSpace
+    }
+    return Effect.succeed({} as never)
+  }) as HulyClientOperations["removeDoc"]
+
+  return HulyClient.testLayer({
+    createDoc,
+    fetchMarkup: () => Effect.succeed("# Snapshot"),
+    findAll,
+    findOne,
+    removeDoc,
+    updateDoc
+  })
+}
+
+describe("issue #102 operations", () => {
+  it.effect("lists and gets document snapshots with markdown only on get", () =>
+    Effect.gen(function*() {
+      const listed = yield* listDocumentSnapshots({
+        document: DocumentIdentifier.make("Spec"),
+        teamspace: TeamspaceIdentifier.make("Docs")
+      }).pipe(Effect.provide(testLayer()))
+      expect(listed.snapshots[0]).toMatchObject({
+        documentId: "doc-1",
+        parentDocumentId: "doc-parent",
+        snapshotId: "snapshot-1",
+        teamspaceId: "teamspace-1",
+        title: "Before release"
+      })
+      expect("markdown" in listed.snapshots[0]).toBe(false)
+
+      const { createdOn: _createdOn, ...snapshotWithoutCreatedOn } = makeSnapshot()
+      const listedWithoutCreatedOn = yield* listDocumentSnapshots({
+        document: DocumentIdentifier.make("Spec"),
+        teamspace: TeamspaceIdentifier.make("Docs")
+      }).pipe(
+        Effect.provide(testLayer({}, {
+          snapshots: [snapshotWithoutCreatedOn]
+        }))
+      )
+      expect(listedWithoutCreatedOn.snapshots[0]?.createdOn).toBeUndefined()
+
+      const got = yield* getDocumentSnapshot({
+        document: DocumentIdentifier.make("Spec"),
+        snapshot: DocumentSnapshotIdentifier.make("snapshot-1"),
+        teamspace: TeamspaceIdentifier.make("Docs")
+      }).pipe(Effect.provide(testLayer()))
+      expect(got.markdown).toBe("# Snapshot")
+    }))
+
+  it.effect("resolves document snapshots by title and createdOn and reports ambiguous or missing matches", () =>
+    Effect.gen(function*() {
+      const byTitle = yield* getDocumentSnapshot({
+        document: DocumentIdentifier.make("Spec"),
+        snapshot: DocumentSnapshotIdentifier.make("Before release"),
+        teamspace: TeamspaceIdentifier.make("Docs")
+      }).pipe(Effect.provide(testLayer()))
+      expect(byTitle.snapshotId).toBe("snapshot-1")
+
+      const byCreatedOn = yield* getDocumentSnapshot({
+        document: DocumentIdentifier.make("Spec"),
+        snapshot: DocumentSnapshotIdentifier.make("10"),
+        teamspace: TeamspaceIdentifier.make("Docs")
+      }).pipe(Effect.provide(testLayer()))
+      expect(byCreatedOn.snapshotId).toBe("snapshot-1")
+
+      const duplicateTitle = makeSnapshot({ _id: ref("snapshot-2") })
+      const ambiguousTitle = yield* Effect.exit(
+        getDocumentSnapshot({
+          document: DocumentIdentifier.make("Spec"),
+          snapshot: DocumentSnapshotIdentifier.make("Before release"),
+          teamspace: TeamspaceIdentifier.make("Docs")
+        }).pipe(Effect.provide(testLayer({}, { snapshots: [makeSnapshot(), duplicateTitle] })))
+      )
+      expect(Exit.isFailure(ambiguousTitle)).toBe(true)
+
+      const duplicateDate = makeSnapshot({ _id: ref("snapshot-3"), title: "Other title" })
+      const ambiguousDate = yield* Effect.exit(
+        getDocumentSnapshot({
+          document: DocumentIdentifier.make("Spec"),
+          snapshot: DocumentSnapshotIdentifier.make("10"),
+          teamspace: TeamspaceIdentifier.make("Docs")
+        }).pipe(Effect.provide(testLayer({}, { snapshots: [makeSnapshot(), duplicateDate] })))
+      )
+      expect(Exit.isFailure(ambiguousDate)).toBe(true)
+
+      const missing = yield* Effect.exit(
+        getDocumentSnapshot({
+          document: DocumentIdentifier.make("Spec"),
+          snapshot: DocumentSnapshotIdentifier.make("missing"),
+          teamspace: TeamspaceIdentifier.make("Docs")
+        }).pipe(Effect.provide(testLayer()))
+      )
+      expect(Exit.isFailure(missing)).toBe(true)
+    }))
+
+  it.effect("lists and upserts project target preferences using Effect clock", () =>
+    Effect.gen(function*() {
+      const listedAll = yield* listProjectTargetPreferences({}).pipe(Effect.provide(testLayer()))
+      expect(listedAll.total).toBe(1)
+
+      const listed = yield* listProjectTargetPreferences({ project: ProjectIdentifier.make("PRJ") }).pipe(
+        Effect.provide(testLayer())
+      )
+      expect(listed.preferences[0]).toMatchObject({
+        attachedTo: "project-1",
+        preferenceId: "pref-1",
+        project: "PRJ",
+        usedOn: 25
+      })
+
+      yield* TestClock.adjust("123 millis")
+      const captures: Captures = { updateDoc: {} }
+      const upserted = yield* upsertProjectTargetPreference({
+        project: ProjectIdentifier.make("PRJ"),
+        props: [{ key: TrackerPreferencePropertyKey.make("github:repo"), value: "repo-2" }]
+      }).pipe(Effect.provide(testLayer(captures)))
+
+      expect(upserted.created).toBe(false)
+      expect(captures.updateDoc?.operations).toMatchObject({
+        props: [{ key: "github:repo", value: "repo-2" }],
+        usedOn: 123
+      })
+
+      const preserved = yield* upsertProjectTargetPreference({
+        project: ProjectIdentifier.make("PRJ")
+      }).pipe(Effect.provide(testLayer({ updateDoc: {} })))
+      expect(preserved.preference.props).toEqual([{ key: "github:repo", value: "repo-1" }])
+
+      const mixedPreference = makePreference({
+        props: [
+          { key: "github:repo", value: "repo-1" },
+          { key: "view", value: "expanded" }
+        ]
+      })
+      const mixed = yield* upsertProjectTargetPreference({
+        project: ProjectIdentifier.make("PRJ"),
+        props: [{ key: TrackerPreferencePropertyKey.make("github:repo"), value: "repo-2" }]
+      }).pipe(Effect.provide(testLayer({ updateDoc: {} }, { preference: mixedPreference })))
+      expect(mixed.preference.props).toEqual([
+        { key: "view", value: "expanded" },
+        { key: "github:repo", value: "repo-2" }
+      ])
+    }))
+
+  it.effect("creates project target preferences when none exists", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust("456 millis")
+      const captures: Captures = { createDoc: {} }
+      const upserted = yield* upsertProjectTargetPreference({
+        project: ProjectIdentifier.make("PRJ"),
+        props: [{ key: TrackerPreferencePropertyKey.make("view"), value: { mode: "compact" } }]
+      }).pipe(Effect.provide(testLayer(captures, { preference: undefined })))
+
+      expect(upserted.created).toBe(true)
+      expect(captures.createDoc?.space).toBe("project-1")
+      expect(captures.createDoc?.attributes).toMatchObject({
+        attachedTo: "project-1",
+        props: [{ key: "view", value: { mode: "compact" } }],
+        usedOn: 456
+      })
+
+      const empty = yield* listProjectTargetPreferences({}).pipe(
+        Effect.provide(testLayer({}, { preference: undefined }))
+      )
+      expect(empty).toEqual({ preferences: [], total: 0 })
+
+      const { props: _props, ...preferenceWithoutProps } = makePreference({
+        attachedTo: ref("missing-project")
+      })
+      const unlinked = yield* listProjectTargetPreferences({}).pipe(
+        Effect.provide(testLayer({}, {
+          preference: preferenceWithoutProps
+        }))
+      )
+      expect(unlinked.preferences[0]).toMatchObject({
+        attachedTo: "missing-project",
+        preferenceId: "pref-1",
+        props: []
+      })
+      expect(unlinked.preferences[0]?.project).toBeUndefined()
+
+      const createdWithoutProps = yield* upsertProjectTargetPreference({
+        project: ProjectIdentifier.make("PRJ")
+      }).pipe(Effect.provide(testLayer({}, { preference: undefined })))
+      expect(createdWithoutProps.preference.props).toEqual([])
+    }))
+
+  it.effect("creates a related issue spaceRule but refuses to create a missing classRule", () =>
+    Effect.gen(function*() {
+      const captures: Captures = { createDoc: {} }
+      const created = yield* setRelatedIssueTarget({
+        space: SpaceIdentifier.make("space-1"),
+        targetProject: ProjectIdentifier.make("PRJ")
+      }).pipe(Effect.provide(testLayer(captures)))
+
+      expect(created.created).toBe(true)
+      expect(captures.createDoc?.space).toBe("space-1")
+      expect(captures.createDoc?.attributes).toMatchObject({
+        rule: { kind: "spaceRule", space: "space-1" },
+        target: "project-1"
+      })
+
+      const classRuleExit = yield* Effect.exit(
+        setRelatedIssueTarget({
+          objectClass: ObjectClassName.make("document:class:Document"),
+          targetProject: ProjectIdentifier.make("PRJ")
+        }).pipe(Effect.provide(testLayer()))
+      )
+      expect(Exit.isFailure(classRuleExit)).toBe(true)
+    }))
+
+  it.effect("lists, updates, and deletes related issue targets", () =>
+    Effect.gen(function*() {
+      const spaceTarget = makeRelatedSpaceTarget()
+      const classTarget = makeRelatedClassTarget()
+      const rawTarget = makeRelatedClassTarget({
+        _id: ref("related-class-target-2"),
+        target: ref("missing-project")
+      })
+      const nullSpaceTarget = makeRelatedSpaceTarget({
+        _id: ref("related-target-2"),
+        target: null
+      })
+      const missingSpaceMetadataTarget = makeRelatedSpaceTarget({
+        _id: ref("related-target-3"),
+        rule: { kind: "spaceRule", space: ref("missing-space") }
+      })
+
+      const invalidFilter = yield* Effect.exit(
+        parseListRelatedIssueTargetsParams({
+          objectClass: "document:class:Document",
+          space: "space-1"
+        })
+      )
+      expect(Exit.isFailure(invalidFilter)).toBe(true)
+
+      const validUnfiltered = yield* parseListRelatedIssueTargetsParams({})
+      expect(validUnfiltered).toEqual({})
+
+      const validSpaceLocator = yield* parseSetRelatedIssueTargetParams({
+        space: "space-1",
+        targetProject: null
+      })
+      expect(validSpaceLocator).toEqual({ space: "space-1", targetProject: null })
+
+      const missingSetLocator = yield* Effect.exit(
+        parseSetRelatedIssueTargetParams({ targetProject: null })
+      )
+      expect(Exit.isFailure(missingSetLocator)).toBe(true)
+
+      const invalidSetLocator = yield* Effect.exit(
+        parseSetRelatedIssueTargetParams({
+          objectClass: "document:class:Document",
+          space: "space-1",
+          targetProject: null
+        })
+      )
+      expect(Exit.isFailure(invalidSetLocator)).toBe(true)
+
+      // This intentionally bypasses schema validation to exercise the operation's defensive guard
+      // for callers that invoke the typed function directly with malformed data.
+      const malformedSet = yield* Effect.exit(
+        setRelatedIssueTarget({ targetProject: null } as Parameters<typeof setRelatedIssueTarget>[0]).pipe(
+          Effect.provide(testLayer())
+        )
+      )
+      expect(Exit.isFailure(malformedSet)).toBe(true)
+
+      const listedAll = yield* listRelatedIssueTargets({}).pipe(
+        Effect.provide(testLayer({}, { relatedTargets: [nullSpaceTarget, rawTarget, missingSpaceMetadataTarget] }))
+      )
+      expect(listedAll.targets.map((target) => target.targetProject)).toEqual([null, "missing-project", "PRJ"])
+      expect(listedAll.targets[2]?.rule).toEqual({
+        kind: "spaceRule",
+        spaceId: "missing-space"
+      })
+
+      const listedSpace = yield* listRelatedIssueTargets({ space: SpaceIdentifier.make("space-1") }).pipe(
+        Effect.provide(testLayer({}, { relatedTargets: [spaceTarget, classTarget] }))
+      )
+      expect(listedSpace.targets[0]).toMatchObject({
+        rule: { kind: "spaceRule", spaceId: "space-1" },
+        targetProject: "PRJ"
+      })
+
+      const listedClass = yield* listRelatedIssueTargets({
+        objectClass: ObjectClassName.make("document:class:Document")
+      }).pipe(Effect.provide(testLayer({}, { relatedTargets: [spaceTarget, classTarget] })))
+      expect(listedClass.targets[0]).toMatchObject({
+        rule: { kind: "classRule", objectClass: "document:class:Document" },
+        targetProject: "PRJ"
+      })
+
+      const captures: Captures = { removeDoc: {}, updateDoc: {} }
+      const updatedSpace = yield* setRelatedIssueTarget({
+        space: SpaceIdentifier.make("space-1"),
+        targetProject: null
+      }).pipe(Effect.provide(testLayer(captures, { relatedTargets: [spaceTarget] })))
+      expect(updatedSpace.created).toBe(false)
+      expect(captures.updateDoc?.operations).toEqual({ target: null })
+
+      const updatedClass = yield* setRelatedIssueTarget({
+        objectClass: ObjectClassName.make("document:class:Document"),
+        targetProject: ProjectIdentifier.make("PRJ")
+      }).pipe(Effect.provide(testLayer(captures, { relatedTargets: [classTarget] })))
+      expect(updatedClass.created).toBe(false)
+
+      const deleted = yield* deleteRelatedIssueSpaceTarget({ space: SpaceIdentifier.make("space-1") }).pipe(
+        Effect.provide(testLayer(captures, { relatedTargets: [spaceTarget] }))
+      )
+      expect(deleted).toEqual({ deleted: true, targetId: "related-target-1" })
+      expect(captures.removeDoc).toMatchObject({ id: "related-target-1", space: "space-1" })
+
+      const missingDelete = yield* Effect.exit(
+        deleteRelatedIssueSpaceTarget({ space: SpaceIdentifier.make("space-1") }).pipe(
+          Effect.provide(testLayer())
+        )
+      )
+      expect(Exit.isFailure(missingDelete)).toBe(true)
+    }))
+})

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -70,6 +70,17 @@ describe("CATEGORY_NAMES", () => {
       expect(names.has("list_device_preferences")).toBe(true)
       expect(names.has("list_office_defaults")).toBe(true)
     }))
+
+  it.effect("registers issue #102 closeout tools in their owning categories", () =>
+    Effect.gen(function*() {
+      expect(TOOL_DEFINITIONS.list_document_snapshots.category).toBe("documents")
+      expect(TOOL_DEFINITIONS.get_document_snapshot.category).toBe("documents")
+      expect(TOOL_DEFINITIONS.list_project_target_preferences.category).toBe("projects")
+      expect(TOOL_DEFINITIONS.upsert_project_target_preference.category).toBe("projects")
+      expect(TOOL_DEFINITIONS.list_related_issue_targets.category).toBe("issues")
+      expect(TOOL_DEFINITIONS.set_related_issue_target.category).toBe("issues")
+      expect(TOOL_DEFINITIONS.delete_related_issue_space_target.category).toBe("issues")
+    }))
 })
 
 describe("toolRegistry", () => {


### PR DESCRIPTION
## Summary
- add document snapshot list/get tools
- add project target preference list/upsert tools
- add related issue target list/set/delete tools
- update parity ledger, gap matrix, README metadata, and focused tests

## Verification
- pnpm update-readme
- pnpm check-all
- final master pnpm check-all after stacked merge rehearsal

Integration suite was not runnable in this environment because Docker is unavailable (`docker: command not found`).