### PR TITLE
fix mcp input schema compatibility

### DIFF
--- a/.changeset/mcp-input-schema-compat.md
+++ b/.changeset/mcp-input-schema-compat.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Fix MCP tool registration for root-composition input schemas and remove raw unknown input JSON Schema fragments.

--- a/src/domain/schemas/project-target-preferences.ts
+++ b/src/domain/schemas/project-target-preferences.ts
@@ -9,13 +9,25 @@ export type ProjectTargetPreferenceId = Schema.Schema.Type<typeof ProjectTargetP
 export const TrackerPreferencePropertyKey = NonEmptyString.pipe(Schema.brand("TrackerPreferencePropertyKey"))
 export type TrackerPreferencePropertyKey = Schema.Schema.Type<typeof TrackerPreferencePropertyKey>
 
+const ProjectTargetPreferencePropertyValueSchema = Schema.Unknown.annotations({
+  jsonSchema: {
+    description: "SDK-open target preference property value. Passed through to Huly without narrowing.",
+    anyOf: [
+      { type: "string" },
+      { type: "number" },
+      { type: "boolean" },
+      { type: "object", additionalProperties: true },
+      { type: "array", items: {} },
+      { type: "null" }
+    ]
+  }
+})
+
 export const ProjectTargetPreferencePropertySchema = Schema.Struct({
   key: TrackerPreferencePropertyKey.annotations({
     description: "Low-level tracker target preference property key. Huly stores arbitrary preference keys here."
   }),
-  value: Schema.Unknown.annotations({
-    description: "SDK-open target preference property value. Passed through to Huly without narrowing."
-  })
+  value: ProjectTargetPreferencePropertyValueSchema
 }).annotations({
   title: "ProjectTargetPreferenceProperty",
   description: "One SDK-open low-level ProjectTargetPreference props entry."

--- a/src/mcp/input-schema-compat.ts
+++ b/src/mcp/input-schema-compat.ts
@@ -13,8 +13,6 @@ const ROOT_COMPOSITION_KEYS = new Set(["anyOf", "oneOf", "allOf"])
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
-export const isObjectSchema = (schema: object): schema is McpInputSchema => "type" in schema && schema.type === "object"
-
 const mergeObjectFields = (
   sources: ReadonlyArray<unknown>
 ): Record<string, unknown> | undefined => {
@@ -25,30 +23,30 @@ const mergeObjectFields = (
   return Object.keys(merged).length > 0 ? merged : undefined
 }
 
-const rootCompositionBranches = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> =>
+const rootCompositionBranches = (schema: object): ReadonlyArray<Record<string, unknown>> =>
   [...ROOT_COMPOSITION_KEYS].flatMap((key) => {
-    const branches = schema[key]
+    const branches = Reflect.get(schema, key)
     return Array.isArray(branches) ? branches.filter(isRecord) : []
   })
 
 const schemaAndCompositionDescendants = (
-  schema: Record<string, unknown>
-): ReadonlyArray<Record<string, unknown>> => [
+  schema: object
+): ReadonlyArray<object> => [
   schema,
   ...rootCompositionBranches(schema).flatMap(schemaAndCompositionDescendants)
 ]
 
 const mergedSchemaField = (
-  schema: McpInputSchema,
+  schema: object,
   field: ObjectSchemaField
 ): Record<string, unknown> | undefined =>
-  mergeObjectFields(schemaAndCompositionDescendants(schema).map((branch) => branch[field]))
+  mergeObjectFields(schemaAndCompositionDescendants(schema).map((branch) => Reflect.get(branch, field)))
 
 /**
  * Some tool clients reject root-level schema composition. Branch-only required
  * constraints stay runtime-only because union branches represent alternatives.
  */
-export const toClientCompatibleInputSchema = (schema: McpInputSchema): McpInputSchema => {
+export const toClientCompatibleInputSchema = (schema: object): McpInputSchema => {
   const rootFields = Object.fromEntries(
     Object.entries(schema).filter(([key]) => key !== "type" && !ROOT_COMPOSITION_KEYS.has(key))
   )

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -25,7 +25,7 @@ import {
   VERSION_TOOL_NAME,
   versionToolDefinition
 } from "./huly-context-tool.js"
-import { isObjectSchema, toClientCompatibleInputSchema } from "./input-schema-compat.js"
+import { toClientCompatibleInputSchema } from "./input-schema-compat.js"
 import { listResources, listResourceTemplates, readHulyResource } from "./resources.js"
 import { defaultToolOutputSchema } from "./tool-output-schema.js"
 import type { ToolRegistry } from "./tools/index.js"
@@ -258,16 +258,13 @@ export const createMcpProtocolHandlers = (
       tools: [
         versionToolDefinition,
         getHulyContextToolDefinition,
-        ...registry.definitions.flatMap((tool) => {
-          if (!isObjectSchema(tool.inputSchema)) return []
-          return [{
-            name: tool.name,
-            description: tool.description,
-            inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
-            outputSchema: defaultToolOutputSchema,
-            annotations: resolveAnnotations(tool)
-          }]
-        })
+        ...registry.definitions.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
+          outputSchema: defaultToolOutputSchema,
+          annotations: resolveAnnotations(tool)
+        }))
       ].map(tool => ({
         ...tool,
         inputSchema: toProtocolObjectSchema(tool.inputSchema),

--- a/test/domain/schemas.issue-102-closeout.test.ts
+++ b/test/domain/schemas.issue-102-closeout.test.ts
@@ -1,11 +1,12 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, Exit } from "effect"
+import { Effect, Exit, Predicate } from "effect"
 import { expect } from "vitest"
 
 import {
   parseGetDocumentSnapshotParams,
   parseSetRelatedIssueTargetParams,
-  parseUpsertProjectTargetPreferenceParams
+  parseUpsertProjectTargetPreferenceParams,
+  upsertProjectTargetPreferenceParamsJsonSchema
 } from "../../src/domain/schemas.js"
 
 describe("issue #102 schemas", () => {
@@ -33,6 +34,36 @@ describe("issue #102 schemas", () => {
 
       expect(parsed.props?.[0]?.value).toEqual({ id: 123, enabled: true })
     }))
+
+  it("emits client-safe JSON Schema for ProjectTargetPreference prop values", () => {
+    if (!Predicate.isRecord(upsertProjectTargetPreferenceParamsJsonSchema)) {
+      throw new Error("Expected root schema object")
+    }
+    const rootProperties = upsertProjectTargetPreferenceParamsJsonSchema.properties
+    if (!Predicate.isRecord(rootProperties)) {
+      throw new Error("Expected root schema properties")
+    }
+    const props = rootProperties.props
+    if (!Predicate.isRecord(props) || !Predicate.isRecord(props.items)) {
+      throw new Error("Expected props array schema")
+    }
+    const itemProperties = props.items.properties
+    if (!Predicate.isRecord(itemProperties)) {
+      throw new Error("Expected props item properties")
+    }
+
+    expect(itemProperties.value).toEqual({
+      description: "SDK-open target preference property value. Passed through to Huly without narrowing.",
+      anyOf: [
+        { type: "string" },
+        { type: "number" },
+        { type: "boolean" },
+        { type: "object", additionalProperties: true },
+        { type: "array", items: {} },
+        { type: "null" }
+      ]
+    })
+  })
 
   it.effect("requires exactly one related issue target locator", () =>
     Effect.gen(function*() {

--- a/test/mcp/input-schema-compat.test.ts
+++ b/test/mcp/input-schema-compat.test.ts
@@ -71,4 +71,39 @@ describe("toClientCompatibleInputSchema", () => {
     expect(defs.IssueIdentifier).toBeDefined()
     expect(defs.DocumentIdentifier).toBeDefined()
   })
+
+  it("accepts root-composition schemas and flattens their object branches", () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      anyOf: [
+        {
+          type: "object",
+          required: ["personId"],
+          properties: {
+            personId: { type: "string" }
+          },
+          additionalProperties: false
+        },
+        {
+          type: "object",
+          required: ["email"],
+          properties: {
+            email: { type: "string", format: "email" }
+          },
+          additionalProperties: false
+        }
+      ],
+      description: "Provide personId or email."
+    }
+
+    const sanitized = toClientCompatibleInputSchema(schema)
+    const properties = expectRecord(sanitized.properties)
+
+    expect(sanitized.type).toBe("object")
+    expect(sanitized.anyOf).toBeUndefined()
+    expect(sanitized.required).toBeUndefined()
+    expect(sanitized.description).toBe("Provide personId or email.")
+    expect(properties.personId).toBeDefined()
+    expect(properties.email).toBeDefined()
+  })
 })

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -135,6 +135,32 @@ describe("createMcpProtocolHandlers", () => {
       expect(listed).toBeDefined()
       expect(listed?.inputSchema).not.toHaveProperty("properties")
     })
+
+    it("lists every registered category tool after schema compatibility conversion", async () => {
+      const handlers = createMcpProtocolHandlers(
+        unusedResolveClients,
+        createTelemetryProbe().telemetry,
+        toolRegistry,
+        unusedGetHulyContext
+      )
+
+      const result = await handlers.listTools()
+      const listedNames = result.tools.map((tool) => tool.name)
+      const expectedNames = [
+        VERSION_TOOL_NAME,
+        GET_HULY_CONTEXT_TOOL_NAME,
+        ...toolRegistry.definitions.map((tool) => tool.name)
+      ]
+
+      expect(listedNames).toEqual(expectedNames)
+      expect(new Set(listedNames).size).toBe(listedNames.length)
+      expect(listedNames).toContain("get_person")
+      expect(listedNames).toContain("list_person_organizations")
+      expect(listedNames).toContain("unschedule_todo")
+      expect(listedNames).toContain("create_access_link")
+      expect(listedNames).toContain("list_project_types")
+      expect(result.tools.every((tool) => Object.hasOwn(tool.inputSchema, "type"))).toBe(true)
+    })
   })
 
   describe("callTool telemetry clock seam", () => {


### PR DESCRIPTION
gpt55

## Summary

- Make MCP input schema compatibility conversion total for all registered tools, so root-composition schemas are converted instead of filtered out of `tools/list`.
- Add a regression test that `tools/list` exactly matches built-ins plus `toolRegistry.definitions`, covering the five previously omitted tools.
- Replace the remaining raw unknown input JSON Schema for project target preference values with an explicit client-safe JSON Schema while preserving `Schema.Unknown` runtime parsing.
- Add a patch changeset.

## Validation

- `pnpm vitest run test/mcp/input-schema-compat.test.ts test/mcp/input-schema-compat.property.test.ts test/mcp/protocol-handlers.test.ts test/domain/schemas.issue-102-closeout.test.ts`
- `pnpm typecheck`
- `pnpm check-all`
- `pnpm build && set -a && source .env.local && set +a && HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh` — 632 passed, 0 failed, 28 skipped
- `pnpm verify-version`
- Explicit schema scan: `registryCount: 378`, `listedCount: 380`, `missing: []`, `unknowns: []`, `badAdditional: []`