### PR TITLE
Add Drive administration tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,12 @@ SDK upgrade revisit:
 |------|-------------|
 | `list_drives` | List Huly Drive spaces. When includeArchived is omitted, includeArchived=undefined. Use this before path operations when you do not know the exact drive id or exact drive name. |
 | `get_drive` | Get one Huly Drive by exact drive id or exact drive name. If an exact name is ambiguous, the error includes candidate ids so the next call can use the id. |
+| `create_drive` | Idempotently create a Huly Drive space. If an active Drive with the same exact name already exists, returns it with created=false. Initial members and owners accept account UUIDs, exact emails, or exact person names; omitted lists default to the caller. |
+| `update_drive` | Update safe metadata on an existing Drive: name, description, private, archived, or autoJoin. Provide at least one update field. This changes the Drive space, not files or folders inside it. |
+| `delete_drive` | Permanently delete an empty Huly Drive space. The Drive must contain no files or folders; non-empty Drives fail with child count and item summaries. This is permanent deletion, not archive or trash. |
+| `add_drive_members` | Idempotently add members to an existing Drive. Members accept account UUIDs, exact emails, or exact person names and resolve to Huly account UUIDs before replacing the Drive member list. |
+| `remove_drive_members` | Idempotently remove members from an existing Drive. Members accept account UUIDs, exact emails, or exact person names and resolve to Huly account UUIDs before replacing the Drive member list. |
+| `set_drive_owners` | Replace owners on an existing Drive. Owners accept account UUIDs, exact emails, or exact person names. By default, each owner is also ensured as a Drive member. Pass owners=[] to clear owners. |
 | `list_drive_items` | List children under a folder path in a Drive. Paths are POSIX-like and normalized to absolute; '/' lists the root. Duplicate same-parent titles fail with candidate ids instead of guessing. |
 | `get_drive_item` | Get one Drive folder or file by either exact itemId or path. Provide only one locator. File results include current version, size, MIME type, and download URL when available. |
 | `create_drive_folder` | Idempotently create a Drive folder path, creating missing parents like mkdir -p. Returns created=false when the full folder path already exists. |

--- a/src/domain/schemas/drive-admin.ts
+++ b/src/domain/schemas/drive-admin.ts
@@ -1,0 +1,137 @@
+import { JSONSchema, Schema } from "effect"
+
+import { clearableText } from "./clearable.js"
+import { DriveIdentifier, DriveSummarySchema } from "./drive.js"
+import {
+  AccountUuid,
+  assertUpdateFields,
+  atLeastOneUpdateFieldMessage,
+  DEFAULT_PRIVATE,
+  hasAtLeastOneDefined,
+  NonEmptyString,
+  withAtLeastOneRequired
+} from "./shared.js"
+import { DEFAULT_SPACE_OWNER_ENSURE_MEMBERS, SpaceMemberIdentifier } from "./spaces.js"
+
+export const DEFAULT_DRIVE_AUTO_JOIN = false
+
+export const CreateDriveResultSchema = Schema.Struct({
+  drive: DriveSummarySchema,
+  created: Schema.Boolean
+})
+export type CreateDriveResult = Schema.Schema.Type<typeof CreateDriveResultSchema>
+
+export const UpdateDriveResultSchema = Schema.Struct({
+  drive: DriveSummarySchema,
+  updated: Schema.Boolean
+})
+export type UpdateDriveResult = Schema.Schema.Type<typeof UpdateDriveResultSchema>
+
+export const DeleteDriveResultSchema = Schema.Struct({
+  drive: DriveSummarySchema,
+  deleted: Schema.Boolean
+})
+export type DeleteDriveResult = Schema.Schema.Type<typeof DeleteDriveResultSchema>
+
+export const DriveMemberMutationResultSchema = Schema.Struct({
+  drive: DriveSummarySchema,
+  members: Schema.Array(AccountUuid),
+  changed: Schema.Boolean
+})
+export type DriveMemberMutationResult = Schema.Schema.Type<typeof DriveMemberMutationResultSchema>
+
+export const SetDriveOwnersResultSchema = Schema.Struct({
+  drive: DriveSummarySchema,
+  owners: Schema.Array(AccountUuid),
+  members: Schema.Array(AccountUuid),
+  changed: Schema.Boolean
+})
+export type SetDriveOwnersResult = Schema.Schema.Type<typeof SetDriveOwnersResultSchema>
+
+export const CreateDriveParamsSchema = Schema.Struct({
+  name: NonEmptyString.annotations({
+    description: "Drive name. If an active Drive already has this name, it is returned unchanged."
+  }),
+  description: Schema.optional(Schema.String.annotations({ description: "Plain-text Drive description." })),
+  private: Schema.optional(Schema.Boolean.annotations({
+    description: `Whether the Drive is private. Defaults to ${DEFAULT_PRIVATE}.`
+  })),
+  autoJoin: Schema.optional(Schema.Boolean.annotations({
+    description: `Whether workspace members should auto-join the Drive. Defaults to ${DEFAULT_DRIVE_AUTO_JOIN}.`
+  })),
+  members: Schema.optional(
+    Schema.Array(SpaceMemberIdentifier).annotations({
+      description:
+        "Initial Drive members. Each entry may be an account UUID, exact email address, or exact person name. When omitted, the caller is added."
+    })
+  ),
+  owners: Schema.optional(
+    Schema.Array(SpaceMemberIdentifier).annotations({
+      description:
+        "Initial Drive owners. Each entry may be an account UUID, exact email address, or exact person name. When omitted, the caller is the owner."
+    })
+  )
+})
+export type CreateDriveParams = Schema.Schema.Type<typeof CreateDriveParamsSchema>
+
+export const UPDATE_DRIVE_FIELDS = ["name", "description", "private", "archived", "autoJoin"] as const
+
+export const UpdateDriveParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  name: Schema.optional(NonEmptyString.annotations({ description: "New Drive name." })),
+  description: Schema.optional(clearableText("New plain-text Drive description.")),
+  private: Schema.optional(Schema.Boolean.annotations({ description: "Whether the Drive is private." })),
+  archived: Schema.optional(Schema.Boolean.annotations({ description: "Whether the Drive is archived." })),
+  autoJoin: Schema.optional(Schema.Boolean.annotations({
+    description: "Whether workspace members should auto-join the Drive."
+  }))
+}).pipe(
+  Schema.filter((params) =>
+    hasAtLeastOneDefined(params, UPDATE_DRIVE_FIELDS)
+      ? undefined
+      : atLeastOneUpdateFieldMessage(UPDATE_DRIVE_FIELDS)
+  )
+)
+export type UpdateDriveParams = Schema.Schema.Type<typeof UpdateDriveParamsSchema>
+assertUpdateFields<UpdateDriveParams>()(["drive"], UPDATE_DRIVE_FIELDS)
+
+export const DeleteDriveParamsSchema = Schema.Struct({
+  drive: DriveIdentifier
+})
+export type DeleteDriveParams = Schema.Schema.Type<typeof DeleteDriveParamsSchema>
+
+export const DriveMemberMutationParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  members: Schema.Array(SpaceMemberIdentifier).pipe(Schema.minItems(1)).annotations({
+    description:
+      "Members to add or remove. Each entry may be an account UUID, exact email address, or exact person name."
+  })
+})
+export type DriveMemberMutationParams = Schema.Schema.Type<typeof DriveMemberMutationParamsSchema>
+
+export const SetDriveOwnersParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  owners: Schema.Array(SpaceMemberIdentifier).annotations({
+    description:
+      "Replacement Drive owner list. Each entry may be an account UUID, exact email address, or exact person name. Pass [] to clear owners."
+  }),
+  ensureMembers: Schema.optional(Schema.Boolean.annotations({
+    description: `Also add each owner to Drive members. Defaults to ${DEFAULT_SPACE_OWNER_ENSURE_MEMBERS}.`
+  }))
+})
+export type SetDriveOwnersParams = Schema.Schema.Type<typeof SetDriveOwnersParamsSchema>
+
+export const createDriveParamsJsonSchema = JSONSchema.make(CreateDriveParamsSchema)
+export const updateDriveParamsJsonSchema = withAtLeastOneRequired(
+  JSONSchema.make(UpdateDriveParamsSchema),
+  UPDATE_DRIVE_FIELDS
+)
+export const deleteDriveParamsJsonSchema = JSONSchema.make(DeleteDriveParamsSchema)
+export const driveMemberMutationParamsJsonSchema = JSONSchema.make(DriveMemberMutationParamsSchema)
+export const setDriveOwnersParamsJsonSchema = JSONSchema.make(SetDriveOwnersParamsSchema)
+
+export const parseCreateDriveParams = Schema.decodeUnknown(CreateDriveParamsSchema)
+export const parseUpdateDriveParams = Schema.decodeUnknown(UpdateDriveParamsSchema)
+export const parseDeleteDriveParams = Schema.decodeUnknown(DeleteDriveParamsSchema)
+export const parseDriveMemberMutationParams = Schema.decodeUnknown(DriveMemberMutationParamsSchema)
+export const parseSetDriveOwnersParams = Schema.decodeUnknown(SetDriveOwnersParamsSchema)

