### PR TITLE
Fix thread reply collection deletion

### DIFF
--- a/.changeset/thread-reply-collection-delete.md
+++ b/.changeset/thread-reply-collection-delete.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Delete thread replies through Huly collection transactions so parent reply metadata stays in sync.

--- a/src/huly/operations/activity-messages.ts
+++ b/src/huly/operations/activity-messages.ts
@@ -35,12 +35,14 @@ import {
   Timestamp
 } from "../../domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../client.js"
+import type { HulyError } from "../errors.js"
 import { ActivityMessageNotFoundError } from "../errors.js"
 import { activity, chunter } from "../huly-plugins.js"
 import { findActivityMessage, toActivityMessage } from "./activity-shared.js"
 import { markdownToMarkupString } from "./markup.js"
 import { clampLimit, findOneOrFail, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
+import { removeThreadReply } from "./thread-replies-shared.js"
 
 type GetActivityMessageError = HulyClientError | ActivityMessageNotFoundError
 type PinActivityMessageError = HulyClientError | ActivityMessageNotFoundError
@@ -49,7 +51,7 @@ type ListActivityReferencesError = HulyClientError
 type ListActivityRepliesError = HulyClientError | ActivityMessageNotFoundError
 type AddActivityReplyError = HulyClientError | ActivityMessageNotFoundError
 type UpdateActivityReplyError = HulyClientError | ActivityMessageNotFoundError
-type DeleteActivityReplyError = HulyClientError | ActivityMessageNotFoundError
+type DeleteActivityReplyError = HulyClientError | HulyError | ActivityMessageNotFoundError
 
 export const getActivityMessage = (
   params: GetActivityMessageParams
@@ -217,6 +219,6 @@ export const deleteActivityReply = (
       () => new ActivityMessageNotFoundError({ messageId: params.replyId })
     )
 
-    yield* client.removeDoc(chunter.class.ThreadMessage, reply.space, reply._id)
+    yield* removeThreadReply(client, reply)
     return { replyId: ActivityMessageId.make(reply._id), deleted: true }
   })

--- a/src/huly/operations/thread-replies-shared.ts
+++ b/src/huly/operations/thread-replies-shared.ts
@@ -1,0 +1,29 @@
+import type { ActivityMessage } from "@hcengineering/activity"
+import type { ThreadMessage as HulyThreadMessage } from "@hcengineering/chunter"
+import { Effect } from "effect"
+
+import type { HulyClient, HulyClientError } from "../client.js"
+import { HulyError } from "../errors.js"
+import { chunter } from "../huly-plugins.js"
+
+type RemoveThreadReplyError = HulyClientError | HulyError
+
+export const removeThreadReply = (
+  client: HulyClient["Type"],
+  reply: HulyThreadMessage
+): Effect.Effect<void, RemoveThreadReplyError> =>
+  Effect.gen(function*() {
+    const removeCollection = client.removeCollection
+    if (removeCollection === undefined) {
+      return yield* new HulyError({ message: "Huly client does not support removeCollection" })
+    }
+
+    yield* removeCollection<ActivityMessage, HulyThreadMessage>(
+      chunter.class.ThreadMessage,
+      reply.space,
+      reply._id,
+      reply.attachedTo,
+      reply.attachedToClass,
+      reply.collection
+    )
+  })

--- a/src/huly/operations/threads.ts
+++ b/src/huly/operations/threads.ts
@@ -26,13 +26,14 @@ import type {
 } from "../../domain/schemas/channels.js"
 import { ChannelId, MessageId, ThreadReplyId } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
-import type { ChannelNotFoundError, MessageNotFoundError } from "../errors.js"
+import type { ChannelNotFoundError, HulyError, MessageNotFoundError } from "../errors.js"
 import { ThreadReplyNotFoundError } from "../errors.js"
 import { findChannelMessage } from "./channel-messages-shared.js"
 import { buildSocialIdToPersonNameMap } from "./channels.js"
 import { listTotal } from "./counts.js"
 import { markdownToMarkupString, markupToMarkdownString } from "./markup.js"
 import { toRef } from "./sdk-boundary.js"
+import { removeThreadReply } from "./thread-replies-shared.js"
 
 import { chunter } from "../huly-plugins.js"
 
@@ -56,6 +57,7 @@ type UpdateThreadReplyError =
 
 type DeleteThreadReplyError =
   | HulyClientError
+  | HulyError
   | ChannelNotFoundError
   | MessageNotFoundError
   | ThreadReplyNotFoundError
@@ -207,11 +209,7 @@ export const deleteThreadReply = (
     const { channel, client, message } = yield* findChannelMessage(params)
     const reply = yield* findReply(client, channel, message, params.replyId)
 
-    yield* client.removeDoc(
-      chunter.class.ThreadMessage,
-      channel._id,
-      reply._id
-    )
+    yield* removeThreadReply(client, reply)
 
     return { id: ThreadReplyId.make(reply._id), deleted: true }
   })

