### PR TITLE
SpacePreference discovery tools

### DIFF
--- a/.changeset/quiet-space-preferences.md
+++ b/.changeset/quiet-space-preferences.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": minor
+---
+
+Add read-only SpacePreference discovery tools.

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ SDK upgrade revisit:
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
+**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
 
 ### Projects
 
@@ -784,6 +784,13 @@ SDK upgrade revisit:
 | `delete_todo` | Delete a Planner ToDo. This is destructive; deleting the last open issue ToDo can cause Huly classic issue status automation. |
 | `schedule_todo` | Schedule a Planner ToDo by raw todoId or human locator, creating a work slot with ToDo title, description, and visibility metadata. |
 | `unschedule_todo` | Remove ToDo work slots. Pass either workSlotId to remove one slot, locator with scope=all, or locator with scope=future and optional from. |
+
+### Preferences
+
+| Tool | Description |
+|------|-------------|
+| `list_space_preferences` | List low-level Huly SpacePreference records. These generic preference rows are attached to spaces and the published SDK exposes only the attached space link, so this tool is read-only discovery. Omit space to list recent rows across spaces, or pass a space _id/exact name with optional class/type narrowing to inspect one space. |
+| `get_space_preference` | Read the low-level Huly SpacePreference record attached to one space. Accepts a space _id or exact name with optional class/type narrowing. Returns present=false when the space exists but no generic SpacePreference row exists; use module-specific preference tools for writable preference payloads. |
 
 ### Processes
 

--- a/plans/huly-sdk-gap-matrix.md
+++ b/plans/huly-sdk-gap-matrix.md
@@ -59,7 +59,7 @@ Current high-level MCP categories:
 | Analytics collector / onboarding channel | `.reference/platform/models/analytics-collector/src/index.ts`: `OnboardingChannel` | No analytics/onboarding tools | Onboarding channels and analytics collector configuration; likely low priority for MCP |
 | View / saved filtered views | `.reference/platform/models/view/src/index.ts`: `FilteredView`, `Viewlet`, actions, view preferences | No saved-view tools; list tools accept ad hoc filters | Saved filtered views, user view preferences, viewlet descriptors, reusable filters/sorts/groups |
 | Workbench tabs/widgets/apps | `.reference/platform/models/workbench/src/index.ts`: `Application`, `ApplicationNavModel`, `HiddenApplication`, `Widget`, `WidgetPreference`, `WorkbenchTab` | No workbench UI state tools | List/hide apps, tabs, widgets, widget prefs. Mostly UI state, lower MCP priority |
-| Preference model | `.reference/platform/models/preference`; many modules store preferences | No generic preference tools | User preferences discovery/update for modules with preference-backed settings |
+| Preference model | `.reference/platform/models/preference`; many modules store preferences | Read-only generic `SpacePreference` discovery through `list_space_preferences` and `get_space_preference` | Generic preference writes and module-specific preference payloads remain deferred unless the published SDK exposes safe typed fields |
 | Document preferences and history | Installed `@hcengineering/document`; `node_modules/@hcengineering/document/types/types.d.ts` still exposes stale `SavedDocument extends Preference` plus `DocumentSnapshot`. Current platform source removed the `SavedDocument` model in hcengineering/platform#10124 and replaced document stars with rating-backed `DocReaction` / `ReactionKind.Star` | Document tools cover teamspaces, document CRUD, content edit, inline comments, relations, deletion, and read-only snapshot/history list/get. | Snapshot restore remains deferred until restore semantics are proven. Do not implement `SavedDocument` as SDK parity unless the platform model is restored; current document stars belong to the Rating / reputation row |
 
 ## Installed SDK Packages With Partial MCP Coverage
@@ -78,7 +78,7 @@ Current high-level MCP categories:
 | `@hcengineering/document` | Partial | Snapshot restore, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships |
 | `@hcengineering/inventory` | Model CRUD plus product media/discussion wrappers covered; wrappers partial | Category/variant discussion wrappers if they prove user-visible |
 | `@hcengineering/notification` | Partial | Mute contexts, notification type settings, collaborators |
-| `@hcengineering/preference` | No first-class generic tools | Generic user/space preference discovery and safe updates |
+| `@hcengineering/preference` | Read-only `SpacePreference` discovery covered | Generic preference writes and any module-specific preference payloads without published typed fields |
 | `@hcengineering/tags` | SDK-level covered; module wrappers partial | Module-specific wrappers for tag-backed concepts such as recruiting skills, board labels, controlled-doc labels, and contact tags |
 | `@hcengineering/task` | Partial | Generic task/project abstractions beyond tracker, reusable task workflows |
 | `@hcengineering/time` | Partial | Document-attached action items, automation helper visibility, team planner/schedule reports |