--- a/src/domain/schemas/drive.ts
+++ b/src/domain/schemas/drive.ts
@@ -85,6 +85,7 @@ export const DriveSummarySchema = Schema.Struct({
   description: Schema.optional(Schema.String),
   archived: Schema.Boolean,
   private: Schema.Boolean,
+  autoJoin: Schema.optional(Schema.Boolean),
   membersCount: Count,
   ownersCount: Count,
   url: UrlString

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -2085,6 +2085,41 @@ export {
 } from "./leads.js"
 
 export {
+  type CreateDriveParams,
+  createDriveParamsJsonSchema,
+  CreateDriveParamsSchema,
+  type CreateDriveResult,
+  CreateDriveResultSchema,
+  DEFAULT_DRIVE_AUTO_JOIN,
+  type DeleteDriveParams,
+  deleteDriveParamsJsonSchema,
+  DeleteDriveParamsSchema,
+  type DeleteDriveResult,
+  DeleteDriveResultSchema,
+  type DriveMemberMutationParams,
+  driveMemberMutationParamsJsonSchema,
+  DriveMemberMutationParamsSchema,
+  type DriveMemberMutationResult,
+  DriveMemberMutationResultSchema,
+  parseCreateDriveParams,
+  parseDeleteDriveParams,
+  parseDriveMemberMutationParams,
+  parseSetDriveOwnersParams,
+  parseUpdateDriveParams,
+  type SetDriveOwnersParams,
+  setDriveOwnersParamsJsonSchema,
+  SetDriveOwnersParamsSchema,
+  type SetDriveOwnersResult,
+  SetDriveOwnersResultSchema,
+  UPDATE_DRIVE_FIELDS,
+  type UpdateDriveParams,
+  updateDriveParamsJsonSchema,
+  UpdateDriveParamsSchema,
+  type UpdateDriveResult,
+  UpdateDriveResultSchema
+} from "./drive-admin.js"
+
+export {
   type CreateDriveFolderParams,
   createDriveFolderParamsJsonSchema,
   CreateDriveFolderParamsSchema,

--- a/src/huly/errors-drive.ts
+++ b/src/huly/errors-drive.ts
@@ -170,3 +170,18 @@ export class DriveFolderNotEmptyError extends Schema.TaggedError<DriveFolderNotE
     return `Drive folder '${this.path}' in drive '${this.drive}' is not empty (${this.childCount} child items).${suffix}`
   }
 }
+
+export class DriveNotEmptyError extends Schema.TaggedError<DriveNotEmptyError>()(
+  "DriveNotEmptyError",
+  {
+    drive: NonEmptyString,
+    childCount: Count,
+    children: Schema.Array(DriveFolderChildSummarySchema)
+  }
+) {
+  override get message(): string {
+    const shown = this.children.map((child) => `${child.title} (${child.kind} ${child.id})`).join(", ")
+    const suffix = shown.length === 0 ? "" : ` Children: ${shown}`
+    return `Drive '${this.drive}' is not empty (${this.childCount} child items).${suffix}`
+  }
+}

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -53,6 +53,7 @@ import {
   DriveIdentifierAmbiguousError,
   DriveInvalidItemOperationError,
   DriveInvalidMoveError,
+  DriveNotEmptyError,
   DriveNotFoundError,
   DriveParentNotFolderError,
   DrivePathAmbiguousError,
@@ -184,6 +185,7 @@ export {
   DriveIdentifierAmbiguousError,
   DriveInvalidItemOperationError,
   DriveInvalidMoveError,
+  DriveNotEmptyError,
   DriveNotFoundError,
   DriveParentNotFolderError,
   DrivePathAmbiguousError,
@@ -389,7 +391,8 @@ export const HulyDomainError = Schema.Union(
   DrivePathConflictError,
   DriveInvalidMoveError,
   DriveInvalidItemOperationError,
-  DriveFolderNotEmptyError
+  DriveFolderNotEmptyError,
+  DriveNotEmptyError
 )
 
 /**

--- a/src/huly/operations/drive-admin.ts
+++ b/src/huly/operations/drive-admin.ts
@@ -1,0 +1,266 @@
+import type { AccountUuid as HulyAccountUuid, Data, DocumentUpdate, Ref, Space, SpaceType } from "@hcengineering/core"
+import { generateId } from "@hcengineering/core"
+import { Effect } from "effect"
+
+import type {
+  CreateDriveParams,
+  CreateDriveResult,
+  DeleteDriveParams,
+  DeleteDriveResult,
+  DriveMemberMutationParams,
+  DriveMemberMutationResult,
+  SetDriveOwnersParams,
+  SetDriveOwnersResult,
+  UpdateDriveParams,
+  UpdateDriveResult
+} from "../../domain/schemas/drive-admin.js"
+import { DEFAULT_DRIVE_AUTO_JOIN, UPDATE_DRIVE_FIELDS } from "../../domain/schemas/drive-admin.js"
+import { AccountUuid, Count, DEFAULT_PRIVATE } from "../../domain/schemas/shared.js"
+import { DEFAULT_SPACE_OWNER_ENSURE_MEMBERS } from "../../domain/schemas/spaces.js"
+import { HulyClient } from "../client.js"
+import { drive, type DriveSpace, type File, type Folder } from "../drive-sdk.js"
+import { DriveNotEmptyError } from "../errors-drive.js"
+import { core } from "../huly-plugins.js"
+import { clearTextAsEmptyString } from "./clear-field-updates.js"
+import { toDriveSummary } from "./drive-mappers.js"
+import { resolveDrive } from "./drive-resolvers.js"
+import { type DriveOperationError, driveTextOrUntitled, itemKind } from "./drive-shared.js"
+import { hulyQuery } from "./query-helpers.js"
+import { toAccountUuid, toRef } from "./sdk-boundary.js"
+import {
+  arraysEqual,
+  mergeUniqueSortedAccountUuids,
+  removeAccountUuids,
+  resolveMembers,
+  sortStrings
+} from "./spaces-shared.js"
+import { type DirectUpdateEntry, mergeUpdateEntries, requireUpdateFields } from "./update-guards.js"
+
+const DRIVE_NOT_EMPTY_CHILD_SUMMARY_LIMIT = 5
+
+type MemberListMutation = (
+  currentMembers: ReadonlyArray<HulyAccountUuid>,
+  resolvedMembers: ReadonlyArray<HulyAccountUuid>
+) => ReadonlyArray<HulyAccountUuid>
+
+type UpdateDriveField = typeof UPDATE_DRIVE_FIELDS[number]
+
+type UpdateDriveEntries = {
+  readonly [Field in UpdateDriveField]: DirectUpdateEntry<UpdateDriveField, DocumentUpdate<DriveSpace>, Field>
+}
+
+const currentAccountMemberList = (client: HulyClient["Type"]): ReadonlyArray<HulyAccountUuid> => [
+  client.getAccountUuid()
+]
+
+const resolveInitialMembers = (
+  client: HulyClient["Type"],
+  params: CreateDriveParams
+): Effect.Effect<
+  { readonly members: ReadonlyArray<HulyAccountUuid>; readonly owners: ReadonlyArray<HulyAccountUuid> },
+  DriveOperationError
+> =>
+  Effect.gen(function*() {
+    const owners = params.owners === undefined
+      ? currentAccountMemberList(client)
+      : yield* resolveMembers(client, params.owners)
+    const baseMembers = params.members === undefined
+      ? currentAccountMemberList(client)
+      : yield* resolveMembers(client, params.members)
+
+    return {
+      members: mergeUniqueSortedAccountUuids(baseMembers, owners),
+      owners: sortStrings(owners)
+    }
+  })
+
+const buildUpdateDriveOperations = (params: UpdateDriveParams): DocumentUpdate<DriveSpace> => {
+  const updateEntries = {
+    name: params.name === undefined ? {} : { name: params.name },
+    description: params.description === undefined ? {} : { description: clearTextAsEmptyString(params.description) },
+    private: params.private === undefined ? {} : { private: params.private },
+    archived: params.archived === undefined ? {} : { archived: params.archived },
+    autoJoin: params.autoJoin === undefined ? {} : { autoJoin: params.autoJoin }
+  } satisfies UpdateDriveEntries
+
+  return mergeUpdateEntries(Object.values(updateEntries))
+}
+
+const updateDriveDoc = (
+  client: HulyClient["Type"],
+  driveSpace: DriveSpace,
+  operations: DocumentUpdate<DriveSpace>
+): Effect.Effect<void, DriveOperationError> =>
+  client.updateDoc(drive.class.Drive, core.space.Space, driveSpace._id, operations).pipe(Effect.asVoid)
+
+const withDriveUpdates = (
+  driveSpace: DriveSpace,
+  operations: DocumentUpdate<DriveSpace>
+): DriveSpace => ({ ...driveSpace, ...operations })
+
+const mutateDriveMembers = (
+  params: DriveMemberMutationParams,
+  mutateMembers: MemberListMutation
+): Effect.Effect<DriveMemberMutationResult, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const driveSpace = yield* resolveDrive(client, params.drive)
+    const resolvedMembers = yield* resolveMembers(client, params.members)
+    const nextMembers = mutateMembers(driveSpace.members, resolvedMembers).map(toAccountUuid)
+    const changed = !arraysEqual(sortStrings(driveSpace.members), nextMembers)
+    const updatedDrive = changed ? { ...driveSpace, members: nextMembers } : driveSpace
+
+    if (changed) {
+      yield* updateDriveDoc(client, driveSpace, { members: nextMembers })
+    }
+
+    return {
+      drive: toDriveSummary(client, updatedDrive),
+      members: nextMembers.map((member) => AccountUuid.make(member)),
+      changed
+    }
+  })
+
+const driveChildSummary = (item: Folder | File) => ({
+  id: driveTextOrUntitled(item._id),
+  title: driveTextOrUntitled(item.title),
+  kind: itemKind(item)
+})
+
+const findDriveChildren = (
+  client: HulyClient["Type"],
+  driveSpace: DriveSpace
+): Effect.Effect<
+  { readonly folders: ReadonlyArray<Folder>; readonly files: ReadonlyArray<File> },
+  DriveOperationError
+> =>
+  Effect.gen(function*() {
+    const folders = yield* client.findAll<Folder>(drive.class.Folder, hulyQuery<Folder>({ space: driveSpace._id }))
+    const files = yield* client.findAll<File>(drive.class.File, hulyQuery<File>({ space: driveSpace._id }))
+    return { folders, files }
+  })
+
+export const createDrive = (
+  params: CreateDriveParams
+): Effect.Effect<CreateDriveResult, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const existing = yield* client.findOne<DriveSpace>(
+      drive.class.Drive,
+      hulyQuery<DriveSpace>({ name: params.name, archived: false })
+    )
+
+    if (existing !== undefined) {
+      return { drive: toDriveSummary(client, existing), created: false }
+    }
+
+    const initial = yield* resolveInitialMembers(client, params)
+    const driveId: Ref<DriveSpace> = generateId()
+    const driveData: Data<DriveSpace> = {
+      name: params.name,
+      description: params.description ?? "",
+      private: params.private ?? DEFAULT_PRIVATE,
+      archived: false,
+      members: initial.members.map(toAccountUuid),
+      owners: initial.owners.map(toAccountUuid),
+      type: toRef<SpaceType>(drive.spaceType.DefaultDrive),
+      autoJoin: params.autoJoin ?? DEFAULT_DRIVE_AUTO_JOIN
+    }
+
+    yield* client.createDoc(drive.class.Drive, core.space.Space, driveData, driveId)
+
+    return {
+      drive: toDriveSummary(client, {
+        _id: driveId,
+        _class: drive.class.Drive,
+        space: toRef<Space>(core.space.Space),
+        modifiedBy: client.getPrimarySocialId(),
+        modifiedOn: 0,
+        createdBy: client.getPrimarySocialId(),
+        createdOn: 0,
+        ...driveData
+      }),
+      created: true
+    }
+  })
+
+export const updateDrive = (
+  params: UpdateDriveParams
+): Effect.Effect<UpdateDriveResult, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    yield* requireUpdateFields("update_drive", params, UPDATE_DRIVE_FIELDS)
+    const client = yield* HulyClient
+    const driveSpace = yield* resolveDrive(client, params.drive)
+    const operations = buildUpdateDriveOperations(params)
+
+    yield* updateDriveDoc(client, driveSpace, operations)
+    return { drive: toDriveSummary(client, withDriveUpdates(driveSpace, operations)), updated: true }
+  })
+
+export const deleteDrive = (
+  params: DeleteDriveParams
+): Effect.Effect<DeleteDriveResult, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const driveSpace = yield* resolveDrive(client, params.drive)
+    const children = yield* findDriveChildren(client, driveSpace)
+    const childItems = [...children.folders, ...children.files]
+
+    if (childItems.length > 0) {
+      return yield* Effect.fail(
+        new DriveNotEmptyError({
+          drive: params.drive,
+          childCount: Count.make(childItems.length),
+          children: childItems.slice(0, DRIVE_NOT_EMPTY_CHILD_SUMMARY_LIMIT).map(driveChildSummary)
+        })
+      )
+    }
+
+    yield* client.removeDoc(drive.class.Drive, core.space.Space, driveSpace._id)
+    return { drive: toDriveSummary(client, driveSpace), deleted: true }
+  })
+
+export const addDriveMembers = (
+  params: DriveMemberMutationParams
+): Effect.Effect<DriveMemberMutationResult, DriveOperationError, HulyClient> =>
+  mutateDriveMembers(params, mergeUniqueSortedAccountUuids)
+
+export const removeDriveMembers = (
+  params: DriveMemberMutationParams
+): Effect.Effect<DriveMemberMutationResult, DriveOperationError, HulyClient> =>
+  mutateDriveMembers(params, removeAccountUuids)
+
+export const setDriveOwners = (
+  params: SetDriveOwnersParams
+): Effect.Effect<SetDriveOwnersResult, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const driveSpace = yield* resolveDrive(client, params.drive)
+    const owners = (yield* resolveMembers(client, params.owners)).map(toAccountUuid)
+    const ensureMembers = params.ensureMembers ?? DEFAULT_SPACE_OWNER_ENSURE_MEMBERS
+    const nextMembers = ensureMembers
+      ? mergeUniqueSortedAccountUuids(driveSpace.members, owners).map(toAccountUuid)
+      : sortStrings(driveSpace.members).map(toAccountUuid)
+    const currentOwners = sortStrings(driveSpace.owners ?? []).map(toAccountUuid)
+    const changedOwners = !arraysEqual(currentOwners, owners)
+    const changedMembers = !arraysEqual(sortStrings(driveSpace.members), nextMembers)
+    const updatedDrive: DriveSpace = {
+      ...driveSpace,
+      owners,
+      members: nextMembers
+    }
+
+    if (changedOwners || changedMembers) {
+      yield* updateDriveDoc(client, driveSpace, {
+        owners,
+        ...(changedMembers ? { members: nextMembers } : {})
+      })
+    }
+
+    return {
+      drive: toDriveSummary(client, updatedDrive),
+      owners: owners.map((owner) => AccountUuid.make(owner)),
+      members: nextMembers.map((member) => AccountUuid.make(member)),
+      changed: changedOwners || changedMembers
+    }
+  })

--- a/src/huly/operations/drive-mappers.ts
+++ b/src/huly/operations/drive-mappers.ts
@@ -17,6 +17,7 @@ export const toDriveSummary = (client: HulyClientOperations, item: DriveSpace): 
     name: driveTextOrUntitled(item.name),
     archived: item.archived,
     private: item.private,
+    autoJoin: item.autoJoin,
     membersCount: Count.make(item.members.length),
     ownersCount: Count.make((item.owners ?? []).length),
     url: buildDriveUrlFromConfig(client.workbenchUrlConfig, DriveId.make(item._id))

--- a/src/huly/operations/drive-shared.ts
+++ b/src/huly/operations/drive-shared.ts
@@ -8,6 +8,7 @@ import type {
   DriveIdentifierAmbiguousError,
   DriveInvalidItemOperationError,
   DriveInvalidMoveError,
+  DriveNotEmptyError,
   DriveNotFoundError,
   DriveParentNotFolderError,
   DrivePathAmbiguousError,
@@ -33,6 +34,7 @@ export type DriveOperationError =
   | DriveInvalidMoveError
   | DriveInvalidItemOperationError
   | DriveFolderNotEmptyError
+  | DriveNotEmptyError
 
 export type DriveItem = Folder | File
 

--- a/src/huly/operations/drive.ts
+++ b/src/huly/operations/drive.ts
@@ -50,6 +50,14 @@ import { makeFileVersionData, uploadSource } from "./drive-upload-shared.js"
 import { clampLimit, hulyQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
+export {
+  addDriveMembers,
+  createDrive,
+  deleteDrive,
+  removeDriveMembers,
+  setDriveOwners,
+  updateDrive
+} from "./drive-admin.js"
 export { deleteDriveItem, moveDriveItem, renameDriveItem, uploadDriveFileVersion } from "./drive-file-operations.js"
 
 export const listDrives = (

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -164,6 +164,7 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "DriveInvalidMoveError",
   "DriveInvalidItemOperationError",
   "DriveFolderNotEmptyError",
+  "DriveNotEmptyError",
   "NoUpdateFieldsError"
 ])
 

--- a/src/mcp/tools/drive.ts
+++ b/src/mcp/tools/drive.ts
@@ -1,9 +1,15 @@
 import {
   createDriveFolderParamsJsonSchema,
   CreateDriveFolderResultSchema,
+  createDriveParamsJsonSchema,
+  CreateDriveResultSchema,
   deleteDriveItemParamsJsonSchema,
   DeleteDriveItemResultSchema,
+  deleteDriveParamsJsonSchema,
+  DeleteDriveResultSchema,
   DriveItemSummarySchema,
+  driveMemberMutationParamsJsonSchema,
+  DriveMemberMutationResultSchema,
   DriveSummarySchema,
   getDriveItemParamsJsonSchema,
   getDriveParamsJsonSchema,
@@ -16,7 +22,10 @@ import {
   moveDriveItemParamsJsonSchema,
   MoveDriveItemResultSchema,
   parseCreateDriveFolderParams,
+  parseCreateDriveParams,
   parseDeleteDriveItemParams,
+  parseDeleteDriveParams,
+  parseDriveMemberMutationParams,
   parseGetDriveItemParams,
   parseGetDriveParams,
   parseListDriveFileVersionsParams,
@@ -25,12 +34,18 @@ import {
   parseMoveDriveItemParams,
   parseRenameDriveItemParams,
   parseRestoreDriveFileVersionParams,
+  parseSetDriveOwnersParams,
+  parseUpdateDriveParams,
   parseUploadDriveFileParams,
   parseUploadDriveFileVersionParams,
   renameDriveItemParamsJsonSchema,
   RenameDriveItemResultSchema,
   restoreDriveFileVersionParamsJsonSchema,
   RestoreDriveFileVersionResultSchema,
+  setDriveOwnersParamsJsonSchema,
+  SetDriveOwnersResultSchema,
+  updateDriveParamsJsonSchema,
+  UpdateDriveResultSchema,
   uploadDriveFileParamsJsonSchema,
   UploadDriveFileResultSchema,
   uploadDriveFileVersionParamsJsonSchema,
@@ -38,7 +53,10 @@ import {
 } from "../../domain/schemas.js"
 import { DEFAULT_INCLUDE_ARCHIVED } from "../../domain/schemas/shared.js"
 import {
+  addDriveMembers,
+  createDrive,
   createDriveFolder,
+  deleteDrive,
   deleteDriveItem,
   getDrive,
   getDriveItem,
@@ -46,8 +64,11 @@ import {
   listDriveItems,
   listDrives,
   moveDriveItem,
+  removeDriveMembers,
   renameDriveItem,
   restoreDriveFileVersion,
+  setDriveOwners,
+  updateDrive,
   uploadDriveFile,
   uploadDriveFileVersion
 } from "../../huly/operations/drive.js"
@@ -71,6 +92,90 @@ export const driveTools: ReadonlyArray<RegisteredTool> = [
     category: CATEGORY,
     inputSchema: getDriveParamsJsonSchema,
     handler: createEncodedCombinedToolHandler("get_drive", parseGetDriveParams, getDrive, DriveSummarySchema)
+  },
+  {
+    name: "create_drive",
+    description:
+      "Idempotently create a Huly Drive space. If an active Drive with the same exact name already exists, returns it with created=false. Initial members and owners accept account UUIDs, exact emails, or exact person names; omitted lists default to the caller.",
+    category: CATEGORY,
+    inputSchema: createDriveParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "create_drive",
+      parseCreateDriveParams,
+      createDrive,
+      CreateDriveResultSchema
+    )
+  },
+  {
+    name: "update_drive",
+    description:
+      "Update safe metadata on an existing Drive: name, description, private, archived, or autoJoin. Provide at least one update field. This changes the Drive space, not files or folders inside it.",
+    category: CATEGORY,
+    inputSchema: updateDriveParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "update_drive",
+      parseUpdateDriveParams,
+      updateDrive,
+      UpdateDriveResultSchema
+    )
+  },
+  {
+    name: "delete_drive",
+    description:
+      "Permanently delete an empty Huly Drive space. The Drive must contain no files or folders; non-empty Drives fail with child count and item summaries. This is permanent deletion, not archive or trash.",
+    category: CATEGORY,
+    inputSchema: deleteDriveParamsJsonSchema,
+    annotations: { idempotentHint: false, destructiveHint: true },
+    handler: createEncodedCombinedToolHandler(
+      "delete_drive",
+      parseDeleteDriveParams,
+      deleteDrive,
+      DeleteDriveResultSchema
+    )
+  },
+  {
+    name: "add_drive_members",
+    description:
+      "Idempotently add members to an existing Drive. Members accept account UUIDs, exact emails, or exact person names and resolve to Huly account UUIDs before replacing the Drive member list.",
+    category: CATEGORY,
+    inputSchema: driveMemberMutationParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "add_drive_members",
+      parseDriveMemberMutationParams,
+      addDriveMembers,
+      DriveMemberMutationResultSchema
+    )
+  },
+  {
+    name: "remove_drive_members",
+    description:
+      "Idempotently remove members from an existing Drive. Members accept account UUIDs, exact emails, or exact person names and resolve to Huly account UUIDs before replacing the Drive member list.",
+    category: CATEGORY,
+    inputSchema: driveMemberMutationParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "remove_drive_members",
+      parseDriveMemberMutationParams,
+      removeDriveMembers,
+      DriveMemberMutationResultSchema
+    )
+  },
+  {
+    name: "set_drive_owners",
+    description:
+      "Replace owners on an existing Drive. Owners accept account UUIDs, exact emails, or exact person names. By default, each owner is also ensured as a Drive member. Pass owners=[] to clear owners.",
+    category: CATEGORY,
+    inputSchema: setDriveOwnersParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "set_drive_owners",
+      parseSetDriveOwnersParams,
+      setDriveOwners,
+      SetDriveOwnersResultSchema
+    )
   },
   {
     name: "list_drive_items",

--- a/test/domain/schemas.drive.test.ts
+++ b/test/domain/schemas.drive.test.ts
@@ -3,21 +3,31 @@ import { Effect, Schema } from "effect"
 import { expect } from "vitest"
 
 import {
+  CreateDriveResultSchema,
   DeleteDriveItemResultSchema,
+  DeleteDriveResultSchema,
   DriveFileVersionSummarySchema,
   DriveItemSummarySchema,
   DriveItemTitle,
+  DriveMemberMutationResultSchema,
+  DriveSummarySchema,
   MoveDriveItemResultSchema,
   parseDeleteDriveItemParams,
+  parseDriveMemberMutationParams,
   parseGetDriveItemParams,
   parseMoveDriveItemParams,
   parseRenameDriveItemParams,
+  parseSetDriveOwnersParams,
+  parseUpdateDriveParams,
   parseUploadDriveFileParams,
   parseUploadDriveFileVersionParams,
   RenameDriveItemResultSchema,
+  SetDriveOwnersResultSchema,
+  UpdateDriveResultSchema,
   uploadDriveFileParamsJsonSchema,
   UploadDriveFileVersionResultSchema
 } from "../../src/domain/schemas.js"
+import { AccountUuid } from "../../src/domain/schemas/shared.js"
 import { normalizeDrivePath } from "../../src/huly/operations/drive-path.js"
 
 describe("drive schemas", () => {
@@ -116,6 +126,28 @@ describe("drive schemas", () => {
       expect(moveAmbiguousLocator._tag).toBe("Left")
       expect(versionMissingSource._tag).toBe("Left")
       expect(versionConflictingSource._tag).toBe("Left")
+    }))
+
+  it.effect("validates Drive administration params", () =>
+    Effect.gen(function*() {
+      const updateMissingField = yield* Effect.either(parseUpdateDriveParams({ drive: "Docs" }))
+      const updateAccepted = yield* parseUpdateDriveParams({ drive: "Docs", autoJoin: true })
+      const memberMissing = yield* Effect.either(parseDriveMemberMutationParams({ drive: "Docs", members: [] }))
+      const memberAccepted = yield* parseDriveMemberMutationParams({
+        drive: "Docs",
+        members: ["00000000-0000-4000-8000-000000000001"]
+      })
+      const ownersAccepted = yield* parseSetDriveOwnersParams({
+        drive: "Docs",
+        owners: ["00000000-0000-4000-8000-000000000002"],
+        ensureMembers: false
+      })
+
+      expect(updateMissingField._tag).toBe("Left")
+      expect(updateAccepted.autoJoin).toBe(true)
+      expect(memberMissing._tag).toBe("Left")
+      expect(memberAccepted.members).toEqual(["00000000-0000-4000-8000-000000000001"])
+      expect(ownersAccepted.ensureMembers).toBe(false)
     }))
 
   it.effect("rejects root paths for item mutations", () =>
@@ -221,6 +253,44 @@ describe("drive schemas", () => {
       expect(moved.toPath).toBe("/Specs/API.md")
       expect(renamed.renamed).toBe(true)
       expect(deleted.deletedVersions).toBe(2)
+    }))
+
+  it.effect("encodes branded outputs for Drive administration operations", () =>
+    Effect.gen(function*() {
+      const drive = yield* Schema.decodeUnknown(DriveSummarySchema)({
+        id: "drive-1",
+        name: "Docs",
+        description: "Drive docs",
+        archived: false,
+        private: true,
+        autoJoin: true,
+        membersCount: 2,
+        ownersCount: 1,
+        url: "https://huly.test/workbench/ws/drive/drive-1"
+      })
+      const created = yield* Schema.encode(CreateDriveResultSchema)({ drive, created: true })
+      const updated = yield* Schema.encode(UpdateDriveResultSchema)({ drive, updated: true })
+      const deleted = yield* Schema.encode(DeleteDriveResultSchema)({ drive, deleted: true })
+      const members = yield* Schema.encode(DriveMemberMutationResultSchema)({
+        drive,
+        members: [AccountUuid.make("00000000-0000-4000-8000-000000000001")],
+        changed: true
+      })
+      const owners = yield* Schema.encode(SetDriveOwnersResultSchema)({
+        drive,
+        owners: [AccountUuid.make("00000000-0000-4000-8000-000000000002")],
+        members: [
+          AccountUuid.make("00000000-0000-4000-8000-000000000001"),
+          AccountUuid.make("00000000-0000-4000-8000-000000000002")
+        ],
+        changed: true
+      })
+
+      expect(created.drive.id).toBe("drive-1")
+      expect(updated.drive.autoJoin).toBe(true)
+      expect(deleted.deleted).toBe(true)
+      expect(members.members).toEqual(["00000000-0000-4000-8000-000000000001"])
+      expect(owners.owners).toEqual(["00000000-0000-4000-8000-000000000002"])
     }))
 
   it("exposes source alternatives in upload JSON schema", () => {

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -42,6 +42,7 @@ import {
   DriveIdentifierAmbiguousError,
   DriveInvalidItemOperationError,
   DriveInvalidMoveError,
+  DriveNotEmptyError,
   DriveNotFoundError,
   DriveParentNotFolderError,
   DrivePathAmbiguousError,
@@ -962,6 +963,8 @@ describe("Huly Errors", () => {
               return `drive-invalid-item-operation:${error.drive}:${error.path}:${error.operation}:${error.reason}`
             case "DriveFolderNotEmptyError":
               return `drive-folder-not-empty:${error.drive}:${error.path}:${error.childCount}:${error.children.length}`
+            case "DriveNotEmptyError":
+              return `drive-not-empty:${error.drive}:${error.childCount}:${error.children.length}`
             default: {
               const _exhaustive: never = error
               return _exhaustive
@@ -1324,6 +1327,27 @@ describe("Huly Errors", () => {
             children: []
           }).message
         ).toBe("Drive folder '/Specs' in drive 'Docs' is not empty (0 child items).")
+        expect(matchError(
+          new DriveNotEmptyError({
+            drive: "Docs",
+            childCount: Count.make(1),
+            children: [{ id: "folder-1", title: "Specs", kind: "folder" }]
+          })
+        )).toBe("drive-not-empty:Docs:1:1")
+        expect(
+          new DriveNotEmptyError({
+            drive: "Docs",
+            childCount: Count.make(1),
+            children: [{ id: "folder-1", title: "Specs", kind: "folder" }]
+          }).message
+        ).toBe("Drive 'Docs' is not empty (1 child items). Children: Specs (folder folder-1)")
+        expect(
+          new DriveNotEmptyError({
+            drive: "Docs",
+            childCount: Count.make(0),
+            children: []
+          }).message
+        ).toBe("Drive 'Docs' is not empty (0 child items).")
       }))
   })
 })

--- a/test/huly/operations/drive.test.ts
+++ b/test/huly/operations/drive.test.ts
@@ -17,7 +17,10 @@ import { expect } from "vitest"
 
 import {
   parseCreateDriveFolderParams,
+  parseCreateDriveParams,
   parseDeleteDriveItemParams,
+  parseDeleteDriveParams,
+  parseDriveMemberMutationParams,
   parseGetDriveItemParams,
   parseGetDriveParams,
   parseListDriveFileVersionsParams,
@@ -26,10 +29,12 @@ import {
   parseMoveDriveItemParams,
   parseRenameDriveItemParams,
   parseRestoreDriveFileVersionParams,
+  parseSetDriveOwnersParams,
+  parseUpdateDriveParams,
   parseUploadDriveFileParams,
   parseUploadDriveFileVersionParams
 } from "../../../src/domain/schemas.js"
-import { BlobId } from "../../../src/domain/schemas/shared.js"
+import { AccountUuid, BlobId } from "../../../src/domain/schemas/shared.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import { drive, type DriveSpace, type File, type FileVersion, type Folder } from "../../../src/huly/drive-sdk.js"
 import {
@@ -39,6 +44,7 @@ import {
   DriveIdentifierAmbiguousError,
   DriveInvalidItemOperationError,
   DriveInvalidMoveError,
+  DriveNotEmptyError,
   DriveNotFoundError,
   DriveParentNotFolderError,
   DrivePathAmbiguousError,
@@ -46,7 +52,10 @@ import {
   DrivePathNotFoundError
 } from "../../../src/huly/errors-drive.js"
 import {
+  addDriveMembers,
+  createDrive,
   createDriveFolder,
+  deleteDrive,
   deleteDriveItem,
   getDrive,
   getDriveItem,
@@ -54,12 +63,15 @@ import {
   listDriveItems,
   listDrives,
   moveDriveItem,
+  removeDriveMembers,
   renameDriveItem,
   restoreDriveFileVersion,
+  setDriveOwners,
+  updateDrive,
   uploadDriveFile,
   uploadDriveFileVersion
 } from "../../../src/huly/operations/drive.js"
-import { toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import { toAccountUuid, toRef } from "../../../src/huly/operations/sdk-boundary.js"
 import { HulyStorageClient, type HulyStorageOperations } from "../../../src/huly/storage.js"
 import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
 import { corePersonId, findResult } from "../../helpers/huly-sdk.js"
@@ -70,6 +82,7 @@ interface DriveState {
   readonly files: Array<File>
   readonly versions: Array<FileVersion>
   nextId: number
+  readonly updatedDrives?: Array<{ readonly id: string; readonly operations: DocumentUpdate<DriveSpace> }>
   readonly updatedFiles?: Array<{ readonly id: string; readonly operations: DocumentUpdate<File> }>
   readonly updatedFolders?: Array<{ readonly id: string; readonly operations: DocumentUpdate<Folder> }>
   readonly removedDocs?: Array<{ readonly classRef: string; readonly id: string }>
@@ -78,6 +91,8 @@ interface DriveState {
 }
 
 const personId = corePersonId("person-1")
+const accountA = toAccountUuid(AccountUuid.make("00000000-0000-4000-8000-000000000001"))
+const accountB = toAccountUuid(AccountUuid.make("00000000-0000-4000-8000-000000000002"))
 const driveSpace = (id = "drive-1", name = "Docs"): DriveSpace => ({
   _id: toRef<DriveSpace>(id),
   _class: drive.class.Drive,
@@ -86,6 +101,7 @@ const driveSpace = (id = "drive-1", name = "Docs"): DriveSpace => ({
   description: "Drive docs",
   private: false,
   archived: false,
+  autoJoin: false,
   members: [],
   owners: [],
   modifiedBy: personId,
@@ -191,6 +207,18 @@ const makeLayer = (state: DriveState): Layer.Layer<HulyClient | HulyStorageClien
     id?: Ref<T>
   ) => {
     const next = id ?? toRef<T>(`created-${state.nextId++}`)
+    if (classRef === drive.class.Drive) {
+      state.drives.push({
+        _id: next as unknown as Ref<DriveSpace>,
+        _class: drive.class.Drive,
+        space,
+        modifiedBy: personId,
+        modifiedOn: 0,
+        createdBy: personId,
+        createdOn: 0,
+        ...(attributes as unknown as Data<DriveSpace>)
+      })
+    }
     if (classRef === drive.class.FileVersion) {
       state.versions.push({
         _id: next as unknown as Ref<FileVersion>,
@@ -240,6 +268,15 @@ const makeLayer = (state: DriveState): Layer.Layer<HulyClient | HulyStorageClien
     objectId: Ref<T>,
     operations: DocumentUpdate<T>
   ) => {
+    if (classRef === drive.class.Drive) {
+      state.updatedDrives?.push({
+        id: String(objectId),
+        operations: operations as unknown as DocumentUpdate<DriveSpace>
+      })
+      const targetIndex = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
+      const target = state.drives[targetIndex]
+      state.drives[targetIndex] = { ...target, ...(operations as unknown as Partial<DriveSpace>) }
+    }
     if (classRef === drive.class.File) {
       state.updatedFiles?.push({ id: String(objectId), operations: operations as unknown as DocumentUpdate<File> })
       const targetIndex = state.files.findIndex((candidate) => String(candidate._id) === String(objectId))
@@ -279,6 +316,10 @@ const makeLayer = (state: DriveState): Layer.Layer<HulyClient | HulyStorageClien
     objectId: Ref<T>
   ) => {
     state.removedDocs?.push({ classRef: String(classRef), id: String(objectId) })
+    if (classRef === drive.class.Drive) {
+      const index = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
+      if (index >= 0) state.drives.splice(index, 1)
+    }
     if (classRef === drive.class.File) {
       const index = state.files.findIndex((candidate) => String(candidate._id) === String(objectId))
       if (index >= 0) state.files.splice(index, 1)
@@ -358,6 +399,219 @@ describe("drive operations", () => {
       expect(ambiguous).toBeInstanceOf(DriveIdentifierAmbiguousError)
       expect(notFound).toBeInstanceOf(DriveNotFoundError)
       expect(unfiltered.drives).toContainEqual(expect.objectContaining({ name: "(untitled)", ownersCount: 0 }))
+    }))
+
+  it.effect("creates a Drive idempotently and defaults caller membership", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1
+      }
+
+      const params = yield* parseCreateDriveParams({ name: "Specs", private: true, autoJoin: true })
+      const created = yield* createDrive(params).pipe(Effect.provide(makeLayer(state)))
+      const repeated = yield* createDrive(params).pipe(Effect.provide(makeLayer(state)))
+
+      expect(created.created).toBe(true)
+      expect(created.drive).toMatchObject({ name: "Specs", private: true, autoJoin: true, membersCount: 1 })
+      expect(repeated.created).toBe(false)
+      expect(state.drives).toHaveLength(1)
+      expect(state.drives[0].members).toEqual(["00000000-0000-4000-8000-000000000000"])
+      expect(state.drives[0].owners).toEqual(["00000000-0000-4000-8000-000000000000"])
+    }))
+
+  it.effect("creates a Drive with explicit initial members and owners", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1
+      }
+
+      const params = yield* parseCreateDriveParams({
+        name: "Team Drive",
+        members: [accountA],
+        owners: [accountB]
+      })
+      const created = yield* createDrive(params).pipe(Effect.provide(makeLayer(state)))
+
+      expect(created.created).toBe(true)
+      expect(created.drive).toMatchObject({ name: "Team Drive", membersCount: 2, ownersCount: 1 })
+      expect(state.drives[0].members).toEqual([accountA, accountB])
+      expect(state.drives[0].owners).toEqual([accountB])
+    }))
+
+  it.effect("updates Drive metadata with clearable description", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [driveSpace()],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        updatedDrives: []
+      }
+
+      const params = yield* parseUpdateDriveParams({
+        drive: "Docs",
+        name: "Knowledge",
+        description: null,
+        private: true,
+        archived: true,
+        autoJoin: true
+      })
+      const result = yield* updateDrive(params).pipe(Effect.provide(makeLayer(state)))
+
+      expect(result.drive).toMatchObject({ name: "Knowledge", private: true, archived: true, autoJoin: true })
+      expect(state.updatedDrives).toEqual([{
+        id: "drive-1",
+        operations: {
+          name: "Knowledge",
+          description: "",
+          private: true,
+          archived: true,
+          autoJoin: true
+        }
+      }])
+    }))
+
+  it.effect("updates only supplied Drive fields", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [driveSpace()],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        updatedDrives: []
+      }
+
+      const params = yield* parseUpdateDriveParams({
+        drive: "Docs",
+        autoJoin: true
+      })
+      const result = yield* updateDrive(params).pipe(Effect.provide(makeLayer(state)))
+
+      expect(result.drive).toMatchObject({ name: "Docs", autoJoin: true })
+      expect(state.updatedDrives).toEqual([{
+        id: "drive-1",
+        operations: {
+          autoJoin: true
+        }
+      }])
+    }))
+
+  it.effect("adds, removes, and replaces Drive members and owners idempotently", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [{ ...driveSpace(), members: [accountA], owners: [accountA] }],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        updatedDrives: []
+      }
+
+      const addParams = yield* parseDriveMemberMutationParams({ drive: "Docs", members: [accountB] })
+      const added = yield* addDriveMembers(addParams).pipe(Effect.provide(makeLayer(state)))
+      const addedAgain = yield* addDriveMembers(addParams).pipe(Effect.provide(makeLayer(state)))
+      const ownerParams = yield* parseSetDriveOwnersParams({ drive: "Docs", owners: [accountB] })
+      const owners = yield* setDriveOwners(ownerParams).pipe(Effect.provide(makeLayer(state)))
+      const removeParams = yield* parseDriveMemberMutationParams({ drive: "Docs", members: [accountA] })
+      const removed = yield* removeDriveMembers(removeParams).pipe(Effect.provide(makeLayer(state)))
+
+      expect(added.changed).toBe(true)
+      expect(added.members).toEqual([accountA, accountB])
+      expect(addedAgain.changed).toBe(false)
+      expect(owners).toMatchObject({ owners: [accountB], members: [accountA, accountB], changed: true })
+      expect(removed.members).toEqual([accountB])
+      expect(state.drives[0]).toMatchObject({ members: [accountB], owners: [accountB] })
+    }))
+
+  it.effect("adds replacement Drive owners to members when required", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [{ ...driveSpace(), members: [accountA], owners: [accountA] }],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        updatedDrives: []
+      }
+
+      const ownerParams = yield* parseSetDriveOwnersParams({ drive: "Docs", owners: [accountB] })
+      const owners = yield* setDriveOwners(ownerParams).pipe(Effect.provide(makeLayer(state)))
+
+      expect(owners).toMatchObject({ owners: [accountB], members: [accountA, accountB], changed: true })
+      expect(state.updatedDrives).toEqual([{
+        id: "drive-1",
+        operations: {
+          owners: [accountB],
+          members: [accountA, accountB]
+        }
+      }])
+    }))
+
+  it.effect("leaves Drive owners unchanged when replacement is already current", () =>
+    Effect.gen(function*() {
+      const state: DriveState = {
+        drives: [{ ...driveSpace(), members: [accountA], owners: [accountA] }],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        updatedDrives: []
+      }
+
+      const ownerParams = yield* parseSetDriveOwnersParams({
+        drive: "Docs",
+        owners: [accountA],
+        ensureMembers: false
+      })
+      const owners = yield* setDriveOwners(ownerParams).pipe(Effect.provide(makeLayer(state)))
+
+      expect(owners).toMatchObject({ owners: [accountA], members: [accountA], changed: false })
+      expect(state.updatedDrives).toEqual([])
+    }))
+
+  it.effect("deletes only empty Drives and rejects non-empty Drives with child summaries", () =>
+    Effect.gen(function*() {
+      const specs = folder("folder-specs", "Specs", drive.ids.Root)
+      const nonEmptyState: DriveState = {
+        drives: [driveSpace()],
+        folders: [specs],
+        files: [],
+        versions: [],
+        nextId: 1
+      }
+      const emptyState: DriveState = {
+        drives: [driveSpace("drive-empty", "Empty")],
+        folders: [],
+        files: [],
+        versions: [],
+        nextId: 1,
+        removedDocs: []
+      }
+
+      const nonEmptyParams = yield* parseDeleteDriveParams({ drive: "Docs" })
+      const nonEmpty = yield* Effect.flip(deleteDrive(nonEmptyParams).pipe(Effect.provide(makeLayer(nonEmptyState))))
+      const emptyParams = yield* parseDeleteDriveParams({ drive: "Empty" })
+      const deleted = yield* deleteDrive(emptyParams).pipe(Effect.provide(makeLayer(emptyState)))
+
+      expect(nonEmpty).toBeInstanceOf(DriveNotEmptyError)
+      if (!(nonEmpty instanceof DriveNotEmptyError)) {
+        throw new Error("expected DriveNotEmptyError")
+      }
+      expect(nonEmpty.childCount).toBe(1)
+      expect(nonEmpty.children).toEqual([{ id: "folder-specs", title: "Specs", kind: "folder" }])
+      expect(deleted).toMatchObject({ deleted: true, drive: { id: "drive-empty", name: "Empty" } })
+      expect(emptyState.drives).toEqual([])
+      expect(emptyState.removedDocs).toEqual([{ classRef: drive.class.Drive, id: "drive-empty" }])
     }))
 
   it.effect("lists children under a normalized folder path", () =>

--- a/test/mcp/tools/drive.test.ts
+++ b/test/mcp/tools/drive.test.ts
@@ -1,9 +1,153 @@
 import { describe, it } from "@effect/vitest"
+import type { Class, Data, Doc, DocumentQuery, DocumentUpdate, Ref, Space, SpaceType } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
+import type { HulyClientOperations } from "../../../src/huly/client.js"
+import { drive, type DriveSpace, type File, type Folder } from "../../../src/huly/drive-sdk.js"
+import { core } from "../../../src/huly/huly-plugins.js"
+import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import { toAccountUuid, toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import type { HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
+import { McpErrorCode } from "../../../src/mcp/error-mapping.js"
 import { driveTools } from "../../../src/mcp/tools/drive.js"
 import { TOOL_DEFINITIONS } from "../../../src/mcp/tools/index.js"
+import { corePersonId } from "../../helpers/huly-sdk.js"
+
+interface DriveToolState {
+  readonly drives: Array<DriveSpace>
+  readonly folders: Array<Folder>
+  readonly files: Array<File>
+  nextId: number
+}
+
+const personId = corePersonId("drive-tool-person")
+const accountA = toAccountUuid("00000000-0000-4000-8000-000000000001")
+const accountB = toAccountUuid("00000000-0000-4000-8000-000000000002")
+
+const driveSpace = (id = "drive-1", name = "Docs"): DriveSpace => ({
+  _id: toRef<DriveSpace>(id),
+  _class: drive.class.Drive,
+  space: toRef<Space>(core.space.Space),
+  name,
+  description: "Drive docs",
+  private: false,
+  archived: false,
+  autoJoin: false,
+  type: toRef<SpaceType>(drive.spaceType.DefaultDrive),
+  members: [accountA],
+  owners: [accountA],
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+})
+
+const folder = (id: string, title: string): Folder => ({
+  _id: toRef<Folder>(id),
+  _class: drive.class.Folder,
+  space: toRef<DriveSpace>("drive-1"),
+  title,
+  parent: drive.ids.Root,
+  path: [],
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+})
+
+const matchesQuery = (doc: Doc, query: DocumentQuery<Doc>): boolean =>
+  Object.entries(query).every(([key, value]) => Reflect.get(doc, key) === value)
+
+const documentsForClass = (state: DriveToolState, classRef: Ref<Class<Doc>>): ReadonlyArray<Doc> =>
+  classRef === drive.class.Drive
+    ? state.drives
+    : classRef === drive.class.Folder
+    ? state.folders
+    : classRef === drive.class.File
+    ? state.files
+    : []
+
+const makeHulyClient = (state: DriveToolState): HulyClientOperations => ({
+  getAccountUuid: () => accountA,
+  getPrimarySocialId: () => personId,
+  markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
+  findAll: <T extends Doc>(classRef: Ref<Class<T>>, query: DocumentQuery<T>) => {
+    const docs = documentsForClass(state, classRef as Ref<Class<Doc>>)
+    return Effect.succeed(
+      // The class ref selects the fixture array; Huly SDK brands are erased at runtime.
+      // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+      toFindResult(docs.filter((doc) => matchesQuery(doc, query as DocumentQuery<Doc>)) as unknown as Array<T>)
+    )
+  },
+  findOne: <T extends Doc>(classRef: Ref<Class<T>>, query: DocumentQuery<T>) =>
+    Effect.map(makeHulyClient(state).findAll(classRef, query), (docs) => docs[0]),
+  createDoc: <T extends Doc>(
+    classRef: Ref<Class<T>>,
+    space: Ref<Space>,
+    attributes: Data<T>,
+    id?: Ref<T>
+  ) => {
+    const next = id ?? toRef<T>(`created-${state.nextId++}`)
+    if (classRef === drive.class.Drive) {
+      state.drives.push({
+        // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; Drive class branch selects DriveSpace
+        _id: next as unknown as Ref<DriveSpace>,
+        _class: drive.class.Drive,
+        space,
+        modifiedBy: personId,
+        modifiedOn: 0,
+        createdBy: personId,
+        createdOn: 0,
+        // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; Drive class branch selects DriveSpace data
+        ...(attributes as unknown as Data<DriveSpace>)
+      })
+    }
+    return Effect.succeed(next)
+  },
+  updateDoc: <T extends Doc>(
+    _classRef: Ref<Class<T>>,
+    _space: Ref<Space>,
+    objectId: Ref<T>,
+    operations: DocumentUpdate<T>
+  ) => {
+    const targetIndex = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
+    const target = state.drives[targetIndex]
+    state.drives[targetIndex] = {
+      ...target,
+      // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; test updates only Drive docs
+      ...(operations as unknown as Partial<DriveSpace>)
+    }
+    return Effect.succeed([])
+  },
+  removeDoc: <T extends Doc>(_classRef: Ref<Class<T>>, _space: Ref<Space>, objectId: Ref<T>) => {
+    const index = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
+    if (index >= 0) state.drives.splice(index, 1)
+    return Effect.succeed([])
+  },
+  addCollection: () => Effect.die(new Error("not implemented")),
+  removeCollection: () => Effect.die(new Error("not implemented")),
+  uploadMarkup: () => Effect.die(new Error("not implemented")),
+  fetchMarkup: () => Effect.succeed(""),
+  updateMarkup: () => Effect.die(new Error("not implemented")),
+  updateMixin: () => Effect.die(new Error("not implemented")),
+  createMixin: () => Effect.die(new Error("not implemented")),
+  searchFulltext: () => Effect.die(new Error("not implemented"))
+})
+
+const storageClient: HulyStorageOperations = {
+  uploadFile: () => Effect.die(new Error("not implemented")),
+  getFileUrl: (blobId) => `https://test.huly.io/files?file=${blobId}`
+}
+
+const findTool = (name: string) => {
+  const tool = driveTools.find((candidate) => candidate.name === name)
+  if (tool === undefined) throw new Error(`Tool ${name} not found`)
+  return tool
+}
 
 describe("driveTools", () => {
   it.effect("exports Drive tools in the drive category and registers them globally", () =>
@@ -11,6 +155,12 @@ describe("driveTools", () => {
       expect(driveTools.map((tool) => tool.name)).toEqual([
         "list_drives",
         "get_drive",
+        "create_drive",
+        "update_drive",
+        "delete_drive",
+        "add_drive_members",
+        "remove_drive_members",
+        "set_drive_owners",
         "list_drive_items",
         "get_drive_item",
         "create_drive_folder",
@@ -31,8 +181,89 @@ describe("driveTools", () => {
       expect(driveTools.find((tool) => tool.name === "move_drive_item")?.description).toContain(
         "file or folder"
       )
+      expect(driveTools.find((tool) => tool.name === "create_drive")?.description).toContain(
+        "created=false"
+      )
+      expect(driveTools.find((tool) => tool.name === "set_drive_owners")?.description).toContain(
+        "ensured as a Drive member"
+      )
+      expect(driveTools.find((tool) => tool.name === "delete_drive")?.description).toContain(
+        "empty Huly Drive space"
+      )
       expect(driveTools.find((tool) => tool.name === "delete_drive_item")?.description).toContain(
         "permanent deletion"
       )
+    }))
+
+  it.effect("Drive administration handlers encode successful structured output", () =>
+    Effect.gen(function*() {
+      const state: DriveToolState = {
+        drives: [driveSpace()],
+        folders: [],
+        files: [],
+        nextId: 1
+      }
+      const hulyClient = makeHulyClient(state)
+
+      const created = yield* Effect.promise(() =>
+        findTool("create_drive").handler(
+          { name: "Team Drive", members: [accountA], owners: [accountB] },
+          hulyClient,
+          storageClient
+        )
+      )
+      const updated = yield* Effect.promise(() =>
+        findTool("update_drive").handler({ drive: "Docs", autoJoin: true }, hulyClient, storageClient)
+      )
+      const added = yield* Effect.promise(() =>
+        findTool("add_drive_members").handler({ drive: "Docs", members: [accountB] }, hulyClient, storageClient)
+      )
+      const removed = yield* Effect.promise(() =>
+        findTool("remove_drive_members").handler({ drive: "Docs", members: [accountA] }, hulyClient, storageClient)
+      )
+      const owners = yield* Effect.promise(() =>
+        findTool("set_drive_owners").handler({ drive: "Docs", owners: [accountB] }, hulyClient, storageClient)
+      )
+      const deleted = yield* Effect.promise(() =>
+        findTool("delete_drive").handler({ drive: "Team Drive" }, hulyClient, storageClient)
+      )
+
+      expect(created.isError).toBeUndefined()
+      expect(created.structuredContent?.result).toMatchObject({ created: true, drive: { name: "Team Drive" } })
+      expect(JSON.parse(created.content[0].text)).toMatchObject({ created: true })
+      expect(updated.structuredContent?.result).toMatchObject({ updated: true, drive: { autoJoin: true } })
+      expect(added.structuredContent?.result).toMatchObject({ changed: true, members: [accountA, accountB] })
+      expect(removed.structuredContent?.result).toMatchObject({ changed: true, members: [accountB] })
+      expect(owners.structuredContent?.result).toMatchObject({
+        changed: true,
+        owners: [accountB],
+        members: [accountB]
+      })
+      expect(deleted.structuredContent?.result).toMatchObject({ deleted: true, drive: { name: "Team Drive" } })
+    }))
+
+  it.effect("Drive administration handlers map parse and domain errors", () =>
+    Effect.gen(function*() {
+      const nonEmptyState: DriveToolState = {
+        drives: [driveSpace()],
+        folders: [folder("folder-specs", "Specs")],
+        files: [],
+        nextId: 1
+      }
+      const hulyClient = makeHulyClient(nonEmptyState)
+
+      const parseError = yield* Effect.promise(() =>
+        findTool("update_drive").handler({ drive: "Docs" }, hulyClient, storageClient)
+      )
+      const domainError = yield* Effect.promise(() =>
+        findTool("delete_drive").handler({ drive: "Docs" }, hulyClient, storageClient)
+      )
+
+      expect(parseError.isError).toBe(true)
+      expect(parseError._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
+      expect(parseError.content[0].text).toContain("Invalid parameters for update_drive")
+      expect(domainError.isError).toBe(true)
+      expect(domainError._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
+      expect(domainError.content[0].text).toContain("Drive 'Docs' is not empty")
     }))
 })


### PR DESCRIPTION
## Summary
- add Drive space administration tools: create, update, delete empty Drive, add/remove members, and replace owners
- add Drive admin schemas, typed non-empty Drive deletion error, and MCP error mapping
- update Drive summaries with autoJoin and expand domain, operation, MCP handler, and README coverage

## Verification
- pnpm update-readme
- pnpm check-all (3042 tests, branch coverage 99.02%)
- git diff --check
- rg "Schema\.String|Schema\.Number|Schema\.Unknown|: string|: number| as " src test

## Integration
- Local Huly integration suite was blocked: Docker is not installed (`docker: command not found`) and `http://localhost:8087/config.json` is unreachable.

Stacked on #111 (`drive-phase2-core-file-ops`).