--- a/test/huly/operations/channels.test.ts
+++ b/test/huly/operations/channels.test.ts
@@ -9,6 +9,8 @@ import type {
 import type { Employee as HulyEmployee, Person, SocialIdentity } from "@hcengineering/contact"
 import {
   type AccountUuid,
+  type AttachedDoc,
+  type Class,
   type Doc,
   type PersonId,
   type Ref,
@@ -186,6 +188,15 @@ interface MockConfig {
   captureUpdateDoc?: { operations?: Record<string, unknown> }
   captureAddCollection?: { attributes?: Record<string, unknown>; id?: string }
   captureRemoveDoc?: { called?: boolean }
+  captureRemoveCollection?: {
+    classId?: unknown
+    space?: unknown
+    objectId?: unknown
+    attachedTo?: unknown
+    attachedToClass?: unknown
+    collection?: unknown
+  }
+  removeCollectionAvailable?: boolean
 }
 
 const createTestLayerWithMocks = (config: MockConfig) => {
@@ -353,13 +364,36 @@ const createTestLayerWithMocks = (config: MockConfig) => {
     }
   ) as HulyClientOperations["removeDoc"]
 
+  const removeCollectionImpl: NonNullable<HulyClientOperations["removeCollection"]> = <
+    T extends Doc,
+    P extends AttachedDoc
+  >(
+    classId: Ref<Class<P>>,
+    space: Ref<Space>,
+    objectId: Ref<P>,
+    attachedTo: Ref<T>,
+    attachedToClass: Ref<Class<T>>,
+    collection: Extract<keyof T, string> | string
+  ) => {
+    if (config.captureRemoveCollection) {
+      config.captureRemoveCollection.classId = classId
+      config.captureRemoveCollection.space = space
+      config.captureRemoveCollection.objectId = objectId
+      config.captureRemoveCollection.attachedTo = attachedTo
+      config.captureRemoveCollection.attachedToClass = attachedToClass
+      config.captureRemoveCollection.collection = collection
+    }
+    return Effect.succeed(attachedTo)
+  }
+
   return HulyClient.testLayer({
     findAll: findAllImpl,
     findOne: findOneImpl,
     createDoc: createDocImpl,
     updateDoc: updateDocImpl,
     addCollection: addCollectionImpl,
-    removeDoc: removeDocImpl
+    removeDoc: removeDocImpl,
+    ...(config.removeCollectionAvailable === false ? {} : { removeCollection: removeCollectionImpl })
   })
 }
 
@@ -1242,12 +1276,14 @@ describe("deleteThreadReply", () => {
         attachedTo: "msg-1" as Ref<ActivityMessage>
       })
       const captureRemoveDoc: MockConfig["captureRemoveDoc"] = {}
+      const captureRemoveCollection: MockConfig["captureRemoveCollection"] = {}
 
       const testLayer = createTestLayerWithMocks({
         channels: [channel],
         messages: [parentMsg],
         threadMessages: [reply],
-        captureRemoveDoc
+        captureRemoveDoc,
+        captureRemoveCollection
       })
 
       const result = yield* deleteThreadReply({
@@ -1258,7 +1294,45 @@ describe("deleteThreadReply", () => {
 
       expect(result.id).toBe("reply-1")
       expect(result.deleted).toBe(true)
-      expect(captureRemoveDoc.called).toBe(true)
+      expect(captureRemoveDoc.called).toBeUndefined()
+      expect(captureRemoveCollection.classId).toBe(chunter.class.ThreadMessage)
+      expect(captureRemoveCollection.space).toBe("ch-1")
+      expect(captureRemoveCollection.objectId).toBe("reply-1")
+      expect(captureRemoveCollection.attachedTo).toBe("msg-1")
+      expect(captureRemoveCollection.attachedToClass).toBe(chunter.class.ChatMessage)
+      expect(captureRemoveCollection.collection).toBe("replies")
+    }))
+
+  it.effect("fails when collection deletion is unavailable", () =>
+    Effect.gen(function*() {
+      const channel = makeChannel({ _id: "ch-1" as Ref<HulyChannel>, name: "general" })
+      const parentMsg = makeChatMessage({
+        _id: "msg-1" as Ref<ChatMessage>,
+        space: "ch-1" as Ref<Space>
+      })
+      const reply = makeThreadMessage({
+        _id: "reply-1" as Ref<HulyThreadMessage>,
+        space: "ch-1" as Ref<Space>,
+        attachedTo: "msg-1" as Ref<ActivityMessage>
+      })
+
+      const testLayer = createTestLayerWithMocks({
+        channels: [channel],
+        messages: [parentMsg],
+        threadMessages: [reply],
+        removeCollectionAvailable: false
+      })
+
+      const error = yield* Effect.flip(
+        deleteThreadReply({
+          channel: channelIdentifier("general"),
+          messageId: messageBrandId("msg-1"),
+          replyId: threadReplyId("reply-1")
+        }).pipe(Effect.provide(testLayer))
+      )
+
+      expect(error._tag).toBe("HulyError")
+      expect(error.message).toBe("Huly client does not support removeCollection")
     }))
 
   it.effect("returns ThreadReplyNotFoundError when reply doesn't exist", () =>

--- a/test/huly/operations/object-notifications-activity-media.test.ts
+++ b/test/huly/operations/object-notifications-activity-media.test.ts
@@ -13,6 +13,8 @@ import type {
 import type { ThreadMessage as HulyThreadMessage } from "@hcengineering/chunter"
 import type {
   AccountUuid as HulyAccountUuid,
+  AttachedDoc,
+  Class,
   Collaborator as HulyCollaborator,
   Doc,
   FindResult,
@@ -112,7 +114,13 @@ interface Capture {
   readonly createDocs: Array<{ readonly _class: unknown; readonly attributes: unknown; readonly id: unknown }>
   readonly updateDocs: Array<{ readonly _class: unknown; readonly objectId: unknown; readonly operations: unknown }>
   readonly removeDocs: Array<{ readonly _class: unknown; readonly objectId: unknown }>
-  readonly removeCollections: Array<{ readonly _class: unknown; readonly objectId: unknown }>
+  readonly removeCollections: Array<{
+    readonly _class: unknown
+    readonly objectId: unknown
+    readonly attachedTo: unknown
+    readonly attachedToClass: unknown
+    readonly collection: unknown
+  }>
   readonly uploads: Array<{ readonly filename: string; readonly contentType: string; readonly size: number }>
 }
 
@@ -533,11 +541,20 @@ const testLayer = (config: FixtureConfig = {}) => {
     return Effect.succeed({} as never)
   }) as HulyClientOperations["removeDoc"]
 
-  const removeCollection: NonNullable<HulyClientOperations["removeCollection"]> =
-    ((_class: unknown, _space: unknown, objectId: unknown) => {
-      capture.removeCollections.push({ _class, objectId })
-      return Effect.succeed("parent-1" as Ref<Doc>)
-    }) as NonNullable<HulyClientOperations["removeCollection"]>
+  const removeCollection: NonNullable<HulyClientOperations["removeCollection"]> = <
+    T extends Doc,
+    P extends AttachedDoc
+  >(
+    _class: Ref<Class<P>>,
+    _space: Ref<Space>,
+    objectId: Ref<P>,
+    attachedTo: Ref<T>,
+    attachedToClass: Ref<Class<T>>,
+    collection: Extract<keyof T, string> | string
+  ) => {
+    capture.removeCollections.push({ _class, objectId, attachedTo, attachedToClass, collection })
+    return Effect.succeed(attachedTo)
+  }
 
   const uploadFile: HulyStorageOperations["uploadFile"] = ((filename: string, buffer: Buffer, contentType: string) => {
     capture.uploads.push({ filename, contentType, size: buffer.length })
@@ -619,7 +636,12 @@ describe("activity message operations", () => {
 
       const deleted = yield* deleteActivityReply({ replyId: activityMessageId("reply-1") }).pipe(Effect.provide(layer))
       expect(deleted.deleted).toBe(true)
-      expect(capture.removeDocs[0]._class).toBe(chunter.class.ThreadMessage)
+      expect(capture.removeDocs).toHaveLength(0)
+      expect(capture.removeCollections[0]._class).toBe(chunter.class.ThreadMessage)
+      expect(capture.removeCollections[0].objectId).toBe("reply-1")
+      expect(capture.removeCollections[0].attachedTo).toBe("msg-1")
+      expect(capture.removeCollections[0].attachedToClass).toBe(activity.class.ActivityMessage)
+      expect(capture.removeCollections[0].collection).toBe("replies")
     }))
 
   it.effect("returns idempotently when pin state already matches and reports missing replies", () =>


### PR DESCRIPTION
gpt 55

## Summary
- delete thread replies through Huly collection transactions instead of raw document deletes
- share the collection-delete helper between channel thread replies and generic activity replies
- add regression tests proving `removeDoc` is not used for reply deletion and that attached-doc metadata is passed to `removeCollection`

## Root Cause
`delete_thread_reply` and `delete_activity_reply` removed `chunter.class.ThreadMessage` with `client.removeDoc`, while replies are created with `addCollection(..., "replies", ...)`. Raw deletion skips Huly collection CUD metadata, so parent reply counters/metadata can desync.

## Validation
- Reviewer agent loop: first pass found test-cast cleanup, second pass returned no findings
- `pnpm check-all`
- `pnpm build && set -a && source .env.local && set +a && HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh`
- Integration result: 412 passed, 0 failed, 28 skipped