--- a/plans/sdk-parity-ledger.json
+++ b/plans/sdk-parity-ledger.json
@@ -462,9 +462,9 @@
     },
     {
       "package": "@hcengineering/preference",
-      "status": "gap",
+      "status": "covered",
       "matrixLocation": "Preference model",
-      "rationale": "Generic space preference discovery/update remains a matrix gap.",
+      "rationale": "Read-only generic SpacePreference discovery is covered by list_space_preferences and get_space_preference. Generic preference writes remain deferred because the published SDK model exposes no safe typed writable fields beyond attachedTo.",
       "exports": [
         "SpacePreference"
       ]

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -3306,6 +3306,32 @@ if [ $? -eq 0 ]; then
   fi
 fi
 
+run_capture_to_var SPACE_PREFS_TEXT "list_space_preferences" \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_space_preferences","arguments":{"limit":5}},"id":2}'
+if [ $? -eq 0 ]; then
+  assert_json_field_nonempty "list_space_preferences returns total" "$SPACE_PREFS_TEXT" ".total"
+fi
+if [ -n "$FIRST_SPACE_ID" ]; then
+  FIRST_SPACE_ID_JSON=$(json_string "$FIRST_SPACE_ID")
+  run_capture_to_var SPACE_PREF_TEXT "get_space_preference($FIRST_SPACE_ID)" \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_space_preference\",\"arguments\":{\"space\":$FIRST_SPACE_ID_JSON,\"includeArchived\":true}},\"id\":2}"
+  if [ $? -eq 0 ]; then
+    SPACE_PREF_PRESENT_TYPE=$(printf '%s\n' "$SPACE_PREF_TEXT" | jq -r '.present | type' 2>/dev/null)
+    if [ "$SPACE_PREF_PRESENT_TYPE" = "boolean" ]; then
+      echo "PASS: get_space_preference($FIRST_SPACE_ID) returns presence boolean"
+      PASSED=$((PASSED + 1))
+    else
+      echo "FAIL: get_space_preference($FIRST_SPACE_ID) missing presence boolean"
+      FAILED=$((FAILED + 1))
+      ERRORS="${ERRORS}\n  - get_space_preference($FIRST_SPACE_ID): missing presence boolean"
+    fi
+    assert_json_field_nonempty "get_space_preference($FIRST_SPACE_ID) returns attached space id" "$SPACE_PREF_TEXT" \
+      'if .present then .preference.attachedTo else .attachedTo end'
+  fi
+else
+  skip_test "get_space_preference" "no spaces found"
+fi
+
 run_capture_to_var SPACE_TYPES_TEXT "list_space_types" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_space_types","arguments":{"limit":50}},"id":2}'
 if [ $? -eq 0 ]; then

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -70,6 +70,7 @@ export { optionalOutput } from "./output-helpers.js"
 
 export {
   MessageTemplateMetadataDegradedWarningCode,
+  SpacePreferenceMetadataDegradedWarningCode,
   SpaceRoleAssignmentsDegradedWarningCode,
   StatusMetadataUnresolvedWarningCode,
   type ToolWarning,
@@ -78,6 +79,24 @@ export {
   ToolWarningSchema,
   ViewletDescriptorMetadataDegradedWarningCode
 } from "./tool-warnings.js"
+
+export {
+  type GetSpacePreferenceParams,
+  getSpacePreferenceParamsJsonSchema,
+  GetSpacePreferenceParamsSchema,
+  type GetSpacePreferenceResult,
+  GetSpacePreferenceResultSchema,
+  type ListSpacePreferencesParams,
+  listSpacePreferencesParamsJsonSchema,
+  ListSpacePreferencesParamsSchema,
+  type ListSpacePreferencesResult,
+  ListSpacePreferencesResultSchema,
+  parseGetSpacePreferenceParams,
+  parseListSpacePreferencesParams,
+  type SpacePreference,
+  SpacePreferenceId,
+  SpacePreferenceSchema
+} from "./preferences.js"
 
 export {
   MonthDayOrdinal,

--- a/src/domain/schemas/preferences.ts
+++ b/src/domain/schemas/preferences.ts
@@ -1,0 +1,115 @@
+import { JSONSchema, Schema } from "effect"
+
+import { optionalOutput } from "./output-helpers.js"
+import {
+  DEFAULT_LIMIT,
+  DocId,
+  LimitParam,
+  ListTotal,
+  ObjectClassName,
+  SpaceClassFilter,
+  SpaceId,
+  SpaceIdentifier,
+  SpaceTypeId
+} from "./shared.js"
+import { SpaceSummarySchema } from "./spaces.js"
+
+export const SpacePreferenceId = DocId.pipe(Schema.brand("SpacePreferenceId"))
+export type SpacePreferenceId = Schema.Schema.Type<typeof SpacePreferenceId>
+
+const spaceResolverOptionsRequireSpace = "includeArchived, class, and type can only be provided when space is provided."
+
+export const ListSpacePreferencesParamsSchema = Schema.Struct({
+  space: Schema.optional(SpaceIdentifier.annotations({
+    description:
+      "Optional space _id or exact space name whose low-level SpacePreference record should be listed. Resolution tries _id first, then exact name."
+  })),
+  includeArchived: Schema.optional(Schema.Boolean.annotations({
+    description:
+      "Allow matching archived spaces by exact name when space is provided. ID lookup can return archived spaces."
+  })),
+  class: Schema.optional(SpaceClassFilter.annotations({
+    description: "Optional raw Huly space class ID used to disambiguate exact-name lookup when space is provided."
+  })),
+  type: Schema.optional(SpaceTypeId.annotations({
+    description: "Optional raw Huly SpaceType _id used to disambiguate exact-name lookup when space is provided."
+  })),
+  limit: Schema.optional(LimitParam.annotations({
+    description: `Maximum number of space preferences to return (default: ${DEFAULT_LIMIT}).`
+  }))
+}).pipe(
+  Schema.filter((params) =>
+    params.space !== undefined || (
+        params.includeArchived === undefined && params.class === undefined && params.type === undefined
+      )
+      ? undefined
+      : spaceResolverOptionsRequireSpace
+  )
+).annotations({
+  title: "ListSpacePreferencesParams",
+  description:
+    "List low-level Huly SpacePreference records. These records are generic space-attached preference markers; module-specific preference payloads remain exposed through module-specific tools."
+})
+export type ListSpacePreferencesParams = Schema.Schema.Type<typeof ListSpacePreferencesParamsSchema>
+
+export const GetSpacePreferenceParamsSchema = Schema.Struct({
+  space: SpaceIdentifier.annotations({
+    description:
+      "Space _id or exact space name whose low-level SpacePreference record should be read. Resolution tries _id first, then exact name."
+  }),
+  includeArchived: Schema.optional(Schema.Boolean.annotations({
+    description: "Allow matching archived spaces by exact name. ID lookup can return archived spaces."
+  })),
+  class: Schema.optional(SpaceClassFilter.annotations({
+    description: "Optional raw Huly space class ID used to disambiguate exact-name lookup."
+  })),
+  type: Schema.optional(SpaceTypeId.annotations({
+    description: "Optional raw Huly SpaceType _id used to disambiguate exact-name lookup."
+  }))
+}).annotations({
+  title: "GetSpacePreferenceParams",
+  description:
+    "Read the low-level Huly SpacePreference record attached to one space. Absence is returned as present=false."
+})
+export type GetSpacePreferenceParams = Schema.Schema.Type<typeof GetSpacePreferenceParamsSchema>
+
+export const SpacePreferenceSchema = Schema.Struct({
+  preferenceId: SpacePreferenceId,
+  attachedTo: SpaceId.annotations({
+    description: "Raw Huly space ID stored in SpacePreference.attachedTo."
+  }),
+  attachedSpace: optionalOutput(SpaceSummarySchema),
+  class: ObjectClassName.annotations({
+    description: "Raw Huly class ID for the returned preference document."
+  })
+}).annotations({
+  title: "SpacePreference",
+  description:
+    "Low-level Huly SpacePreference row attached to a space. The published SDK model exposes no safe generic writable preference fields beyond attachedTo."
+})
+export type SpacePreference = Schema.Schema.Type<typeof SpacePreferenceSchema>
+
+export const ListSpacePreferencesResultSchema = Schema.Struct({
+  preferences: Schema.Array(SpacePreferenceSchema),
+  total: ListTotal
+})
+export type ListSpacePreferencesResult = Schema.Schema.Type<typeof ListSpacePreferencesResultSchema>
+
+export const GetSpacePreferenceResultSchema = Schema.Union(
+  Schema.Struct({
+    present: Schema.Literal(true),
+    preference: SpacePreferenceSchema
+  }),
+  Schema.Struct({
+    present: Schema.Literal(false),
+    attachedTo: SpaceId,
+    attachedSpace: SpaceSummarySchema
+  })
+)
+export type GetSpacePreferenceResult = Schema.Schema.Type<typeof GetSpacePreferenceResultSchema>
+
+export const listSpacePreferencesParamsJsonSchema = JSONSchema.make(ListSpacePreferencesParamsSchema)
+export const getSpacePreferenceParamsJsonSchema = JSONSchema.make(GetSpacePreferenceParamsSchema)
+
+export const parseListSpacePreferencesParams = Schema.decodeUnknown(ListSpacePreferencesParamsSchema)
+export const parseGetSpacePreferenceParams = Schema.decodeUnknown(GetSpacePreferenceParamsSchema)

--- a/src/domain/schemas/tool-warnings.ts
+++ b/src/domain/schemas/tool-warnings.ts
@@ -4,7 +4,8 @@ export const ToolWarningCodeSchema = Schema.Literal(
   "status_metadata_unresolved",
   "space_role_assignments_degraded",
   "message_template_metadata_degraded",
-  "viewlet_descriptor_metadata_degraded"
+  "viewlet_descriptor_metadata_degraded",
+  "space_preference_metadata_degraded"
 ).annotations({
   identifier: "ToolWarningCode",
   title: "ToolWarningCode",
@@ -15,6 +16,7 @@ export const StatusMetadataUnresolvedWarningCode = ToolWarningCodeSchema.literal
 export const SpaceRoleAssignmentsDegradedWarningCode = ToolWarningCodeSchema.literals[1]
 export const MessageTemplateMetadataDegradedWarningCode = ToolWarningCodeSchema.literals[2]
 export const ViewletDescriptorMetadataDegradedWarningCode = ToolWarningCodeSchema.literals[3]
+export const SpacePreferenceMetadataDegradedWarningCode = ToolWarningCodeSchema.literals[4]
 
 export const ToolWarningSchema = Schema.Struct({
   code: ToolWarningCodeSchema,

--- a/src/huly/operations/preferences.ts
+++ b/src/huly/operations/preferences.ts
@@ -1,0 +1,133 @@
+import type { Ref, Space } from "@hcengineering/core"
+import { SortingOrder } from "@hcengineering/core"
+import type { SpacePreference as HulySpacePreference } from "@hcengineering/preference"
+import { Effect } from "effect"
+
+import type {
+  GetSpacePreferenceParams,
+  GetSpacePreferenceResult,
+  ListSpacePreferencesParams,
+  ListSpacePreferencesResult,
+  SpacePreference
+} from "../../domain/schemas/preferences.js"
+import { SpacePreferenceId } from "../../domain/schemas/preferences.js"
+import { ObjectClassName, SpaceId } from "../../domain/schemas/shared.js"
+import { SpacePreferenceMetadataDegradedWarningCode } from "../../domain/schemas/tool-warnings.js"
+import { HulyClient, type HulyClientError } from "../client.js"
+import { Diagnostics } from "../diagnostics.js"
+import type { SpaceIdentifierAmbiguousError, SpaceNotFoundError } from "../errors.js"
+import { preference } from "../huly-plugins.js"
+import { clampLimit, hulyQuery, type StrictDocumentQuery } from "./query-helpers.js"
+import { toRef } from "./sdk-boundary.js"
+import { toSpaceSummary } from "./spaces-projections.js"
+import { findSpace, type GenericSpace, listTotal, spaceClass } from "./spaces-shared.js"
+
+type SpacePreferenceError = HulyClientError | SpaceNotFoundError | SpaceIdentifierAmbiguousError
+
+type SpacePreferenceProjection = Pick<HulySpacePreference, "_class" | "_id" | "attachedTo">
+
+const spaceRef = (id: string): Ref<Space> => toRef<Space>(SpaceId.make(id))
+
+const spaceMapById = (
+  client: HulyClient["Type"],
+  ids: ReadonlyArray<Ref<Space>>
+): Effect.Effect<ReadonlyMap<string, GenericSpace>, HulyClientError> =>
+  Effect.gen(function*() {
+    const uniqueIds = [...new Set(ids.map(String))]
+    if (uniqueIds.length === 0) return new Map<string, GenericSpace>()
+
+    const spaces = yield* client.findAll<GenericSpace>(
+      spaceClass,
+      hulyQuery<GenericSpace>({ _id: { $in: uniqueIds.map((id) => toRef<GenericSpace>(SpaceId.make(id))) } }),
+      { limit: uniqueIds.length }
+    )
+
+    return new Map(spaces.map((space) => [space._id, space]))
+  })
+
+const preferenceResult = (
+  item: SpacePreferenceProjection,
+  attachedSpace: GenericSpace | undefined
+): SpacePreference => ({
+  preferenceId: SpacePreferenceId.make(item._id),
+  attachedTo: SpaceId.make(item.attachedTo),
+  ...(attachedSpace === undefined ? {} : { attachedSpace: toSpaceSummary(attachedSpace) }),
+  class: ObjectClassName.make(item._class)
+})
+
+const warnMissingAttachedSpaces = (
+  diagnostics: Diagnostics["Type"],
+  items: ReadonlyArray<SpacePreferenceProjection>,
+  spacesById: ReadonlyMap<string, GenericSpace>
+): Effect.Effect<void> => {
+  const missingIds = [...new Set(items.map((item) => String(item.attachedTo)).filter((id) => !spacesById.has(id)))]
+    .sort()
+  if (missingIds.length === 0) return Effect.void
+
+  return diagnostics.warnAgent({
+    code: SpacePreferenceMetadataDegradedWarningCode,
+    message:
+      `Some SpacePreference attached space metadata was omitted because ${missingIds.length} attached space id(s) could not be resolved: ${
+        missingIds.join(", ")
+      }. Results still include raw attachedTo space IDs.`
+  })
+}
+
+const listQuery = (
+  targetSpace: GenericSpace | undefined
+): StrictDocumentQuery<HulySpacePreference> =>
+  targetSpace === undefined ? {} : { attachedTo: spaceRef(targetSpace._id) }
+
+export const listSpacePreferences = (
+  params: ListSpacePreferencesParams
+): Effect.Effect<ListSpacePreferencesResult, SpacePreferenceError, HulyClient | Diagnostics> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const diagnostics = yield* Diagnostics
+    const targetSpace = params.space === undefined
+      ? undefined
+      : yield* findSpace(client, {
+        space: params.space,
+        ...(params.includeArchived === undefined ? {} : { includeArchived: params.includeArchived }),
+        ...(params.class === undefined ? {} : { class: params.class }),
+        ...(params.type === undefined ? {} : { type: params.type })
+      })
+
+    const preferences = yield* client.findAll<HulySpacePreference>(
+      preference.class.SpacePreference,
+      hulyQuery(listQuery(targetSpace)),
+      { limit: clampLimit(params.limit), sort: { modifiedOn: SortingOrder.Descending }, total: true }
+    )
+    const spacesById = yield* spaceMapById(client, preferences.map((item) => item.attachedTo))
+    yield* warnMissingAttachedSpaces(diagnostics, preferences, spacesById)
+
+    return {
+      preferences: preferences.map((item) => preferenceResult(item, spacesById.get(item.attachedTo))),
+      total: listTotal(preferences.total)
+    }
+  })
+
+export const getSpacePreference = (
+  params: GetSpacePreferenceParams
+): Effect.Effect<GetSpacePreferenceResult, SpacePreferenceError, HulyClient> =>
+  Effect.gen(function*() {
+    const client = yield* HulyClient
+    const targetSpace = yield* findSpace(client, params)
+    const item = yield* client.findOne<HulySpacePreference>(
+      preference.class.SpacePreference,
+      hulyQuery<HulySpacePreference>({ attachedTo: spaceRef(targetSpace._id) })
+    )
+
+    if (item === undefined) {
+      return {
+        present: false,
+        attachedTo: SpaceId.make(targetSpace._id),
+        attachedSpace: toSpaceSummary(targetSpace)
+      }
+    }
+
+    return {
+      present: true,
+      preference: preferenceResult(item, targetSpace)
+    }
+  })

--- a/src/huly/operations/sdk-discovery-tool-hints.ts
+++ b/src/huly/operations/sdk-discovery-tool-hints.ts
@@ -55,6 +55,10 @@ export const firstClassToolHints = new Map<string, ReadonlyArray<HulyClassToolHi
   [String(view.class.Viewlet), [toolHint("views", ["list_viewlets"])]],
   [String(view.class.ViewletDescriptor), [toolHint("views", ["list_viewlets"])]],
   [String(view.class.ViewletPreference), [toolHint("views", ["list_viewlets"])]],
+  [
+    String(preference.class.SpacePreference),
+    [toolHint("preferences", ["list_space_preferences", "get_space_preference"])]
+  ],
   [String(chunter.class.ChatMessage), [toolHint("channels", ["list_channel_messages", "send_channel_message"])]],
   [
     String(tracker.class.ProjectTargetPreference),
@@ -107,6 +111,8 @@ const boardCoveredRationale =
   "Current board tools cover board discovery, board create/update/archive, board card list/get/create/update, workflow status/type resolution, assignees, members, location, cover, dates, archived-card deletion, board labels, saved views, menu pages, viewlets, and common board preference reads. Provider integrations and board deletion remain deferred."
 const viewCoveredRationale =
   "Current view tools cover read-only saved filtered view discovery/get operations across modules plus viewlet descriptor and ViewletPreference configuration discovery. View and preference writes remain deferred."
+const preferenceCoveredRationale =
+  "Read-only generic SpacePreference discovery is covered by list_space_preferences and get_space_preference. Generic preference writes remain deferred because the published SDK model exposes no safe typed writable fields beyond attachedTo."
 const boardNotMcpFacingRationale =
   "Board card cover values are exposed through board card create/update fields. The CardCover SDK export is the underlying type metadata rather than a separate LLM-facing resource."
 const chunterCoveredRationale =
@@ -212,6 +218,12 @@ export const runtimeParityRoutingRows: ReadonlyArray<RuntimeParityRoutingRow> = 
     "@hcengineering/board",
     "CommonBoardPreference",
     covered(["get_board_common_preference"], boardCoveredRationale)
+  ),
+  routingRow(
+    String(preference.class.SpacePreference),
+    "@hcengineering/preference",
+    "SpacePreference",
+    covered(["list_space_preferences", "get_space_preference"], preferenceCoveredRationale)
   ),
   routingRow(
     String(preference.class.Preference),

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -26,6 +26,7 @@ import { messageTemplateTools } from "./message-templates.js"
 import { milestoneTools } from "./milestones.js"
 import { notificationTools } from "./notifications.js"
 import { plannerTools } from "./planner.js"
+import { preferenceTools } from "./preferences.js"
 import { processTools } from "./processes.js"
 import { projectTargetPreferenceTools } from "./project-target-preferences.js"
 import { projectTools } from "./projects.js"
@@ -89,6 +90,7 @@ const allTools: ReadonlyArray<RegisteredTool> = [
   ...calendarTools,
   ...timeTools,
   ...plannerTools,
+  ...preferenceTools,
   ...searchTools,
   ...activityTools,
   ...notificationTools,

--- a/src/mcp/tools/preferences.ts
+++ b/src/mcp/tools/preferences.ts
@@ -1,0 +1,39 @@
+import {
+  getSpacePreferenceParamsJsonSchema,
+  GetSpacePreferenceResultSchema,
+  listSpacePreferencesParamsJsonSchema,
+  ListSpacePreferencesResultSchema,
+  parseGetSpacePreferenceParams,
+  parseListSpacePreferencesParams
+} from "../../domain/schemas/preferences.js"
+import { getSpacePreference, listSpacePreferences } from "../../huly/operations/preferences.js"
+import { defineTool, type RegisteredTool } from "./registry.js"
+
+const CATEGORY = "preferences" as const
+
+export const preferenceTools: ReadonlyArray<RegisteredTool> = [
+  defineTool(
+    {
+      name: "list_space_preferences",
+      description:
+        "List low-level Huly SpacePreference records. These generic preference rows are attached to spaces and the published SDK exposes only the attached space link, so this tool is read-only discovery. Omit space to list recent rows across spaces, or pass a space _id/exact name with optional class/type narrowing to inspect one space.",
+      category: CATEGORY,
+      inputSchema: listSpacePreferencesParamsJsonSchema,
+      resultSchema: ListSpacePreferencesResultSchema
+    },
+    parseListSpacePreferencesParams,
+    listSpacePreferences
+  ),
+  defineTool(
+    {
+      name: "get_space_preference",
+      description:
+        "Read the low-level Huly SpacePreference record attached to one space. Accepts a space _id or exact name with optional class/type narrowing. Returns present=false when the space exists but no generic SpacePreference row exists; use module-specific preference tools for writable preference payloads.",
+      category: CATEGORY,
+      inputSchema: getSpacePreferenceParamsJsonSchema,
+      resultSchema: GetSpacePreferenceResultSchema
+    },
+    parseGetSpacePreferenceParams,
+    getSpacePreference
+  )
+]

--- a/test/domain/schemas.preferences.test.ts
+++ b/test/domain/schemas.preferences.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "@effect/vitest"
+import { Effect, Exit, Predicate, Schema } from "effect"
+import { expect } from "vitest"
+
+import {
+  getSpacePreferenceParamsJsonSchema,
+  GetSpacePreferenceResultSchema,
+  listSpacePreferencesParamsJsonSchema,
+  parseGetSpacePreferenceParams,
+  parseListSpacePreferencesParams
+} from "../../src/domain/schemas/preferences.js"
+
+describe("preference schemas", () => {
+  it.effect("parses list/get SpacePreference params", () =>
+    Effect.gen(function*() {
+      const listParams = yield* parseListSpacePreferencesParams({
+        space: "General",
+        includeArchived: true,
+        class: "core:class:Space",
+        limit: 10
+      })
+      const getParams = yield* parseGetSpacePreferenceParams({ space: "space-1" })
+
+      expect(listParams).toMatchObject({
+        space: "General",
+        includeArchived: true,
+        class: "core:class:Space",
+        limit: 10
+      })
+      expect(getParams).toMatchObject({ space: "space-1" })
+    }))
+
+  it.effect("rejects list resolver options when no space is provided", () =>
+    Effect.gen(function*() {
+      const rejectedParams = [
+        { includeArchived: true },
+        { class: "core:class:Space" },
+        { type: "space-type-1" }
+      ]
+
+      for (const params of rejectedParams) {
+        const exit = yield* parseListSpacePreferencesParams(params).pipe(Effect.exit)
+        if (Exit.isSuccess(exit)) throw new Error("Expected params to be rejected")
+        expect(exit.cause.toString()).toContain(
+          "includeArchived, class, and type can only be provided when space is provided."
+        )
+      }
+    }))
+
+  it("emits client-safe JSON Schema for SpacePreference tool inputs", () => {
+    expect(Predicate.isRecord(listSpacePreferencesParamsJsonSchema)).toBe(true)
+    expect(Predicate.isRecord(getSpacePreferenceParamsJsonSchema)).toBe(true)
+    expect(listSpacePreferencesParamsJsonSchema).toMatchObject({
+      type: "object",
+      properties: {
+        space: {},
+        limit: {}
+      }
+    })
+    expect(getSpacePreferenceParamsJsonSchema).toMatchObject({
+      type: "object",
+      required: ["space"]
+    })
+  })
+
+  it("accepts the absent SpacePreference result shape", () => {
+    const decoded = Schema.decodeUnknownSync(GetSpacePreferenceResultSchema)({
+      present: false,
+      attachedTo: "space-1",
+      attachedSpace: {
+        id: "space-1",
+        name: "General",
+        class: "core:class:Space",
+        private: false,
+        archived: false,
+        membersCount: 1,
+        ownersCount: 0
+      }
+    })
+
+    expect(decoded.present).toBe(false)
+  })
+})

--- a/test/huly/operations/preferences.test.ts
+++ b/test/huly/operations/preferences.test.ts
@@ -1,0 +1,276 @@
+import { describe, it } from "@effect/vitest"
+import type { Class, Doc, DocumentQuery, FindOptions, PersonId, Ref, Space, SpaceType } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import type { SpacePreference as HulySpacePreference } from "@hcengineering/preference"
+import { Effect, Exit } from "effect"
+import { expect } from "vitest"
+import { assertAt } from "../../../src/utils/assertions.js"
+
+import { SpaceClassFilter, SpaceIdentifier, SpaceTypeId } from "../../../src/domain/schemas/shared.js"
+import { SpacePreferenceMetadataDegradedWarningCode } from "../../../src/domain/schemas/tool-warnings.js"
+import type { ToolWarning } from "../../../src/domain/schemas/tool-warnings.js"
+import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
+import { Diagnostics, makeDiagnosticsScope } from "../../../src/huly/diagnostics.js"
+import { core, preference } from "../../../src/huly/huly-plugins.js"
+import { getSpacePreference, listSpacePreferences } from "../../../src/huly/operations/preferences.js"
+import { toAccountUuid, toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import type { GenericSpace } from "../../../src/huly/operations/spaces-shared.js"
+import { corePersonId } from "../../helpers/huly-sdk.js"
+
+type QueryRecord = Readonly<Record<string, unknown>>
+type DocRecord = Readonly<Record<string, unknown>>
+
+interface CapturedFindAll {
+  readonly classId: string
+  readonly query: QueryRecord
+  readonly options: FindOptions<Doc> | undefined
+}
+
+interface FixtureConfig {
+  readonly spaces?: ReadonlyArray<GenericSpace>
+  readonly preferences?: ReadonlyArray<HulySpacePreference>
+  readonly captures?: Array<CapturedFindAll>
+}
+
+const personId: PersonId = corePersonId("person-social-1")
+const accountUuid = toAccountUuid("00000000-0000-4000-8000-000000000001")
+const spaceIdentifier = (value: string) => SpaceIdentifier.make(value)
+
+const exitCauseText = <A, E>(exit: Exit.Exit<A, E>): string => {
+  if (Exit.isSuccess(exit)) throw new Error("Expected effect to fail")
+  return exit.cause.toString()
+}
+
+const recordFromPort = (value: unknown): QueryRecord => {
+  // Huly SDK query/doc payloads are plain objects at runtime; tests inspect them at the fake-client boundary.
+
+  return value as QueryRecord
+}
+
+const docRecord = (doc: Doc): DocRecord => {
+  // Huly docs are plain objects in these fixtures, and the fake client indexes fields by query keys.
+  // eslint-disable-next-line no-restricted-syntax -- test-only structural query/doc matcher
+  return doc as unknown as DocRecord
+}
+
+const hasInOperator = (value: unknown): value is { readonly $in: ReadonlyArray<unknown> } =>
+  typeof value === "object" && value !== null && "$in" in value && Array.isArray(value.$in)
+
+const matchesQuery = (doc: Doc, query: QueryRecord): boolean => {
+  const source = docRecord(doc)
+  return Object.entries(query).every(([key, expected]) =>
+    hasInOperator(expected) ? expected.$in.includes(source[key]) : source[key] === expected
+  )
+}
+
+const makeSpace = (overrides: Partial<GenericSpace> = {}): GenericSpace => ({
+  _id: toRef<Space>("space-1"),
+  _class: core.class.Space,
+  space: core.space.Space,
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0,
+  name: "General",
+  description: "Default space",
+  private: false,
+  members: [accountUuid],
+  owners: [],
+  archived: false,
+  ...overrides
+})
+
+const makePreference = (overrides: Partial<HulySpacePreference> = {}): HulySpacePreference => ({
+  _id: toRef<HulySpacePreference>("pref-1"),
+  _class: preference.class.SpacePreference,
+  space: core.space.Workspace,
+  modifiedBy: personId,
+  modifiedOn: 10,
+  createdBy: personId,
+  createdOn: 5,
+  attachedTo: toRef<Space>("space-1"),
+  ...overrides
+})
+
+const docsForClass = (
+  classId: unknown,
+  spaces: ReadonlyArray<GenericSpace>,
+  preferences: ReadonlyArray<HulySpacePreference>
+): ReadonlyArray<Doc> => {
+  if (classId === core.class.Space) return spaces
+  if (classId === preference.class.SpacePreference) return preferences
+  return []
+}
+
+const testLayer = (config: FixtureConfig = {}) => {
+  const spaces = config.spaces ?? [makeSpace()]
+  const preferences = config.preferences ?? [makePreference()]
+
+  const findAll: HulyClientOperations["findAll"] = (<T extends Doc>(
+    classId: Ref<Class<T>>,
+    query: DocumentQuery<T>,
+    options?: FindOptions<T>
+  ) => {
+    const queryRecord = recordFromPort(query)
+    config.captures?.push({
+      classId: String(classId),
+      query: queryRecord,
+      // The fake stores only read-only FindOptions fields for assertions; it never invokes or mutates option payloads.
+      // Re-typing the generic SDK options to Doc options keeps the capture collection class-agnostic.
+      options: options as FindOptions<Doc> | undefined
+    })
+    const matched = docsForClass(classId, spaces, preferences).filter((doc) => matchesQuery(doc, queryRecord))
+    const limited = options?.limit === undefined ? matched : matched.slice(0, options.limit)
+
+    // docsForClass branches on the same classId that defines T, but Ref<Class<T>> branding is erased at runtime.
+    // The cast is limited to this test port after the classId branch selects the matching fixture array.
+    return Effect.succeed(toFindResult(limited as Array<T>, matched.length))
+  }) as HulyClientOperations["findAll"]
+
+  const findOne: HulyClientOperations["findOne"] = (<T extends Doc>(
+    classId: Ref<Class<T>>,
+    query: DocumentQuery<T>
+  ) => {
+    const matched = docsForClass(classId, spaces, preferences).find((doc) => matchesQuery(doc, recordFromPort(query)))
+
+    // docsForClass branches on the same classId that defines T, but Ref<Class<T>> branding is erased at runtime.
+    // The cast is limited to this test port after the classId branch selects the matching fixture array.
+    return Effect.succeed(matched as T | undefined)
+  }) as HulyClientOperations["findOne"]
+
+  return HulyClient.testLayer({ findAll, findOne })
+}
+
+const withWarnings = <A, E, R>(
+  effect: Effect.Effect<A, E, R | Diagnostics>
+): Effect.Effect<{ readonly value: A; readonly warnings: ReadonlyArray<ToolWarning> }, E, R> =>
+  Effect.gen(function*() {
+    const diagnostics = yield* makeDiagnosticsScope
+    const value = yield* effect.pipe(Effect.provideService(Diagnostics, diagnostics.service))
+    const warnings = yield* diagnostics.drainWarnings
+    return { value, warnings }
+  })
+
+describe("space preference operations", () => {
+  it.effect("lists SpacePreference rows with attached space summaries", () =>
+    Effect.gen(function*() {
+      const secondSpace = makeSpace({ _id: toRef<Space>("space-2"), name: "Design" })
+      const secondPreference = makePreference({
+        _id: toRef<HulySpacePreference>("pref-2"),
+        attachedTo: toRef<Space>("space-2")
+      })
+
+      const { value, warnings } = yield* listSpacePreferences({ limit: 10 }).pipe(
+        withWarnings,
+        Effect.provide(
+          testLayer({ spaces: [makeSpace(), secondSpace], preferences: [makePreference(), secondPreference] })
+        )
+      )
+
+      expect(warnings).toEqual([])
+      expect(value.total).toBe(2)
+      expect(value.preferences.map((item) => item.preferenceId)).toEqual(["pref-1", "pref-2"])
+      expect(value.preferences.map((item) => item.attachedSpace?.name)).toEqual(["General", "Design"])
+    }))
+
+  it.effect("filters listSpacePreferences by resolved space name", () =>
+    Effect.gen(function*() {
+      const captures: Array<CapturedFindAll> = []
+      const typedSpace = makeSpace({ type: toRef<SpaceType>("space-type-1") })
+      const otherPreference = makePreference({
+        _id: toRef<HulySpacePreference>("pref-2"),
+        attachedTo: toRef<Space>("space-2")
+      })
+
+      const { value } = yield* listSpacePreferences({
+        space: spaceIdentifier("General"),
+        includeArchived: true,
+        class: SpaceClassFilter.make(core.class.Space),
+        type: SpaceTypeId.make("space-type-1")
+      }).pipe(
+        withWarnings,
+        Effect.provide(testLayer({ captures, spaces: [typedSpace], preferences: [makePreference(), otherPreference] }))
+      )
+
+      expect(value.preferences.map((item) => item.preferenceId)).toEqual(["pref-1"])
+      const preferenceQuery = captures.find((capture) => capture.classId === preference.class.SpacePreference)?.query
+      expect(preferenceQuery).toMatchObject({ attachedTo: "space-1" })
+    }))
+
+  it.effect("filters listSpacePreferences with default space resolver options", () =>
+    Effect.gen(function*() {
+      const { value, warnings } = yield* listSpacePreferences({ space: spaceIdentifier("General") }).pipe(
+        withWarnings,
+        Effect.provide(testLayer())
+      )
+
+      expect(warnings).toEqual([])
+      expect(value.preferences.map((item) => item.preferenceId)).toEqual(["pref-1"])
+    }))
+
+  it.effect("returns present=false when a resolved space has no SpacePreference row", () =>
+    Effect.gen(function*() {
+      const result = yield* getSpacePreference({ space: spaceIdentifier("General") }).pipe(
+        Effect.provide(testLayer({ preferences: [] }))
+      )
+
+      expect(result).toMatchObject({
+        present: false,
+        attachedTo: "space-1",
+        attachedSpace: { id: "space-1", name: "General" }
+      })
+    }))
+
+  it.effect("returns present=true when a resolved space has a SpacePreference row", () =>
+    Effect.gen(function*() {
+      const result = yield* getSpacePreference({ space: spaceIdentifier("General") }).pipe(
+        Effect.provide(testLayer())
+      )
+
+      expect(result).toMatchObject({
+        present: true,
+        preference: {
+          preferenceId: "pref-1",
+          attachedTo: "space-1",
+          attachedSpace: { id: "space-1", name: "General" }
+        }
+      })
+    }))
+
+  it.effect("lists an empty SpacePreference result without metadata warnings", () =>
+    Effect.gen(function*() {
+      const captures: Array<CapturedFindAll> = []
+      const { value, warnings } = yield* listSpacePreferences({}).pipe(
+        withWarnings,
+        Effect.provide(testLayer({ captures, preferences: [] }))
+      )
+
+      expect(value).toEqual({ preferences: [], total: 0 })
+      expect(warnings).toEqual([])
+      expect(captures.filter((capture) => capture.classId === core.class.Space)).toEqual([])
+    }))
+
+  it.effect("fails getSpacePreference when the target space cannot be resolved", () =>
+    Effect.gen(function*() {
+      const exit = yield* getSpacePreference({ space: spaceIdentifier("Missing") }).pipe(
+        Effect.provide(testLayer({ spaces: [], preferences: [] })),
+        Effect.exit
+      )
+
+      expect(exitCauseText(exit)).toContain("SpaceNotFoundError")
+    }))
+
+  it.effect("warns when listSpacePreferences cannot hydrate attached space metadata", () =>
+    Effect.gen(function*() {
+      const missingPreference = makePreference({ attachedTo: toRef<Space>("missing-space") })
+      const { value, warnings } = yield* listSpacePreferences({}).pipe(
+        withWarnings,
+        Effect.provide(testLayer({ spaces: [], preferences: [missingPreference] }))
+      )
+
+      expect(assertAt(warnings, 0).code).toBe(SpacePreferenceMetadataDegradedWarningCode)
+      const firstPreference = assertAt(value.preferences, 0)
+      expect(firstPreference.attachedTo).toBe("missing-space")
+      expect("attachedSpace" in firstPreference).toBe(false)
+    }))
+})

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -52,6 +52,7 @@ describe("CATEGORY_NAMES", () => {
       expect(CATEGORY_NAMES.has("inventory")).toBe(true)
       expect(CATEGORY_NAMES.has("recruiting")).toBe(true)
       expect(CATEGORY_NAMES.has("views")).toBe(true)
+      expect(CATEGORY_NAMES.has("preferences")).toBe(true)
       expect(CATEGORY_NAMES.size).toBeGreaterThan(5)
     }))
 
@@ -87,6 +88,12 @@ describe("CATEGORY_NAMES", () => {
       expect(toolDefinition("list_related_issue_targets").category).toBe("issues")
       expect(toolDefinition("set_related_issue_target").category).toBe("issues")
       expect(toolDefinition("delete_related_issue_space_target").category).toBe("issues")
+    }))
+
+  it.effect("registers preference tools in the preferences category", () =>
+    Effect.gen(function*() {
+      expect(toolDefinition("list_space_preferences").category).toBe("preferences")
+      expect(toolDefinition("get_space_preference").category).toBe("preferences")
     }))
 })
 

--- a/test/mcp/tools/preferences.test.ts
+++ b/test/mcp/tools/preferences.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from "@effect/vitest"
+import type { AccountUuid, Class, Doc, DocumentQuery, PersonId, Ref, Space } from "@hcengineering/core"
+import { toFindResult } from "@hcengineering/core"
+import type { SpacePreference as HulySpacePreference } from "@hcengineering/preference"
+import { Effect } from "effect"
+import { expect } from "vitest"
+import { assertAt } from "../../../src/utils/assertions.js"
+
+import type { HulyClientOperations } from "../../../src/huly/client.js"
+import { core, preference } from "../../../src/huly/huly-plugins.js"
+import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
+import { toAccountUuid, toRef } from "../../../src/huly/operations/sdk-boundary.js"
+import type { HulyStorageOperations } from "../../../src/huly/storage.js"
+import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
+import { resolveAnnotations, TOOL_DEFINITIONS } from "../../../src/mcp/tools/index.js"
+import { preferenceTools } from "../../../src/mcp/tools/preferences.js"
+import { corePersonId } from "../../helpers/huly-sdk.js"
+
+const personId: PersonId = corePersonId("person-social-1")
+const accountUuid = toAccountUuid("00000000-0000-4000-8000-000000000001")
+
+const space: Space = {
+  _id: toRef<Space>("space-1"),
+  _class: core.class.Space,
+  space: core.space.Space,
+  modifiedBy: personId,
+  modifiedOn: 0,
+  createdBy: personId,
+  createdOn: 0,
+  name: "General",
+  description: "Default space",
+  private: false,
+  members: [accountUuid],
+  owners: [],
+  archived: false
+}
+
+const spacePreference: HulySpacePreference = {
+  _id: toRef<HulySpacePreference>("pref-1"),
+  _class: preference.class.SpacePreference,
+  space: core.space.Workspace,
+  modifiedBy: personId,
+  modifiedOn: 10,
+  createdBy: personId,
+  createdOn: 5,
+  attachedTo: toRef<Space>("space-1")
+}
+
+const findAll: HulyClientOperations["findAll"] = <T extends Doc>(
+  classId: Ref<Class<T>>,
+  _query: DocumentQuery<T>
+) => {
+  if (classId === preference.class.SpacePreference) {
+    // The class ref selects the SpacePreference fixture for T.
+    // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+    return Effect.succeed(toFindResult([spacePreference] as unknown as Array<T>))
+  }
+  if (classId === core.class.Space) {
+    // The class ref selects the Space fixture for T.
+    // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+    return Effect.succeed(toFindResult([space] as unknown as Array<T>))
+  }
+  return Effect.succeed(toFindResult<T>([]))
+}
+
+const findOne: HulyClientOperations["findOne"] = <T extends Doc>(classId: Ref<Class<T>>) => {
+  if (classId === core.class.Space) {
+    // The class ref selects the Space fixture for T.
+    // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+    return Effect.succeed(space as unknown as T)
+  }
+  if (classId === preference.class.SpacePreference) {
+    // The class ref selects the SpacePreference fixture for T.
+    // eslint-disable-next-line no-restricted-syntax -- brands erased at runtime; class branch selects T
+    return Effect.succeed(spacePreference as unknown as T)
+  }
+  return Effect.succeed(undefined)
+}
+
+const hulyClient: HulyClientOperations = {
+  getAccountUuid: (): AccountUuid => accountUuid,
+  getPrimarySocialId: () => personId,
+  markupUrlConfig: testMarkupUrlConfig,
+  workbenchUrlConfig: testWorkbenchUrlConfig,
+  findAll,
+  findAllInModel: findAll,
+  findOne,
+  createDoc: () => Effect.die(new Error("not implemented")),
+  updateDoc: () => Effect.die(new Error("not implemented")),
+  addCollection: () => Effect.die(new Error("not implemented")),
+  removeDoc: () => Effect.die(new Error("not implemented")),
+  uploadMarkup: () => Effect.die(new Error("not implemented")),
+  fetchMarkup: () => Effect.succeed(""),
+  updateMarkup: () => Effect.die(new Error("not implemented")),
+  updateMixin: () => Effect.die(new Error("not implemented")),
+  createMixin: () => Effect.die(new Error("not implemented")),
+  searchFulltext: () => Effect.die(new Error("not implemented"))
+}
+
+const storageClient: HulyStorageOperations = {
+  uploadFile: () => Effect.die(new Error("not implemented")),
+  getFileUrl: (blobId: string) => `https://test.huly.io/files?file=${blobId}`
+}
+
+const findTool = (name: string) => {
+  const tool = preferenceTools.find((candidate) => candidate.name === name)
+  if (tool === undefined) throw new Error(`Tool ${name} not found`)
+  return tool
+}
+
+describe("preferenceTools", () => {
+  it.effect("exports space preference tools in the preferences category and registers them globally", () =>
+    Effect.gen(function*() {
+      expect(preferenceTools.map((tool) => tool.name)).toEqual([
+        "list_space_preferences",
+        "get_space_preference"
+      ])
+      for (const tool of preferenceTools) {
+        expect(tool.category).toBe("preferences")
+        expect(TOOL_DEFINITIONS[tool.name]).toBe(tool)
+        expect(resolveAnnotations(tool).readOnlyHint).toBe(true)
+      }
+    }))
+
+  it.effect("list_space_preferences handler encodes successful structured output", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.promise(() =>
+        findTool("list_space_preferences").handler({}, hulyClient, storageClient)
+      )
+
+      expect(result.isError).toBeUndefined()
+      expect(result.structuredContent?.result).toMatchObject({
+        preferences: [{
+          preferenceId: "pref-1",
+          attachedTo: "space-1",
+          attachedSpace: { id: "space-1", name: "General" },
+          class: preference.class.SpacePreference
+        }],
+        total: 1
+      })
+      expect(JSON.parse(assertAt(result.content, 0).text)).toMatchObject({ total: 1 })
+    }))
+
+  it.effect("get_space_preference maps validation errors to invalid params", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.promise(() =>
+        findTool("get_space_preference").handler({}, hulyClient, storageClient)
+      )
+
+      expect(result.isError).toBe(true)
+      expect(assertAt(result.content, 0).text).toContain("Invalid parameters for get_space_preference")
+    }))
+})


### PR DESCRIPTION
gpt 55 

## Summary

- Adds read-only `list_space_preferences` and `get_space_preference` MCP tools for the published `SpacePreference` SDK model.
- Wires the new `preferences` category into tool registration, README generation, SDK parity routing, and integration coverage.
- Marks generic preference writes as deferred because the published SDK exposes no safe typed writable fields beyond `attachedTo`.

## Review Notes

- Self-review subagent ran and its findings were addressed: exact optional attached-space output, rejected no-op resolver params, and stronger fake-client cast rationale.
- Existing unrelated untracked plan artifacts were left out of the commit.

## Verification

- `pnpm test -- test/domain/schemas.preferences.test.ts test/huly/operations/preferences.test.ts test/mcp/tools/preferences.test.ts`
- `pnpm check-all`
- `pnpm build && set -a && source .env.local && set +a && HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh`
- Full integration result: `758 passed, 0 failed, 28 skipped (of 786)`
