### PR TITLE
Add Drive file comments and activity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,11 @@ SDK upgrade revisit:
 | `set_drive_owners` | Replace owners on an existing Drive. Owners accept account UUIDs, exact emails, or exact person names. By default, each owner is also ensured as a Drive member. Pass owners=[] to clear owners. |
 | `list_drive_items` | List children under a folder path in a Drive. Paths are POSIX-like and normalized to absolute; '/' lists the root. Duplicate same-parent titles fail with candidate ids instead of guessing. |
 | `get_drive_item` | Get one Drive folder or file by either exact itemId or path. Provide only one locator. File results include current version, size, MIME type, and download URL when available. |
+| `list_drive_file_comments` | List comments on a Drive file resolved by filePath or fileId. Provide only one locator. Returns comments sorted by creation date, oldest first. |
+| `add_drive_file_comment` | Add a Markdown comment to a Drive file resolved by filePath or fileId. Provide only one locator. The comment is attached directly to the file. |
+| `update_drive_file_comment` | Update a comment on a Drive file resolved by filePath or fileId. Provide only one locator. Idempotent when the comment body is unchanged. |
+| `delete_drive_file_comment` | Permanently delete a comment from a Drive file resolved by filePath or fileId. Provide only one locator. This deletes the comment, not the file. |
+| `list_drive_file_activity` | List activity messages for a Drive file resolved by filePath or fileId. Provide only one locator. Returns activity sorted by date, newest first. |
 | `create_drive_folder` | Idempotently create a Drive folder path, creating missing parents like mkdir -p. Returns created=false when the full folder path already exists. |
 | `upload_drive_file` | Upload a file into Drive at a full path including filename. Provide exactly one source: filePath, fileUrl, or base64 data. By default createParents=true creates missing parent folders and reports them. |
 | `upload_drive_file_version` | Upload a new version for an existing Drive file resolved by file id or file path. Provide exactly one source: filePath, fileUrl, or base64 data. This increments the file version counter and makes the uploaded version current. |

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -3044,6 +3044,8 @@ if [ -n "$DRIVE_ID" ]; then
   DRIVE_TEST_VERSION_DATA=$(printf 'Drive integration version 2 %s' "$RUN_ID" | base64 | tr -d '\n')
   DRIVE_TEST_DATA_JSON=$(json_string "$DRIVE_TEST_DATA")
   DRIVE_TEST_VERSION_DATA_JSON=$(json_string "$DRIVE_TEST_VERSION_DATA")
+  DRIVE_TEST_COMMENT_BODY_JSON=$(json_string "Drive comment $RUN_ID")
+  DRIVE_TEST_COMMENT_UPDATED_BODY_JSON=$(json_string "Drive comment updated $RUN_ID")
   remember_drive_item_cleanup "$DRIVE_ID" "$DRIVE_TEST_RENAMED_FILE"
   remember_drive_item_cleanup "$DRIVE_ID" "$DRIVE_TEST_MOVED_FILE"
   remember_drive_item_cleanup "$DRIVE_ID" "$DRIVE_TEST_FILE"
@@ -3067,6 +3069,28 @@ if [ -n "$DRIVE_ID" ]; then
       "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_drive_item\",\"arguments\":{\"drive\":$DRIVE_JSON,\"itemId\":$DRIVE_FILE_ID_JSON}},\"id\":2}"
     run_test "list_drive_file_versions($DRIVE_FILE_ID)" \
       "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_drive_file_versions\",\"arguments\":{\"drive\":$DRIVE_JSON,\"file\":$DRIVE_FILE_ID_JSON}},\"id\":2}"
+    run_capture_to_var DRIVE_ADD_COMMENT_TEXT "add_drive_file_comment($DRIVE_FILE_ID)" \
+      "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"add_drive_file_comment\",\"arguments\":{\"drive\":$DRIVE_JSON,\"fileId\":$DRIVE_FILE_ID_JSON,\"body\":$DRIVE_TEST_COMMENT_BODY_JSON}},\"id\":2}"
+    DRIVE_COMMENT_ID=$(echo "$DRIVE_ADD_COMMENT_TEXT" | jq -r '.commentId // empty' 2>/dev/null)
+    if [ -n "$DRIVE_COMMENT_ID" ]; then
+      DRIVE_COMMENT_ID_JSON=$(json_string "$DRIVE_COMMENT_ID")
+      run_capture_to_var DRIVE_COMMENTS_TEXT "list_drive_file_comments($DRIVE_FILE_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_drive_file_comments\",\"arguments\":{\"drive\":$DRIVE_JSON,\"fileId\":$DRIVE_FILE_ID_JSON,\"limit\":10}},\"id\":2}"
+      assert_json_field_equals "list_drive_file_comments sees comment" "$DRIVE_COMMENTS_TEXT" ".comments[0].id" "$DRIVE_COMMENT_ID"
+      run_capture_to_var DRIVE_UPDATE_COMMENT_TEXT "update_drive_file_comment($DRIVE_COMMENT_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"update_drive_file_comment\",\"arguments\":{\"drive\":$DRIVE_JSON,\"fileId\":$DRIVE_FILE_ID_JSON,\"commentId\":$DRIVE_COMMENT_ID_JSON,\"body\":$DRIVE_TEST_COMMENT_UPDATED_BODY_JSON}},\"id\":2}"
+      assert_json_field_equals "update_drive_file_comment updates comment" "$DRIVE_UPDATE_COMMENT_TEXT" ".updated" "true"
+      run_test "list_drive_file_activity($DRIVE_FILE_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"list_drive_file_activity\",\"arguments\":{\"drive\":$DRIVE_JSON,\"fileId\":$DRIVE_FILE_ID_JSON,\"limit\":10}},\"id\":2}"
+      run_capture_to_var DRIVE_DELETE_COMMENT_TEXT "delete_drive_file_comment($DRIVE_COMMENT_ID)" \
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"delete_drive_file_comment\",\"arguments\":{\"drive\":$DRIVE_JSON,\"fileId\":$DRIVE_FILE_ID_JSON,\"commentId\":$DRIVE_COMMENT_ID_JSON}},\"id\":2}"
+      assert_json_field_equals "delete_drive_file_comment deletes comment" "$DRIVE_DELETE_COMMENT_TEXT" ".deleted" "true"
+    else
+      skip_test "list_drive_file_comments" "add_drive_file_comment did not return a comment id"
+      skip_test "update_drive_file_comment" "add_drive_file_comment did not return a comment id"
+      skip_test "list_drive_file_activity" "add_drive_file_comment did not return a comment id"
+      skip_test "delete_drive_file_comment" "add_drive_file_comment did not return a comment id"
+    fi
     run_capture_to_var DRIVE_VERSION_TEXT "upload_drive_file_version($DRIVE_FILE_ID)" \
       "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"upload_drive_file_version\",\"arguments\":{\"drive\":$DRIVE_JSON,\"file\":$DRIVE_FILE_ID_JSON,\"contentType\":\"text/plain\",\"data\":$DRIVE_TEST_VERSION_DATA_JSON}},\"id\":2}"
     assert_json_field_equals "upload_drive_file_version increments version" "$DRIVE_VERSION_TEXT" ".currentVersion.version" "2"
@@ -3089,6 +3113,11 @@ if [ -n "$DRIVE_ID" ]; then
   else
     skip_test "get_drive_item(file)" "upload_drive_file did not return a file id"
     skip_test "list_drive_file_versions" "upload_drive_file did not return a file id"
+    skip_test "add_drive_file_comment" "upload_drive_file did not return a file id"
+    skip_test "list_drive_file_comments" "upload_drive_file did not return a file id"
+    skip_test "update_drive_file_comment" "upload_drive_file did not return a file id"
+    skip_test "list_drive_file_activity" "upload_drive_file did not return a file id"
+    skip_test "delete_drive_file_comment" "upload_drive_file did not return a file id"
     skip_test "upload_drive_file_version" "upload_drive_file did not return a file id"
     skip_test "move_drive_item" "upload_drive_file did not return a file id"
     skip_test "rename_drive_item" "upload_drive_file did not return a file id"
@@ -3099,6 +3128,11 @@ else
   skip_test "list_drive_items" "no Drive spaces found in workspace"
   skip_test "create_drive_folder" "no Drive spaces found in workspace"
   skip_test "upload_drive_file" "no Drive spaces found in workspace"
+  skip_test "add_drive_file_comment" "no Drive spaces found in workspace"
+  skip_test "list_drive_file_comments" "no Drive spaces found in workspace"
+  skip_test "update_drive_file_comment" "no Drive spaces found in workspace"
+  skip_test "list_drive_file_activity" "no Drive spaces found in workspace"
+  skip_test "delete_drive_file_comment" "no Drive spaces found in workspace"
   skip_test "upload_drive_file_version" "no Drive spaces found in workspace"
   skip_test "move_drive_item" "no Drive spaces found in workspace"
   skip_test "rename_drive_item" "no Drive spaces found in workspace"

--- a/src/domain/schemas/drive-comments.ts
+++ b/src/domain/schemas/drive-comments.ts
@@ -1,0 +1,173 @@
+import { JSONSchema, Schema } from "effect"
+
+import { ActivityMessageWireSchema } from "./activity.js"
+import { CommentSchema } from "./comments.js"
+import { DriveIdentifier, DriveItemId, DriveItemSummarySchema, DrivePath } from "./drive.js"
+import {
+  CommentId,
+  Count,
+  DEFAULT_LIMIT,
+  hasAtLeastOneDefined,
+  hasMutuallyExclusiveFields,
+  LimitParam,
+  mutuallyExclusiveFieldsMessage,
+  NonEmptyString,
+  withAtLeastOneRequired,
+  withMutuallyExclusiveFields
+} from "./shared.js"
+
+const DriveFileLocatorFields = {
+  filePath: Schema.optional(DrivePath.annotations({
+    description: "Exact Drive file path, such as '/Specs/API.md'. Mutually exclusive with fileId."
+  })),
+  fileId: Schema.optional(DriveItemId.annotations({
+    description: "Exact Drive file id. Mutually exclusive with filePath."
+  }))
+} as const
+
+const requireOneDriveFileLocator = (params: {
+  readonly filePath?: unknown
+  readonly fileId?: unknown
+}) => hasAtLeastOneDefined(params, ["filePath", "fileId"]) || "Provide filePath or fileId."
+
+const requireExclusiveDriveFileLocator = (params: {
+  readonly filePath?: unknown
+  readonly fileId?: unknown
+}) =>
+  !hasMutuallyExclusiveFields(params, ["filePath", "fileId"]) || mutuallyExclusiveFieldsMessage([
+    "filePath",
+    "fileId"
+  ])
+
+const DriveFileCommentTargetSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+
+export const ListDriveFileCommentsParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields,
+  limit: Schema.optional(LimitParam.annotations({
+    description: `Maximum number of comments to return (default: ${DEFAULT_LIMIT}).`
+  }))
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+export type ListDriveFileCommentsParams = Schema.Schema.Type<typeof ListDriveFileCommentsParamsSchema>
+
+export const AddDriveFileCommentParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields,
+  body: NonEmptyString.annotations({
+    description: "Comment body. Markdown is supported."
+  })
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+export type AddDriveFileCommentParams = Schema.Schema.Type<typeof AddDriveFileCommentParamsSchema>
+
+export const UpdateDriveFileCommentParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields,
+  commentId: CommentId.annotations({
+    description: "Drive file comment id to update."
+  }),
+  body: NonEmptyString.annotations({
+    description: "New comment body. Markdown is supported."
+  })
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+export type UpdateDriveFileCommentParams = Schema.Schema.Type<typeof UpdateDriveFileCommentParamsSchema>
+
+export const DeleteDriveFileCommentParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields,
+  commentId: CommentId.annotations({
+    description: "Drive file comment id to permanently delete."
+  })
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+export type DeleteDriveFileCommentParams = Schema.Schema.Type<typeof DeleteDriveFileCommentParamsSchema>
+
+export const ListDriveFileActivityParamsSchema = Schema.Struct({
+  drive: DriveIdentifier,
+  ...DriveFileLocatorFields,
+  limit: Schema.optional(LimitParam.annotations({
+    description: `Maximum number of activity messages to return (default: ${DEFAULT_LIMIT}).`
+  }))
+}).pipe(
+  Schema.filter(requireOneDriveFileLocator),
+  Schema.filter(requireExclusiveDriveFileLocator)
+)
+export type ListDriveFileActivityParams = Schema.Schema.Type<typeof ListDriveFileActivityParamsSchema>
+
+export const ListDriveFileCommentsResultSchema = Schema.Struct({
+  file: DriveItemSummarySchema,
+  comments: Schema.Array(CommentSchema),
+  total: Count
+})
+export type ListDriveFileCommentsResult = Schema.Schema.Type<typeof ListDriveFileCommentsResultSchema>
+
+export const AddDriveFileCommentResultSchema = Schema.Struct({
+  file: DriveItemSummarySchema,
+  commentId: CommentId
+})
+export type AddDriveFileCommentResult = Schema.Schema.Type<typeof AddDriveFileCommentResultSchema>
+
+export const UpdateDriveFileCommentResultSchema = Schema.Struct({
+  file: DriveItemSummarySchema,
+  commentId: CommentId,
+  updated: Schema.Boolean
+})
+export type UpdateDriveFileCommentResult = Schema.Schema.Type<typeof UpdateDriveFileCommentResultSchema>
+
+export const DeleteDriveFileCommentResultSchema = Schema.Struct({
+  file: DriveItemSummarySchema,
+  commentId: CommentId,
+  deleted: Schema.Boolean
+})
+export type DeleteDriveFileCommentResult = Schema.Schema.Type<typeof DeleteDriveFileCommentResultSchema>
+
+export const ListDriveFileActivityResultSchema = Schema.Struct({
+  file: DriveItemSummarySchema,
+  activity: Schema.Array(ActivityMessageWireSchema),
+  total: Count
+})
+export type ListDriveFileActivityResult = Schema.Schema.Type<typeof ListDriveFileActivityResultSchema>
+
+export const listDriveFileCommentsParamsJsonSchema = withAtLeastOneRequired(
+  withMutuallyExclusiveFields(JSONSchema.make(ListDriveFileCommentsParamsSchema), ["filePath", "fileId"]),
+  ["filePath", "fileId"]
+)
+export const addDriveFileCommentParamsJsonSchema = withAtLeastOneRequired(
+  withMutuallyExclusiveFields(JSONSchema.make(AddDriveFileCommentParamsSchema), ["filePath", "fileId"]),
+  ["filePath", "fileId"]
+)
+export const updateDriveFileCommentParamsJsonSchema = withAtLeastOneRequired(
+  withMutuallyExclusiveFields(JSONSchema.make(UpdateDriveFileCommentParamsSchema), ["filePath", "fileId"]),
+  ["filePath", "fileId"]
+)
+export const deleteDriveFileCommentParamsJsonSchema = withAtLeastOneRequired(
+  withMutuallyExclusiveFields(JSONSchema.make(DeleteDriveFileCommentParamsSchema), ["filePath", "fileId"]),
+  ["filePath", "fileId"]
+)
+export const listDriveFileActivityParamsJsonSchema = withAtLeastOneRequired(
+  withMutuallyExclusiveFields(JSONSchema.make(ListDriveFileActivityParamsSchema), ["filePath", "fileId"]),
+  ["filePath", "fileId"]
+)
+
+export const parseDriveFileCommentTarget = Schema.decodeUnknown(DriveFileCommentTargetSchema)
+export const parseListDriveFileCommentsParams = Schema.decodeUnknown(ListDriveFileCommentsParamsSchema)
+export const parseAddDriveFileCommentParams = Schema.decodeUnknown(AddDriveFileCommentParamsSchema)
+export const parseUpdateDriveFileCommentParams = Schema.decodeUnknown(UpdateDriveFileCommentParamsSchema)
+export const parseDeleteDriveFileCommentParams = Schema.decodeUnknown(DeleteDriveFileCommentParamsSchema)
+export const parseListDriveFileActivityParams = Schema.decodeUnknown(ListDriveFileActivityParamsSchema)

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -2120,6 +2120,40 @@ export {
 } from "./drive-admin.js"
 
 export {
+  type AddDriveFileCommentParams,
+  addDriveFileCommentParamsJsonSchema,
+  AddDriveFileCommentParamsSchema,
+  type AddDriveFileCommentResult,
+  AddDriveFileCommentResultSchema,
+  type DeleteDriveFileCommentParams,
+  deleteDriveFileCommentParamsJsonSchema,
+  DeleteDriveFileCommentParamsSchema,
+  type DeleteDriveFileCommentResult,
+  DeleteDriveFileCommentResultSchema,
+  type ListDriveFileActivityParams,
+  listDriveFileActivityParamsJsonSchema,
+  ListDriveFileActivityParamsSchema,
+  type ListDriveFileActivityResult,
+  ListDriveFileActivityResultSchema,
+  type ListDriveFileCommentsParams,
+  listDriveFileCommentsParamsJsonSchema,
+  ListDriveFileCommentsParamsSchema,
+  type ListDriveFileCommentsResult,
+  ListDriveFileCommentsResultSchema,
+  parseAddDriveFileCommentParams,
+  parseDeleteDriveFileCommentParams,
+  parseDriveFileCommentTarget,
+  parseListDriveFileActivityParams,
+  parseListDriveFileCommentsParams,
+  parseUpdateDriveFileCommentParams,
+  type UpdateDriveFileCommentParams,
+  updateDriveFileCommentParamsJsonSchema,
+  UpdateDriveFileCommentParamsSchema,
+  type UpdateDriveFileCommentResult,
+  UpdateDriveFileCommentResultSchema
+} from "./drive-comments.js"
+
+export {
   type CreateDriveFolderParams,
   createDriveFolderParamsJsonSchema,
   CreateDriveFolderParamsSchema,

--- a/src/huly/errors-drive.ts
+++ b/src/huly/errors-drive.ts
@@ -108,6 +108,19 @@ export class DriveFileVersionNotFoundError extends Schema.TaggedError<DriveFileV
   }
 }
 
+export class DriveFileCommentNotFoundError extends Schema.TaggedError<DriveFileCommentNotFoundError>()(
+  "DriveFileCommentNotFoundError",
+  {
+    drive: NonEmptyString,
+    file: NonEmptyString,
+    commentId: NonEmptyString
+  }
+) {
+  override get message(): string {
+    return `Drive file comment '${this.commentId}' for file '${this.file}' not found in drive '${this.drive}'`
+  }
+}
+
 export class DrivePathConflictError extends Schema.TaggedError<DrivePathConflictError>()(
   "DrivePathConflictError",
   {

--- a/src/huly/errors.ts
+++ b/src/huly/errors.ts
@@ -47,6 +47,7 @@ import {
   TeamspaceNotFoundError
 } from "./errors-documents.js"
 import {
+  DriveFileCommentNotFoundError,
   DriveFileNotFoundError,
   DriveFileVersionNotFoundError,
   DriveFolderNotEmptyError,
@@ -179,6 +180,7 @@ export {
   DocumentTextMultipleMatchesError,
   DocumentTextNotFoundError,
   DrawingNotFoundError,
+  DriveFileCommentNotFoundError,
   DriveFileNotFoundError,
   DriveFileVersionNotFoundError,
   DriveFolderNotEmptyError,
@@ -386,6 +388,7 @@ export const HulyDomainError = Schema.Union(
   DrivePathNotFoundError,
   DrivePathAmbiguousError,
   DriveParentNotFolderError,
+  DriveFileCommentNotFoundError,
   DriveFileNotFoundError,
   DriveFileVersionNotFoundError,
   DrivePathConflictError,

--- a/src/huly/operations/drive-comments.ts
+++ b/src/huly/operations/drive-comments.ts
@@ -1,0 +1,237 @@
+import type { ActivityMessage as HulyActivityMessage } from "@hcengineering/activity"
+import type { ChatMessage } from "@hcengineering/chunter"
+import {
+  type AttachedData,
+  type Class,
+  type Doc,
+  type DocumentUpdate,
+  generateId,
+  type Ref,
+  SortingOrder
+} from "@hcengineering/core"
+import { Clock, Effect, Schema } from "effect"
+
+import { CommentSchema } from "../../domain/schemas/comments.js"
+import type {
+  AddDriveFileCommentParams,
+  AddDriveFileCommentResult,
+  DeleteDriveFileCommentParams,
+  DeleteDriveFileCommentResult,
+  ListDriveFileActivityParams,
+  ListDriveFileActivityResult,
+  ListDriveFileCommentsParams,
+  ListDriveFileCommentsResult,
+  UpdateDriveFileCommentParams,
+  UpdateDriveFileCommentResult
+} from "../../domain/schemas/drive-comments.js"
+import { CommentId, Count } from "../../domain/schemas/shared.js"
+import { HulyClient } from "../client.js"
+import { drive, type DriveSpace, type File } from "../drive-sdk.js"
+import { DriveFileCommentNotFoundError } from "../errors-drive.js"
+import { HulyConnectionError } from "../errors.js"
+import { activity, chunter } from "../huly-plugins.js"
+import type { HulyStorageClient } from "../storage.js"
+import { toActivityMessage } from "./activity-shared.js"
+import { pathForItem, toDriveItemSummary } from "./drive-mappers.js"
+import { resolveDrive, resolveFile } from "./drive-resolvers.js"
+import type { DriveOperationError } from "./drive-shared.js"
+import { markdownToMarkupString, optionalMarkupToMarkdown } from "./markup.js"
+import { clampLimit, hulyQuery } from "./query-helpers.js"
+import { toRef } from "./sdk-boundary.js"
+
+interface DriveFileLocatorParams {
+  readonly drive: ListDriveFileCommentsParams["drive"]
+  readonly filePath?: ListDriveFileCommentsParams["filePath"] | undefined
+  readonly fileId?: ListDriveFileCommentsParams["fileId"] | undefined
+}
+
+type DriveFileLocator = NonNullable<DriveFileLocatorParams["filePath"] | DriveFileLocatorParams["fileId"]>
+
+interface DriveFileTarget {
+  readonly client: HulyClient["Type"]
+  readonly driveSpace: DriveSpace
+  readonly file: File
+  readonly locator: DriveFileLocator
+}
+
+const resolveDriveFileTarget = (
+  params: DriveFileLocatorParams
+): Effect.Effect<DriveFileTarget, DriveOperationError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const driveSpace = yield* resolveDrive(client, params.drive)
+    const locator = params.fileId ?? params.filePath
+    if (locator === undefined) {
+      return yield* Effect.dieMessage("Invalid Drive file locator: provide filePath or fileId.")
+    }
+    const file = yield* resolveFile(client, driveSpace, params.drive, locator)
+    return { client, driveSpace, file, locator }
+  })
+
+const findDriveFileComment = (
+  target: DriveFileTarget,
+  commentId: CommentId
+): Effect.Effect<ChatMessage, DriveOperationError, never> =>
+  Effect.gen(function*() {
+    const comment = yield* target.client.findOne<ChatMessage>(
+      chunter.class.ChatMessage,
+      hulyQuery<ChatMessage>({
+        _id: toRef<ChatMessage>(commentId),
+        attachedTo: toRef<Doc>(target.file._id),
+        attachedToClass: toRef<Class<Doc>>(drive.class.File)
+      })
+    )
+    if (comment === undefined) {
+      return yield* Effect.fail(
+        new DriveFileCommentNotFoundError({
+          drive: target.driveSpace.name,
+          file: target.locator,
+          commentId
+        })
+      )
+    }
+    return comment
+  })
+
+const toComment = (
+  client: HulyClient["Type"],
+  message: ChatMessage
+) => ({
+  id: message._id,
+  body: optionalMarkupToMarkdown(message.message, client.markupUrlConfig, ""),
+  authorId: message.modifiedBy,
+  createdOn: message.createdOn,
+  modifiedOn: message.modifiedOn,
+  editedOn: message.editedOn
+})
+
+const decodeComments = (comments: ReadonlyArray<ReturnType<typeof toComment>>) =>
+  Schema.decodeUnknown(Schema.Array(CommentSchema))(comments).pipe(
+    Effect.mapError((parseError) =>
+      new HulyConnectionError({
+        message: `Drive file comments response failed schema validation: ${parseError.message}`,
+        cause: parseError
+      })
+    )
+  )
+
+export const listDriveFileComments = (
+  params: ListDriveFileCommentsParams
+): Effect.Effect<ListDriveFileCommentsResult, DriveOperationError, HulyClient | HulyStorageClient> =>
+  Effect.gen(function*() {
+    const target = yield* resolveDriveFileTarget(params)
+    const messages = yield* target.client.findAll<ChatMessage>(
+      chunter.class.ChatMessage,
+      hulyQuery<ChatMessage>({
+        attachedTo: toRef<Doc>(target.file._id),
+        attachedToClass: toRef<Class<Doc>>(drive.class.File)
+      }),
+      {
+        limit: clampLimit(params.limit),
+        sort: { createdOn: SortingOrder.Ascending }
+      }
+    )
+    const comments = yield* decodeComments(messages.map((message) => toComment(target.client, message)))
+
+    return {
+      file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+      comments: [...comments],
+      total: Count.make(comments.length)
+    }
+  })
+
+export const addDriveFileComment = (
+  params: AddDriveFileCommentParams
+): Effect.Effect<AddDriveFileCommentResult, DriveOperationError, HulyClient | HulyStorageClient> =>
+  Effect.gen(function*() {
+    const target = yield* resolveDriveFileTarget(params)
+    const commentId: Ref<ChatMessage> = generateId()
+    const commentData: AttachedData<ChatMessage> = {
+      message: markdownToMarkupString(params.body, target.client.markupUrlConfig)
+    }
+
+    yield* target.client.addCollection(
+      chunter.class.ChatMessage,
+      target.driveSpace._id,
+      target.file._id,
+      drive.class.File,
+      "comments",
+      commentData,
+      commentId
+    )
+
+    return {
+      file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+      commentId: CommentId.make(commentId)
+    }
+  })
+
+export const updateDriveFileComment = (
+  params: UpdateDriveFileCommentParams
+): Effect.Effect<UpdateDriveFileCommentResult, DriveOperationError, HulyClient | HulyStorageClient> =>
+  Effect.gen(function*() {
+    const target = yield* resolveDriveFileTarget(params)
+    const comment = yield* findDriveFileComment(target, params.commentId)
+    const newMarkup = markdownToMarkupString(params.body, target.client.markupUrlConfig)
+
+    if (newMarkup === comment.message) {
+      return {
+        file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+        commentId: params.commentId,
+        updated: false
+      }
+    }
+
+    const now = yield* Clock.currentTimeMillis
+    const updateOps: DocumentUpdate<ChatMessage> = {
+      message: newMarkup,
+      editedOn: now
+    }
+    yield* target.client.updateDoc(chunter.class.ChatMessage, target.driveSpace._id, comment._id, updateOps)
+
+    return {
+      file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+      commentId: params.commentId,
+      updated: true
+    }
+  })
+
+export const deleteDriveFileComment = (
+  params: DeleteDriveFileCommentParams
+): Effect.Effect<DeleteDriveFileCommentResult, DriveOperationError, HulyClient | HulyStorageClient> =>
+  Effect.gen(function*() {
+    const target = yield* resolveDriveFileTarget(params)
+    const comment = yield* findDriveFileComment(target, params.commentId)
+    yield* target.client.removeDoc(chunter.class.ChatMessage, target.driveSpace._id, comment._id)
+
+    return {
+      file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+      commentId: params.commentId,
+      deleted: true
+    }
+  })
+
+export const listDriveFileActivity = (
+  params: ListDriveFileActivityParams
+): Effect.Effect<ListDriveFileActivityResult, DriveOperationError, HulyClient | HulyStorageClient> =>
+  Effect.gen(function*() {
+    const target = yield* resolveDriveFileTarget(params)
+    const messages = yield* target.client.findAll<HulyActivityMessage>(
+      activity.class.ActivityMessage,
+      hulyQuery<HulyActivityMessage>({
+        attachedTo: toRef<Doc>(target.file._id),
+        attachedToClass: toRef<Class<Doc>>(drive.class.File)
+      }),
+      {
+        limit: clampLimit(params.limit),
+        sort: { modifiedOn: SortingOrder.Descending }
+      }
+    )
+    const mapped = messages.map((message) => toActivityMessage(message, target.client.markupUrlConfig))
+
+    return {
+      file: yield* toDriveItemSummary(target.file, target.driveSpace, pathForItem(target.file), target.client),
+      activity: mapped,
+      total: Count.make(mapped.length)
+    }
+  })

--- a/src/huly/operations/drive-shared.ts
+++ b/src/huly/operations/drive-shared.ts
@@ -2,6 +2,7 @@ import { NonEmptyString } from "../../domain/schemas/shared.js"
 import type { HulyClientError } from "../client.js"
 import type { DriveSpace, File, Folder } from "../drive-sdk.js"
 import type {
+  DriveFileCommentNotFoundError,
   DriveFileNotFoundError,
   DriveFileVersionNotFoundError,
   DriveFolderNotEmptyError,
@@ -29,6 +30,7 @@ export type DriveOperationError =
   | DrivePathAmbiguousError
   | DriveParentNotFolderError
   | DriveFileNotFoundError
+  | DriveFileCommentNotFoundError
   | DriveFileVersionNotFoundError
   | DrivePathConflictError
   | DriveInvalidMoveError

--- a/src/huly/operations/drive.ts
+++ b/src/huly/operations/drive.ts
@@ -58,6 +58,13 @@ export {
   setDriveOwners,
   updateDrive
 } from "./drive-admin.js"
+export {
+  addDriveFileComment,
+  deleteDriveFileComment,
+  listDriveFileActivity,
+  listDriveFileComments,
+  updateDriveFileComment
+} from "./drive-comments.js"
 export { deleteDriveItem, moveDriveItem, renameDriveItem, uploadDriveFileVersion } from "./drive-file-operations.js"
 
 export const listDrives = (

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -159,6 +159,7 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
   "DrivePathAmbiguousError",
   "DriveParentNotFolderError",
   "DriveFileNotFoundError",
+  "DriveFileCommentNotFoundError",
   "DriveFileVersionNotFoundError",
   "DrivePathConflictError",
   "DriveInvalidMoveError",

--- a/src/mcp/tools/drive.ts
+++ b/src/mcp/tools/drive.ts
@@ -1,8 +1,12 @@
 import {
+  addDriveFileCommentParamsJsonSchema,
+  AddDriveFileCommentResultSchema,
   createDriveFolderParamsJsonSchema,
   CreateDriveFolderResultSchema,
   createDriveParamsJsonSchema,
   CreateDriveResultSchema,
+  deleteDriveFileCommentParamsJsonSchema,
+  DeleteDriveFileCommentResultSchema,
   deleteDriveItemParamsJsonSchema,
   DeleteDriveItemResultSchema,
   deleteDriveParamsJsonSchema,
@@ -13,6 +17,10 @@ import {
   DriveSummarySchema,
   getDriveItemParamsJsonSchema,
   getDriveParamsJsonSchema,
+  listDriveFileActivityParamsJsonSchema,
+  ListDriveFileActivityResultSchema,
+  listDriveFileCommentsParamsJsonSchema,
+  ListDriveFileCommentsResultSchema,
   listDriveFileVersionsParamsJsonSchema,
   ListDriveFileVersionsResultSchema,
   listDriveItemsParamsJsonSchema,
@@ -21,13 +29,17 @@ import {
   ListDrivesResultSchema,
   moveDriveItemParamsJsonSchema,
   MoveDriveItemResultSchema,
+  parseAddDriveFileCommentParams,
   parseCreateDriveFolderParams,
   parseCreateDriveParams,
+  parseDeleteDriveFileCommentParams,
   parseDeleteDriveItemParams,
   parseDeleteDriveParams,
   parseDriveMemberMutationParams,
   parseGetDriveItemParams,
   parseGetDriveParams,
+  parseListDriveFileActivityParams,
+  parseListDriveFileCommentsParams,
   parseListDriveFileVersionsParams,
   parseListDriveItemsParams,
   parseListDrivesParams,
@@ -35,6 +47,7 @@ import {
   parseRenameDriveItemParams,
   parseRestoreDriveFileVersionParams,
   parseSetDriveOwnersParams,
+  parseUpdateDriveFileCommentParams,
   parseUpdateDriveParams,
   parseUploadDriveFileParams,
   parseUploadDriveFileVersionParams,
@@ -44,6 +57,8 @@ import {
   RestoreDriveFileVersionResultSchema,
   setDriveOwnersParamsJsonSchema,
   SetDriveOwnersResultSchema,
+  updateDriveFileCommentParamsJsonSchema,
+  UpdateDriveFileCommentResultSchema,
   updateDriveParamsJsonSchema,
   UpdateDriveResultSchema,
   uploadDriveFileParamsJsonSchema,
@@ -53,13 +68,17 @@ import {
 } from "../../domain/schemas.js"
 import { DEFAULT_INCLUDE_ARCHIVED } from "../../domain/schemas/shared.js"
 import {
+  addDriveFileComment,
   addDriveMembers,
   createDrive,
   createDriveFolder,
   deleteDrive,
+  deleteDriveFileComment,
   deleteDriveItem,
   getDrive,
   getDriveItem,
+  listDriveFileActivity,
+  listDriveFileComments,
   listDriveFileVersions,
   listDriveItems,
   listDrives,
@@ -69,6 +88,7 @@ import {
   restoreDriveFileVersion,
   setDriveOwners,
   updateDrive,
+  updateDriveFileComment,
   uploadDriveFile,
   uploadDriveFileVersion
 } from "../../huly/operations/drive.js"
@@ -201,6 +221,74 @@ export const driveTools: ReadonlyArray<RegisteredTool> = [
       parseGetDriveItemParams,
       getDriveItem,
       DriveItemSummarySchema
+    )
+  },
+  {
+    name: "list_drive_file_comments",
+    description:
+      "List comments on a Drive file resolved by filePath or fileId. Provide only one locator. Returns comments sorted by creation date, oldest first.",
+    category: CATEGORY,
+    inputSchema: listDriveFileCommentsParamsJsonSchema,
+    handler: createEncodedCombinedToolHandler(
+      "list_drive_file_comments",
+      parseListDriveFileCommentsParams,
+      listDriveFileComments,
+      ListDriveFileCommentsResultSchema
+    )
+  },
+  {
+    name: "add_drive_file_comment",
+    description:
+      "Add a Markdown comment to a Drive file resolved by filePath or fileId. Provide only one locator. The comment is attached directly to the file.",
+    category: CATEGORY,
+    inputSchema: addDriveFileCommentParamsJsonSchema,
+    annotations: { idempotentHint: false, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "add_drive_file_comment",
+      parseAddDriveFileCommentParams,
+      addDriveFileComment,
+      AddDriveFileCommentResultSchema
+    )
+  },
+  {
+    name: "update_drive_file_comment",
+    description:
+      "Update a comment on a Drive file resolved by filePath or fileId. Provide only one locator. Idempotent when the comment body is unchanged.",
+    category: CATEGORY,
+    inputSchema: updateDriveFileCommentParamsJsonSchema,
+    annotations: { idempotentHint: true, destructiveHint: false },
+    handler: createEncodedCombinedToolHandler(
+      "update_drive_file_comment",
+      parseUpdateDriveFileCommentParams,
+      updateDriveFileComment,
+      UpdateDriveFileCommentResultSchema
+    )
+  },
+  {
+    name: "delete_drive_file_comment",
+    description:
+      "Permanently delete a comment from a Drive file resolved by filePath or fileId. Provide only one locator. This deletes the comment, not the file.",
+    category: CATEGORY,
+    inputSchema: deleteDriveFileCommentParamsJsonSchema,
+    annotations: { idempotentHint: false, destructiveHint: true },
+    handler: createEncodedCombinedToolHandler(
+      "delete_drive_file_comment",
+      parseDeleteDriveFileCommentParams,
+      deleteDriveFileComment,
+      DeleteDriveFileCommentResultSchema
+    )
+  },
+  {
+    name: "list_drive_file_activity",
+    description:
+      "List activity messages for a Drive file resolved by filePath or fileId. Provide only one locator. Returns activity sorted by date, newest first.",
+    category: CATEGORY,
+    inputSchema: listDriveFileActivityParamsJsonSchema,
+    handler: createEncodedCombinedToolHandler(
+      "list_drive_file_activity",
+      parseListDriveFileActivityParams,
+      listDriveFileActivity,
+      ListDriveFileActivityResultSchema
     )
   },
   {

--- a/test/domain/schemas.drive.test.ts
+++ b/test/domain/schemas.drive.test.ts
@@ -3,7 +3,10 @@ import { Effect, Schema } from "effect"
 import { expect } from "vitest"
 
 import {
+  AddDriveFileCommentResultSchema,
+  CommentSchema,
   CreateDriveResultSchema,
+  DeleteDriveFileCommentResultSchema,
   DeleteDriveItemResultSchema,
   DeleteDriveResultSchema,
   DriveFileVersionSummarySchema,
@@ -11,18 +14,26 @@ import {
   DriveItemTitle,
   DriveMemberMutationResultSchema,
   DriveSummarySchema,
+  ListDriveFileActivityResultSchema,
+  ListDriveFileCommentsResultSchema,
   MoveDriveItemResultSchema,
+  parseAddDriveFileCommentParams,
+  parseDeleteDriveFileCommentParams,
   parseDeleteDriveItemParams,
   parseDriveMemberMutationParams,
   parseGetDriveItemParams,
+  parseListDriveFileActivityParams,
+  parseListDriveFileCommentsParams,
   parseMoveDriveItemParams,
   parseRenameDriveItemParams,
   parseSetDriveOwnersParams,
+  parseUpdateDriveFileCommentParams,
   parseUpdateDriveParams,
   parseUploadDriveFileParams,
   parseUploadDriveFileVersionParams,
   RenameDriveItemResultSchema,
   SetDriveOwnersResultSchema,
+  UpdateDriveFileCommentResultSchema,
   UpdateDriveResultSchema,
   uploadDriveFileParamsJsonSchema,
   UploadDriveFileVersionResultSchema
@@ -126,6 +137,48 @@ describe("drive schemas", () => {
       expect(moveAmbiguousLocator._tag).toBe("Left")
       expect(versionMissingSource._tag).toBe("Left")
       expect(versionConflictingSource._tag).toBe("Left")
+    }))
+
+  it.effect("requires exactly one Drive file locator for comments and activity", () =>
+    Effect.gen(function*() {
+      const listAccepted = yield* parseListDriveFileCommentsParams({
+        drive: "Docs",
+        filePath: "/Specs/API.md"
+      })
+      const addAccepted = yield* parseAddDriveFileCommentParams({
+        drive: "Docs",
+        fileId: "file-api",
+        body: "Looks good"
+      })
+      const updateAccepted = yield* parseUpdateDriveFileCommentParams({
+        drive: "Docs",
+        filePath: "/Specs/API.md",
+        commentId: "comment-1",
+        body: "Updated"
+      })
+      const deleteAccepted = yield* parseDeleteDriveFileCommentParams({
+        drive: "Docs",
+        fileId: "file-api",
+        commentId: "comment-1"
+      })
+      const activityAccepted = yield* parseListDriveFileActivityParams({
+        drive: "Docs",
+        filePath: "/Specs/API.md"
+      })
+      const missing = yield* Effect.either(parseListDriveFileCommentsParams({ drive: "Docs" }))
+      const ambiguous = yield* Effect.either(parseListDriveFileActivityParams({
+        drive: "Docs",
+        filePath: "/Specs/API.md",
+        fileId: "file-api"
+      }))
+
+      expect(listAccepted.filePath).toBe("/Specs/API.md")
+      expect(addAccepted.fileId).toBe("file-api")
+      expect(updateAccepted.commentId).toBe("comment-1")
+      expect(deleteAccepted.commentId).toBe("comment-1")
+      expect(activityAccepted.filePath).toBe("/Specs/API.md")
+      expect(missing._tag).toBe("Left")
+      expect(ambiguous._tag).toBe("Left")
     }))
 
   it.effect("validates Drive administration params", () =>
@@ -253,6 +306,71 @@ describe("drive schemas", () => {
       expect(moved.toPath).toBe("/Specs/API.md")
       expect(renamed.renamed).toBe(true)
       expect(deleted.deletedVersions).toBe(2)
+    }))
+
+  it.effect("encodes branded outputs for Drive file comments and activity", () =>
+    Effect.gen(function*() {
+      const file = yield* Schema.decodeUnknown(DriveItemSummarySchema)({
+        id: "file-api",
+        driveId: "drive-1",
+        kind: "file",
+        title: "API.md",
+        path: "/Specs/API.md",
+        url: "https://huly.test/workbench/ws/drive/file/file-api",
+        currentVersionId: "version-2",
+        version: 2,
+        size: 5,
+        contentType: "text/markdown",
+        downloadUrl: "https://files.test/blob-2"
+      })
+      const comment = yield* Schema.decodeUnknown(CommentSchema)({
+        id: "comment-1",
+        body: "Looks good",
+        authorId: "person-1",
+        createdOn: 1,
+        modifiedOn: 1
+      })
+      const decodedListComments = yield* Schema.decodeUnknown(ListDriveFileCommentsResultSchema)({
+        file,
+        comments: [comment],
+        total: 1
+      })
+      const decodedAdded = yield* Schema.decodeUnknown(AddDriveFileCommentResultSchema)({
+        file,
+        commentId: "comment-1"
+      })
+      const decodedUpdated = yield* Schema.decodeUnknown(UpdateDriveFileCommentResultSchema)({
+        file,
+        commentId: "comment-1",
+        updated: true
+      })
+      const decodedDeleted = yield* Schema.decodeUnknown(DeleteDriveFileCommentResultSchema)({
+        file,
+        commentId: "comment-1",
+        deleted: true
+      })
+      const decodedActivity = yield* Schema.decodeUnknown(ListDriveFileActivityResultSchema)({
+        file,
+        activity: [{
+          id: "activity-1",
+          objectId: "file-api",
+          objectClass: "drive:class:File",
+          modifiedBy: "person-1",
+          modifiedOn: 2
+        }],
+        total: 1
+      })
+      const listComments = yield* Schema.encode(ListDriveFileCommentsResultSchema)(decodedListComments)
+      const added = yield* Schema.encode(AddDriveFileCommentResultSchema)(decodedAdded)
+      const updated = yield* Schema.encode(UpdateDriveFileCommentResultSchema)(decodedUpdated)
+      const deleted = yield* Schema.encode(DeleteDriveFileCommentResultSchema)(decodedDeleted)
+      const activity = yield* Schema.encode(ListDriveFileActivityResultSchema)(decodedActivity)
+
+      expect(listComments.comments[0].id).toBe("comment-1")
+      expect(added.commentId).toBe("comment-1")
+      expect(updated.updated).toBe(true)
+      expect(deleted.deleted).toBe(true)
+      expect(activity.activity[0].objectId).toBe("file-api")
     }))
 
   it.effect("encodes branded outputs for Drive administration operations", () =>

--- a/test/huly/errors.test.ts
+++ b/test/huly/errors.test.ts
@@ -36,6 +36,7 @@ import {
   DocumentNotFoundError,
   DocumentReferenceError,
   DrawingNotFoundError,
+  DriveFileCommentNotFoundError,
   DriveFileNotFoundError,
   DriveFileVersionNotFoundError,
   DriveFolderNotEmptyError,
@@ -953,6 +954,8 @@ describe("Huly Errors", () => {
               return `drive-parent-not-folder:${error.drive}:${error.path}:${error.parentPath}`
             case "DriveFileNotFoundError":
               return `drive-file:${error.drive}:${error.file}`
+            case "DriveFileCommentNotFoundError":
+              return `drive-file-comment:${error.drive}:${error.file}:${error.commentId}`
             case "DriveFileVersionNotFoundError":
               return `drive-version:${error.drive}:${error.file}:${error.version}`
             case "DrivePathConflictError":
@@ -1258,6 +1261,20 @@ describe("Huly Errors", () => {
         expect(new DriveFileNotFoundError({ drive: "Docs", file: "/missing.txt" }).message).toBe(
           "Drive file '/missing.txt' not found in drive 'Docs'"
         )
+        expect(matchError(
+          new DriveFileCommentNotFoundError({
+            drive: "Docs",
+            file: "file-1",
+            commentId: "comment-1"
+          })
+        )).toBe("drive-file-comment:Docs:file-1:comment-1")
+        expect(
+          new DriveFileCommentNotFoundError({
+            drive: "Docs",
+            file: "file-1",
+            commentId: "comment-1"
+          }).message
+        ).toBe("Drive file comment 'comment-1' for file 'file-1' not found in drive 'Docs'")
         expect(matchError(
           new DriveFileVersionNotFoundError({
             drive: "Docs",

--- a/test/huly/operations/drive-comments.test.ts
+++ b/test/huly/operations/drive-comments.test.ts
@@ -1,0 +1,352 @@
+/* eslint-disable no-restricted-syntax -- Huly SDK phantom refs are erased at runtime; these tests centralize fixture casts. */
+import { describe, it } from "@effect/vitest"
+import type { ActivityMessage as HulyActivityMessage } from "@hcengineering/activity"
+import type { ChatMessage } from "@hcengineering/chunter"
+import type {
+  AttachedData,
+  AttachedDoc,
+  Class,
+  Data,
+  Doc,
+  DocumentQuery,
+  DocumentUpdate,
+  Ref,
+  Space
+} from "@hcengineering/core"
+import { Effect, Layer } from "effect"
+import { expect } from "vitest"
+
+import {
+  parseAddDriveFileCommentParams,
+  parseDeleteDriveFileCommentParams,
+  parseListDriveFileActivityParams,
+  parseListDriveFileCommentsParams,
+  parseUpdateDriveFileCommentParams
+} from "../../../src/domain/schemas.js"
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import { drive, type DriveSpace, type File, type FileVersion, type Folder } from "../../../src/huly/drive-sdk.js"
+import { DriveFileCommentNotFoundError, DriveFileNotFoundError } from "../../../src/huly/errors-drive.js"
+import { activity, chunter, core } from "../../../src/huly/huly-plugins.js"
+import {
+  addDriveFileComment,
+  deleteDriveFileComment,
+  listDriveFileActivity,
+  listDriveFileComments,
+  updateDriveFileComment
+} from "../../../src/huly/operations/drive.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import { toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import { HulyStorageClient, type HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
+import { corePersonId, findResult } from "../../helpers/huly-sdk.js"
+
+interface DriveCommentState {
+  readonly drives: Array<DriveSpace>
+  readonly folders: Array<Folder>
+  readonly files: Array<File>
+  readonly messages: Array<ChatMessage>
+  readonly activityMessages: Array<HulyActivityMessage>
+  nextId: number
+  readonly updates: Array<{ readonly id: string; readonly operations: DocumentUpdate<ChatMessage> }>
+  readonly removals: Array<{ readonly classRef: string; readonly id: string }>
+}
+
+const personId = corePersonId("drive-comment-person")
+
+const driveSpace = (): DriveSpace => ({
+  _id: toRef<DriveSpace>("drive-1"),
+  _class: drive.class.Drive,
+  space: toRef<Space>(core.space.Space),
+  name: "Docs",
+  description: "Drive docs",
+  private: false,
+  archived: false,
+  autoJoin: false,
+  members: [],
+  owners: [],
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+} as unknown as DriveSpace)
+
+const driveFile = (): File => ({
+  _id: toRef<File>("file-api"),
+  _class: drive.class.File,
+  space: toRef<DriveSpace>("drive-1"),
+  title: "API.md",
+  parent: drive.ids.Root,
+  path: [],
+  file: toRef<FileVersion>("version-1"),
+  versions: 1,
+  version: 1,
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+})
+
+const driveFolder = (): Folder => ({
+  _id: toRef<Folder>("folder-specs"),
+  _class: drive.class.Folder,
+  space: toRef<DriveSpace>("drive-1"),
+  title: "Specs",
+  parent: drive.ids.Root,
+  path: [],
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+})
+
+const chatMessage = (id: string, body: string): ChatMessage => ({
+  _id: toRef<ChatMessage>(id),
+  _class: chunter.class.ChatMessage,
+  space: toRef<DriveSpace>("drive-1"),
+  attachedTo: toRef<Doc>("file-api"),
+  attachedToClass: toRef<Class<Doc>>(drive.class.File),
+  collection: "comments",
+  message: markdownToMarkupString(body, testMarkupUrlConfig),
+  modifiedBy: personId,
+  modifiedOn: 1,
+  createdBy: personId,
+  createdOn: 1,
+  editedOn: undefined,
+  isPinned: false,
+  replies: 0,
+  reactions: 0
+} as unknown as ChatMessage)
+
+const activityMessage = (): HulyActivityMessage => ({
+  _id: toRef<HulyActivityMessage>("activity-1"),
+  _class: activity.class.ActivityMessage,
+  space: toRef<DriveSpace>("drive-1"),
+  attachedTo: toRef<Doc>("file-api"),
+  attachedToClass: toRef<Class<Doc>>(drive.class.File),
+  collection: "activity",
+  modifiedBy: personId,
+  modifiedOn: 2,
+  isPinned: false,
+  replies: 0,
+  reactions: 0
+})
+
+const matchesQuery = (doc: Doc, query: DocumentQuery<Doc>) =>
+  Object.entries(query).every(([key, value]) => Reflect.get(doc, key) === value)
+
+const docsForClass = (state: DriveCommentState, classRef: Ref<Class<Doc>>): ReadonlyArray<Doc> =>
+  classRef === drive.class.Drive
+    ? state.drives
+    : classRef === drive.class.Folder
+    ? state.folders
+    : classRef === drive.class.File
+    ? state.files
+    : classRef === chunter.class.ChatMessage
+    ? state.messages
+    : classRef === activity.class.ActivityMessage
+    ? state.activityMessages
+    : []
+
+const makeLayer = (state: DriveCommentState): Layer.Layer<HulyClient | HulyStorageClient> => {
+  const findAll: HulyClientOperations["findAll"] = <T extends Doc>(
+    classRef: Ref<Class<T>>,
+    query: DocumentQuery<T>
+  ) => {
+    const docs = docsForClass(state, classRef as unknown as Ref<Class<Doc>>)
+    return Effect.succeed(
+      findResult(docs.filter((doc) => matchesQuery(doc, query as unknown as DocumentQuery<Doc>)) as Array<T>)
+    )
+  }
+
+  const findOne: HulyClientOperations["findOne"] = <T extends Doc>(
+    classRef: Ref<Class<T>>,
+    query: DocumentQuery<T>
+  ) => Effect.map(findAll(classRef, query), (docs) => docs[0])
+
+  const addCollection: HulyClientOperations["addCollection"] = <T extends Doc, P extends AttachedDoc>(
+    classRef: Ref<Class<P>>,
+    space: Ref<Space>,
+    attachedTo: Ref<T>,
+    attachedToClass: Ref<Class<T>>,
+    collection: string,
+    attributes: AttachedData<P>,
+    id?: Ref<P>
+  ) => {
+    const next = id ?? toRef<P>(`created-${state.nextId++}`)
+    if (classRef === chunter.class.ChatMessage) {
+      state.messages.push({
+        _id: next as unknown as Ref<ChatMessage>,
+        _class: chunter.class.ChatMessage,
+        space,
+        attachedTo: attachedTo as unknown as Ref<Doc>,
+        attachedToClass: attachedToClass as unknown as Ref<Class<Doc>>,
+        collection,
+        modifiedBy: personId,
+        modifiedOn: 0,
+        createdBy: personId,
+        createdOn: 0,
+        editedOn: undefined,
+        isPinned: false,
+        replies: 0,
+        reactions: 0,
+        ...(attributes as unknown as AttachedData<ChatMessage>)
+      } as unknown as ChatMessage)
+    }
+    return Effect.succeed(next)
+  }
+
+  const updateDoc: HulyClientOperations["updateDoc"] = <T extends Doc>(
+    classRef: Ref<Class<T>>,
+    _space: Ref<Space>,
+    objectId: Ref<T>,
+    operations: DocumentUpdate<T>
+  ) => {
+    if (classRef === chunter.class.ChatMessage) {
+      state.updates.push({
+        id: String(objectId),
+        operations: operations as unknown as DocumentUpdate<ChatMessage>
+      })
+      const index = state.messages.findIndex((message) => String(message._id) === String(objectId))
+      const message = state.messages[index]
+      state.messages[index] = {
+        ...message,
+        ...(operations as unknown as Partial<ChatMessage>)
+      }
+    }
+    return Effect.succeed([])
+  }
+
+  const removeDoc: HulyClientOperations["removeDoc"] = <T extends Doc>(
+    classRef: Ref<Class<T>>,
+    _space: Ref<Space>,
+    objectId: Ref<T>
+  ) => {
+    state.removals.push({ classRef: String(classRef), id: String(objectId) })
+    if (classRef === chunter.class.ChatMessage) {
+      const index = state.messages.findIndex((message) => String(message._id) === String(objectId))
+      if (index >= 0) state.messages.splice(index, 1)
+    }
+    return Effect.succeed([])
+  }
+
+  const storage: HulyStorageOperations = {
+    uploadFile: () => Effect.die(new Error("not implemented")),
+    getFileUrl: (blobId) => `https://files.test/${blobId}`
+  }
+
+  return Layer.merge(
+    HulyClient.testLayer({
+      findAll,
+      findOne,
+      addCollection,
+      updateDoc,
+      removeDoc,
+      createDoc: <T extends Doc>(_classRef: Ref<Class<T>>, _space: Ref<Space>, _attributes: Data<T>) =>
+        Effect.succeed(toRef<T>(`created-${state.nextId++}`)),
+      removeCollection: () => Effect.die(new Error("not implemented")),
+      workbenchUrlConfig: testWorkbenchUrlConfig,
+      markupUrlConfig: testMarkupUrlConfig
+    }),
+    HulyStorageClient.testLayer(storage)
+  )
+}
+
+const baseState = (): DriveCommentState => ({
+  drives: [driveSpace()],
+  folders: [driveFolder()],
+  files: [driveFile()],
+  messages: [chatMessage("comment-1", "Initial")],
+  activityMessages: [activityMessage()],
+  nextId: 1,
+  updates: [],
+  removals: []
+})
+
+describe("drive file comment operations", () => {
+  it.effect("adds, lists, updates, and deletes Drive file comments", () =>
+    Effect.gen(function*() {
+      const state = baseState()
+      const layer = makeLayer(state)
+      const listParams = yield* parseListDriveFileCommentsParams({ drive: "Docs", filePath: "/API.md" })
+      const addParams = yield* parseAddDriveFileCommentParams({
+        drive: "Docs",
+        fileId: "file-api",
+        body: "Added"
+      })
+      const updateNoopParams = yield* parseUpdateDriveFileCommentParams({
+        drive: "Docs",
+        filePath: "/API.md",
+        commentId: "comment-1",
+        body: "Initial"
+      })
+      const updateParams = yield* parseUpdateDriveFileCommentParams({
+        drive: "Docs",
+        filePath: "/API.md",
+        commentId: "comment-1",
+        body: "Updated"
+      })
+      const deleteParams = yield* parseDeleteDriveFileCommentParams({
+        drive: "Docs",
+        fileId: "file-api",
+        commentId: "comment-1"
+      })
+
+      const listed = yield* listDriveFileComments(listParams).pipe(Effect.provide(layer))
+      const added = yield* addDriveFileComment(addParams).pipe(Effect.provide(layer))
+      const noop = yield* updateDriveFileComment(updateNoopParams).pipe(Effect.provide(layer))
+      const updated = yield* updateDriveFileComment(updateParams).pipe(Effect.provide(layer))
+      const deleted = yield* deleteDriveFileComment(deleteParams).pipe(Effect.provide(layer))
+
+      expect(listed).toMatchObject({ file: { id: "file-api" }, total: 1 })
+      expect(listed.comments[0]).toMatchObject({ id: "comment-1", body: "Initial" })
+      expect(added.file.id).toBe("file-api")
+      expect(added.commentId).toBeDefined()
+      expect(noop.updated).toBe(false)
+      expect(updated.updated).toBe(true)
+      expect(state.updates).toHaveLength(1)
+      expect(deleted.deleted).toBe(true)
+      expect(state.removals).toEqual([{ classRef: chunter.class.ChatMessage, id: "comment-1" }])
+    }))
+
+  it.effect("lists Drive file activity for a resolved file", () =>
+    Effect.gen(function*() {
+      const state = baseState()
+      const params = yield* parseListDriveFileActivityParams({ drive: "Docs", fileId: "file-api" })
+      const result = yield* listDriveFileActivity(params).pipe(Effect.provide(makeLayer(state)))
+
+      expect(result.file.id).toBe("file-api")
+      expect(result.total).toBe(1)
+      expect(result.activity[0]).toMatchObject({
+        id: "activity-1",
+        objectId: "file-api",
+        objectClass: drive.class.File
+      })
+    }))
+
+  it.effect("rejects folder targets and missing Drive file comments", () =>
+    Effect.gen(function*() {
+      const state = baseState()
+      const layer = makeLayer(state)
+      const folderParams = yield* parseListDriveFileCommentsParams({ drive: "Docs", filePath: "/Specs" })
+      const missingCommentParams = yield* parseUpdateDriveFileCommentParams({
+        drive: "Docs",
+        filePath: "/API.md",
+        commentId: "missing-comment",
+        body: "Updated"
+      })
+
+      const folderError = yield* Effect.either(listDriveFileComments(folderParams).pipe(Effect.provide(layer)))
+      const missingComment = yield* Effect.either(
+        updateDriveFileComment(missingCommentParams).pipe(Effect.provide(layer))
+      )
+
+      expect(folderError._tag).toBe("Left")
+      if (folderError._tag === "Left") {
+        expect(folderError.left).toBeInstanceOf(DriveFileNotFoundError)
+      }
+      expect(missingComment._tag).toBe("Left")
+      if (missingComment._tag === "Left") {
+        expect(missingComment.left).toBeInstanceOf(DriveFileCommentNotFoundError)
+      }
+    }))
+})

--- a/test/mcp/tools/drive.test.ts
+++ b/test/mcp/tools/drive.test.ts
@@ -1,13 +1,27 @@
+/* eslint-disable no-restricted-syntax -- Huly SDK phantom refs are erased at runtime; this test file builds in-memory SDK fixtures. */
 import { describe, it } from "@effect/vitest"
-import type { Class, Data, Doc, DocumentQuery, DocumentUpdate, Ref, Space, SpaceType } from "@hcengineering/core"
+import type { ActivityMessage as HulyActivityMessage } from "@hcengineering/activity"
+import type { ChatMessage } from "@hcengineering/chunter"
+import type {
+  AttachedData,
+  AttachedDoc,
+  Class,
+  Data,
+  Doc,
+  DocumentQuery,
+  DocumentUpdate,
+  Ref,
+  Space,
+  SpaceType
+} from "@hcengineering/core"
 import { toFindResult } from "@hcengineering/core"
 import { Effect } from "effect"
 import { expect } from "vitest"
 
 import type { HulyClientOperations } from "../../../src/huly/client.js"
-import { drive, type DriveSpace, type File, type Folder } from "../../../src/huly/drive-sdk.js"
-import { core } from "../../../src/huly/huly-plugins.js"
-import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import { drive, type DriveSpace, type File, type FileVersion, type Folder } from "../../../src/huly/drive-sdk.js"
+import { activity, chunter, core } from "../../../src/huly/huly-plugins.js"
+import { markdownToMarkupString, testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
 import { toAccountUuid, toRef } from "../../../src/huly/operations/sdk-boundary.js"
 import type { HulyStorageOperations } from "../../../src/huly/storage.js"
 import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
@@ -20,6 +34,8 @@ interface DriveToolState {
   readonly drives: Array<DriveSpace>
   readonly folders: Array<Folder>
   readonly files: Array<File>
+  readonly messages?: Array<ChatMessage>
+  readonly activityMessages?: Array<HulyActivityMessage>
   nextId: number
 }
 
@@ -58,6 +74,53 @@ const folder = (id: string, title: string): Folder => ({
   createdOn: 0
 })
 
+const file = (id: string, title: string): File => ({
+  _id: toRef<File>(id),
+  _class: drive.class.File,
+  space: toRef<DriveSpace>("drive-1"),
+  title,
+  parent: drive.ids.Root,
+  path: [],
+  file: toRef<FileVersion>("version-1"),
+  versions: 1,
+  version: 1,
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0
+})
+
+const chatMessage = (id: string, body: string): ChatMessage => ({
+  _id: toRef<ChatMessage>(id),
+  _class: chunter.class.ChatMessage,
+  space: toRef<DriveSpace>("drive-1"),
+  attachedTo: toRef<Doc>("file-api"),
+  attachedToClass: toRef<Class<Doc>>(drive.class.File),
+  collection: "comments",
+  message: markdownToMarkupString(body, testMarkupUrlConfig),
+  modifiedBy: personId,
+  modifiedOn: 1,
+  createdBy: personId,
+  createdOn: 1,
+  isPinned: false,
+  replies: 0,
+  reactions: 0
+} as unknown as ChatMessage)
+
+const activityMessage = (): HulyActivityMessage => ({
+  _id: toRef<HulyActivityMessage>("activity-1"),
+  _class: activity.class.ActivityMessage,
+  space: toRef<DriveSpace>("drive-1"),
+  attachedTo: toRef<Doc>("file-api"),
+  attachedToClass: toRef<Class<Doc>>(drive.class.File),
+  collection: "activity",
+  modifiedBy: personId,
+  modifiedOn: 2,
+  isPinned: false,
+  replies: 0,
+  reactions: 0
+})
+
 const matchesQuery = (doc: Doc, query: DocumentQuery<Doc>): boolean =>
   Object.entries(query).every(([key, value]) => Reflect.get(doc, key) === value)
 
@@ -68,6 +131,10 @@ const documentsForClass = (state: DriveToolState, classRef: Ref<Class<Doc>>): Re
     ? state.folders
     : classRef === drive.class.File
     ? state.files
+    : classRef === chunter.class.ChatMessage
+    ? state.messages ?? []
+    : classRef === activity.class.ActivityMessage
+    ? state.activityMessages ?? []
     : []
 
 const makeHulyClient = (state: DriveToolState): HulyClientOperations => ({
@@ -79,7 +146,7 @@ const makeHulyClient = (state: DriveToolState): HulyClientOperations => ({
     const docs = documentsForClass(state, classRef as Ref<Class<Doc>>)
     return Effect.succeed(
       // The class ref selects the fixture array; Huly SDK brands are erased at runtime.
-      // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+
       toFindResult(docs.filter((doc) => matchesQuery(doc, query as DocumentQuery<Doc>)) as unknown as Array<T>)
     )
   },
@@ -94,7 +161,6 @@ const makeHulyClient = (state: DriveToolState): HulyClientOperations => ({
     const next = id ?? toRef<T>(`created-${state.nextId++}`)
     if (classRef === drive.class.Drive) {
       state.drives.push({
-        // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; Drive class branch selects DriveSpace
         _id: next as unknown as Ref<DriveSpace>,
         _class: drive.class.Drive,
         space,
@@ -102,33 +168,79 @@ const makeHulyClient = (state: DriveToolState): HulyClientOperations => ({
         modifiedOn: 0,
         createdBy: personId,
         createdOn: 0,
-        // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; Drive class branch selects DriveSpace data
+
         ...(attributes as unknown as Data<DriveSpace>)
       })
     }
     return Effect.succeed(next)
   },
   updateDoc: <T extends Doc>(
-    _classRef: Ref<Class<T>>,
+    classRef: Ref<Class<T>>,
     _space: Ref<Space>,
     objectId: Ref<T>,
     operations: DocumentUpdate<T>
   ) => {
+    if (classRef === chunter.class.ChatMessage) {
+      const index = state.messages?.findIndex((candidate) => String(candidate._id) === String(objectId)) ?? -1
+      if (state.messages !== undefined && index >= 0) {
+        const target = state.messages[index]
+        state.messages[index] = {
+          ...target,
+
+          ...(operations as unknown as Partial<ChatMessage>)
+        }
+      }
+      return Effect.succeed([])
+    }
     const targetIndex = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
     const target = state.drives[targetIndex]
     state.drives[targetIndex] = {
       ...target,
-      // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; test updates only Drive docs
+
       ...(operations as unknown as Partial<DriveSpace>)
     }
     return Effect.succeed([])
   },
-  removeDoc: <T extends Doc>(_classRef: Ref<Class<T>>, _space: Ref<Space>, objectId: Ref<T>) => {
+  removeDoc: <T extends Doc>(classRef: Ref<Class<T>>, _space: Ref<Space>, objectId: Ref<T>) => {
+    if (classRef === chunter.class.ChatMessage) {
+      const index = state.messages?.findIndex((candidate) => String(candidate._id) === String(objectId)) ?? -1
+      if (state.messages !== undefined && index >= 0) state.messages.splice(index, 1)
+      return Effect.succeed([])
+    }
     const index = state.drives.findIndex((candidate) => String(candidate._id) === String(objectId))
     if (index >= 0) state.drives.splice(index, 1)
     return Effect.succeed([])
   },
-  addCollection: () => Effect.die(new Error("not implemented")),
+  addCollection: <T extends Doc, P extends AttachedDoc>(
+    classRef: Ref<Class<P>>,
+    space: Ref<Space>,
+    attachedTo: Ref<T>,
+    attachedToClass: Ref<Class<T>>,
+    collection: string,
+    attributes: AttachedData<P>,
+    id?: Ref<P>
+  ) => {
+    const next = id ?? toRef<P>(`created-${state.nextId++}`)
+    if (classRef === chunter.class.ChatMessage) {
+      state.messages?.push({
+        _id: next as unknown as Ref<ChatMessage>,
+        _class: chunter.class.ChatMessage,
+        space,
+        attachedTo: attachedTo as unknown as Ref<Doc>,
+        attachedToClass: attachedToClass as unknown as Ref<Class<Doc>>,
+        collection,
+        modifiedBy: personId,
+        modifiedOn: 0,
+        createdBy: personId,
+        createdOn: 0,
+        isPinned: false,
+        replies: 0,
+        reactions: 0,
+        ...(attributes as unknown as AttachedData<ChatMessage>)
+      } as unknown as ChatMessage)
+    }
+    return Effect.succeed(next)
+  },
   removeCollection: () => Effect.die(new Error("not implemented")),
   uploadMarkup: () => Effect.die(new Error("not implemented")),
   fetchMarkup: () => Effect.succeed(""),
@@ -163,6 +275,11 @@ describe("driveTools", () => {
         "set_drive_owners",
         "list_drive_items",
         "get_drive_item",
+        "list_drive_file_comments",
+        "add_drive_file_comment",
+        "update_drive_file_comment",
+        "delete_drive_file_comment",
+        "list_drive_file_activity",
         "create_drive_folder",
         "upload_drive_file",
         "upload_drive_file_version",
@@ -192,6 +309,9 @@ describe("driveTools", () => {
       )
       expect(driveTools.find((tool) => tool.name === "delete_drive_item")?.description).toContain(
         "permanent deletion"
+      )
+      expect(driveTools.find((tool) => tool.name === "list_drive_file_comments")?.description).toContain(
+        "filePath or fileId"
       )
     }))
 
@@ -242,6 +362,62 @@ describe("driveTools", () => {
       expect(deleted.structuredContent?.result).toMatchObject({ deleted: true, drive: { name: "Team Drive" } })
     }))
 
+  it.effect("Drive file comment and activity handlers encode successful structured output", () =>
+    Effect.gen(function*() {
+      const state: DriveToolState = {
+        drives: [driveSpace()],
+        folders: [],
+        files: [file("file-api", "API.md")],
+        messages: [chatMessage("comment-1", "Initial")],
+        activityMessages: [activityMessage()],
+        nextId: 1
+      }
+      const hulyClient = makeHulyClient(state)
+
+      const listed = yield* Effect.promise(() =>
+        findTool("list_drive_file_comments").handler({ drive: "Docs", filePath: "/API.md" }, hulyClient, storageClient)
+      )
+      const added = yield* Effect.promise(() =>
+        findTool("add_drive_file_comment").handler(
+          { drive: "Docs", fileId: "file-api", body: "Added" },
+          hulyClient,
+          storageClient
+        )
+      )
+      const updated = yield* Effect.promise(() =>
+        findTool("update_drive_file_comment").handler(
+          { drive: "Docs", fileId: "file-api", commentId: "comment-1", body: "Updated" },
+          hulyClient,
+          storageClient
+        )
+      )
+      const activityResult = yield* Effect.promise(() =>
+        findTool("list_drive_file_activity").handler({ drive: "Docs", fileId: "file-api" }, hulyClient, storageClient)
+      )
+      const deleted = yield* Effect.promise(() =>
+        findTool("delete_drive_file_comment").handler(
+          { drive: "Docs", fileId: "file-api", commentId: "comment-1" },
+          hulyClient,
+          storageClient
+        )
+      )
+
+      expect(listed.isError).toBeUndefined()
+      expect(listed.structuredContent?.result).toMatchObject({
+        file: { id: "file-api" },
+        comments: [{ id: "comment-1", body: "Initial" }],
+        total: 1
+      })
+      expect(added.structuredContent?.result).toMatchObject({ file: { id: "file-api" } })
+      expect(updated.structuredContent?.result).toMatchObject({ commentId: "comment-1", updated: true })
+      expect(activityResult.structuredContent?.result).toMatchObject({
+        file: { id: "file-api" },
+        activity: [{ id: "activity-1", objectId: "file-api" }],
+        total: 1
+      })
+      expect(deleted.structuredContent?.result).toMatchObject({ commentId: "comment-1", deleted: true })
+    }))
+
   it.effect("Drive administration handlers map parse and domain errors", () =>
     Effect.gen(function*() {
       const nonEmptyState: DriveToolState = {
@@ -265,5 +441,39 @@ describe("driveTools", () => {
       expect(domainError.isError).toBe(true)
       expect(domainError._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
       expect(domainError.content[0].text).toContain("Drive 'Docs' is not empty")
+    }))
+
+  it.effect("Drive file comment handlers map parse and domain errors", () =>
+    Effect.gen(function*() {
+      const state: DriveToolState = {
+        drives: [driveSpace()],
+        folders: [],
+        files: [file("file-api", "API.md")],
+        messages: [],
+        nextId: 1
+      }
+      const hulyClient = makeHulyClient(state)
+
+      const parseError = yield* Effect.promise(() =>
+        findTool("list_drive_file_comments").handler(
+          { drive: "Docs", filePath: "/API.md", fileId: "file-api" },
+          hulyClient,
+          storageClient
+        )
+      )
+      const domainError = yield* Effect.promise(() =>
+        findTool("update_drive_file_comment").handler(
+          { drive: "Docs", fileId: "file-api", commentId: "missing-comment", body: "Updated" },
+          hulyClient,
+          storageClient
+        )
+      )
+
+      expect(parseError.isError).toBe(true)
+      expect(parseError._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
+      expect(parseError.content[0].text).toContain("Invalid parameters for list_drive_file_comments")
+      expect(domainError.isError).toBe(true)
+      expect(domainError._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
+      expect(domainError.content[0].text).toContain("Drive file comment 'missing-comment'")
     }))
 })


### PR DESCRIPTION
gpt 55

## Summary
- add Drive-category tools for file comments: list/add/update/delete
- add Drive file activity listing by filePath or fileId
- add schemas, operation coverage, MCP coverage, README docs, and full integration coverage

## Notes
- Scope is intentionally Drive files, not folders, because Huly marks `drive.class.File` as activity-enabled.
- Added `DriveFileCommentNotFoundError` so Drive comment failures do not use issue-specific error text.

## Verification
- `rg "Schema\.String|Schema\.Number|Schema\.Unknown|: string|: number| as " src test`
- `pnpm update-readme`
- `pnpm check-all`
- `set -a && source .env.local && set +a && HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh`
  - Result: 373 passed, 0 failed, 29 skipped
