### PR TITLE
Add Huly tool scope filtering

### DIFF
--- a/.changeset/fuzzy-apples-approve.md
+++ b/.changeset/fuzzy-apples-approve.md
@@ -1,5 +1,0 @@
----
-"@firfi/huly-mcp": minor
----
-
-Add generic approval request tools backed by `@hcengineering/request`: `list_approval_requests`, `get_approval_request`, `add_approval_request`, `add_approval_request_comment`, `approve_approval_request`, `reject_approval_request`, and `cancel_approval_request`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @firfi/huly-mcp
 
+## 0.43.0
+
+### Minor Changes
+
+- dca1b27: Add generic approval request tools backed by `@hcengineering/request`: `list_approval_requests`, `get_approval_request`, `add_approval_request`, `add_approval_request_comment`, `approve_approval_request`, `reject_approval_request`, and `cancel_approval_request`.
+
 ## 0.42.0
 
 ### Minor Changes

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -147,6 +147,18 @@ NODE_OPTIONS="-r ./scripts/container-patch.cjs" bash scripts/integration_test_fu
 
 The patch (`scripts/container-patch.cjs`) rewrites `localhost:8087` → `nginx` in all `fetch` and `ws` calls at runtime. `.env.local` stays unchanged — same `HULY_URL=http://localhost:8087` as on the host.
 
+### Tool Scope Matrix
+
+Use the dedicated scope matrix when changing MCP tool discovery, client mode mapping, or `TOOLSETS` / `TOOLS` behavior:
+
+```bash
+pnpm build
+set -a && source .env.local && set +a
+HULY_URL="${HULY_URL/localhost/host.docker.internal}" pnpm integration:tool-scope
+```
+
+The matrix exercises stdio discovery with multiple representative clients and env permutations: default unscoped, `TOOLSETS` only, `TOOLS` only, union scope, and all-invalid active scope. It asserts visible and hidden tools through both `tools/list`, `get_huly_context`, and representative `tools/call` results.
+
 ### Running the full suite over HTTP
 
 The same full integration suite can exercise the HTTP MCP transport instead of stdio:

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -111,7 +111,7 @@ Manual setup for the second group-DM participant:
    printf '%s\n%s\n' \
    '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
    '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_workspace_members","arguments":{}},"id":2}' \
-     | MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
+     | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
    ```
 
 5. Confirm `list_employees` shows the owner plus two non-self employees with
@@ -157,7 +157,9 @@ set -a && source .env.local && set +a
 HULY_URL="${HULY_URL/localhost/host.docker.internal}" pnpm integration:tool-scope
 ```
 
-The matrix exercises stdio discovery with multiple representative clients and env permutations: default unscoped, `TOOLSETS` only, `TOOLS` only, union scope, and all-invalid active scope. It asserts visible and hidden tools through both `tools/list`, `get_huly_context`, and representative `tools/call` results.
+The matrix exercises stdio discovery with multiple representative clients and env permutations: default `auto` proxy exposure for Codex, exact `claude-code` native exposure, explicit `HULY_TOOL_MODE` overrides, `TOOLSETS` / `TOOLS` scoped native pins in non-strict proxy mode, `PROXY_OUTPUT_STRICT=true` allow-listing, and all-invalid active strict scope. It asserts visible and hidden tools through `tools/list`, `get_huly_context`, proxy meta-tools, and representative `tools/call` results.
+
+The full integration suite below exercises direct native Huly tools. `scripts/integration_test_full.sh` therefore exports `HULY_TOOL_MODE=native` when the variable is unset and exits early if it is explicitly set to `auto` or `proxy`. Keep proxy exposure assertions in this dedicated tool-scope matrix.
 
 ### Running the full suite over HTTP
 
@@ -205,7 +207,7 @@ INTEGRATION_TRANSPORT=http \
 ```bash
 printf '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_projects","arguments":{}},"id":2}
-' | MCP_AUTO_EXIT=true node dist/index.cjs 2>&1 | grep '"id":2'
+' | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>&1 | grep '"id":2'
 ```
 
 Expected: JSON with `"projects": [...]`
@@ -242,6 +244,8 @@ bash scripts/integration_test_full.sh
 ```
 
 The script requires `jq` for JSON parsing.
+
+The script is a native-tool lifecycle suite, not a proxy exposure suite. It selects `HULY_TOOL_MODE=native` by default so the documented command works with the new `auto` default, where unknown or generic clients resolve to proxy mode.
 
 ### What It Tests
 
@@ -343,7 +347,7 @@ INIT='{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-1
 
 printf '%s\n%s\n' "$INIT" \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"TOOL_NAME","arguments":ARGS},"id":2}' \
-  | MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
+  | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
 ```
 
 ## Checking Results

--- a/README.md
+++ b/README.md
@@ -239,9 +239,8 @@ For a Smithery publish schema example, see [docs/SMITHERY_URL_PUBLISH.md](docs/S
 | `MCP_HTTP_PORT` | No | HTTP server port (falls back to `PORT`, then 3000) |
 | `MCP_HTTP_HOST` | No | HTTP server host. Omit to bind to the package default loopback host. |
 | `MCP_AUTH_TOKEN` | No | Optional bearer token required by HTTP clients for `/mcp`. This protects the MCP endpoint only; it is not a Huly API token. |
-| `HULY_TOOLSETS` | No | Comma-separated tool categories to expose. If neither `HULY_TOOLSETS`, `HULY_TOOLS`, nor `TOOLSETS` is set, all native Huly tools are exposed. Example: `issues,projects,search` |
-| `HULY_TOOLS` | No | Comma-separated exact tool names to expose in addition to selected toolsets. Example: `list_documents,create_issue` |
-| `TOOLSETS` | No | Deprecated alias for `HULY_TOOLSETS`. Ignored when `HULY_TOOLSETS` is set. |
+| `TOOLSETS` | No | Comma-separated tool categories to expose. If neither `TOOLSETS` nor `TOOLS` is set, all native Huly tools are exposed. Example: `issues,projects,search` |
+| `TOOLS` | No | Comma-separated exact tool names to expose in addition to selected toolsets. Example: `list_documents,create_issue` |
 
 *Auth: Provide either `HULY_EMAIL` + `HULY_PASSWORD` or `HULY_TOKEN`.
 
@@ -325,7 +324,7 @@ SDK upgrade revisit:
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-**`HULY_TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `approvals`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
+**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `approvals`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
 
 ### Projects
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The standard configuration works with most MCP clients:
 }
 ```
 
+## Tool Exposure Defaults
+
+By default (`HULY_TOOL_MODE=auto`), Huly MCP optimizes for current MCP clients by avoiding a 470-tool eager list. Exact `claude-code` sessions receive native Huly tools. Codex, Cursor, Windsurf, Copilot, OpenCode, Claude AI/Desktop-style clients, and unknown clients receive a small proxy surface: `list_tool_categories`, `search_tools`, `get_tool_schema`, and `invoke_tool`.
+
+Exact native tool names still dispatch when a client calls them directly, but many clients only call tools returned by `tools/list`. Set `HULY_TOOL_MODE=native` to make every Huly tool appear first-class, or use `TOOLSETS` / `TOOLS` to pin frequently used native tools while keeping proxy discovery available.
+
 <details>
 <summary>Codex</summary>
 
@@ -267,66 +273,15 @@ The server exposes read-only MCP Resources as JSON context for clients that supp
 
 `resources/list` returns concrete active project resources. Issue resources are template-based: use `resources/templates/list` to discover supported issue URI templates, then read a known issue URI.
 
-## Roadmap
+## Backlog
 
-The roadmap is driven by SDK parity and the project principle that this server should expose LLM-first tools: clear names, self-contained parameters, automatic identifier resolution, and single-call correctness. The audited source of truth lives in [plans/huly-sdk-gap-matrix.md](plans/huly-sdk-gap-matrix.md), with machine-checkable classifications in [plans/sdk-parity-ledger.json](plans/sdk-parity-ledger.json).
-
-Highest-value additions for coding agents:
-
-- Generic space follow-ups: role/permission definition writes, generic space creation, and module-specific wrappers above the shared space foundation. Generic space metadata, member/owner mutations, and typed-space role member mutations are covered by the shared spaces tools.
-- Core schema/admin follow-ups: guarded attribute/enum writes, role/permission definition writes, generic space creation, global space admins, and module-specific wrappers above the shared space foundation.
-- Drive follow-ups: drive create/update/delete, item move/rename/delete, adding new versions to existing files, permissions, and comments/activity.
-- Team planner/reporting: team agendas, workload/capacity summaries, visibility-aware free/busy views, document action items, and planner automation diagnostics.
-- Recruiting: vacancies, candidates, applications, application statuses, recruiter assignment, reviews, opinions, skills, and related comments/attachments/activity.
-- Controlled documents and trainings: controlled document spaces/projects, review/approval workflows, templates, categories, snapshots/history, training assignments, attempts, scoring, and results.
-- Module-specific tag wrappers for tag-backed concepts such as recruiting skills, controlled-document labels, and contact tags. Board-label definitions and board-card label attachment are covered by the `boards` tools.
-
-Planned feature surfaces:
-
-- Implemented foundation: generic space discovery and safe existing-space administration are covered by `spaces` tools for listing/getting spaces, listing/getting space types, reading permissions, updating common metadata, adding/removing members, and replacing owners.
-- Controlled Documents / TraceX documents: controlled spaces/projects, controlled document CRUD, quality/technical docs, co-authors/reviewers/approvers, e-signature workflows, release/effective-date metadata, change control, training linkage, controlled-document comments, and snapshots/history.
-- Products and product versions: product spaces, members, descriptions, attachments, versions, version state transitions, and change-control links.
-- Trainings, questions, and assessments: training revisions, releases, requests, due dates, max attempts, question banks, answer options, correct-answer data, submissions, scoring, and reporting.
-- Drive: first slice covers listing/getting drives, path traversal/list/get items, idempotent folder creation, uploads with parent creation, version listing, and restoring existing versions. Remaining gaps are drive create/update/delete, item move/rename/delete, adding new versions to existing files, comments/activity, and permissions/members.
-- HR: departments, nested departments, staff mixins, managers, subscribers, team leads, request types, PTO/sick/overtime/remote requests, public holidays, and schedule/table reports.
-- Recruiting: vacancies, talents/candidates, applications, matches, reviews, verdicts/opinions, vacancy-company lists, skills, and recruiting-specific custom fields/relations.
-- Surveys and polls: survey CRUD, poll creation/attachment, survey question data, completion status, and results.
-- Generic approval requests: create/list/approve/reject/cancel approval requests, decision comments, required approval counts, request status, and requested/approved/rejected people.
-- Boards: board CRUD, board cards, status workflows, members/assignees, location, cover/archive fields, board labels, menu/archive views, saved views, viewlets, and common board preference reads.
-- Inventory: category hierarchy CRUD, product CRUD, variant/SKU CRUD, and product-scoped photo, attachment, comment, and activity wrappers are covered by first-class tools; category/variant discussion wrappers remain outside this slice.
-- Leads write surface: create/update/delete funnels and leads, status changes, assignment, start dates, customer descriptions, person customer support, and lead comments/attachments/labels/relations.
-- Contacts: person channels, social identities, provider discovery, contact statuses, notes/comments, person attachments, person merge, employee invite/create/kick/reinvite, and inactive employee management.
-- Calendar: calendar CRUD/config, external calendar sync metadata, primary calendar management, schedule objects, participant mutations, and RSVP/status support when stable.
-- Team planner and schedule reporting: team agendas, workload/capacity summaries, and visibility-aware free/busy views across members/projects.
-- Virtual office and meetings: offices, floors, rooms, access/language/default recording/transcription settings, meeting schedules, active participants, room info, meeting notes/transcript records (minutes), recordings, and device preferences.
-- Chat and communication: request-access flows if Huly exposes a stable model, pinned messages, translation, applets, in-message polls, guest communication settings, and external Gmail/Telegram/Huly Mail surfaces plus provider-specific attachments once compatible packages/APIs are proven.
-- Notifications and activity: browser/push subscription internals, provider defaults, UI presenter/viewlet metadata, and activity control/extension metadata.
-- Attachments and media: previews/preview metadata and friendly wrappers for additional object types beyond issue/document/inventory product.
-- Core schema and workspace administration: attribute/property create/update/delete/hide, enum CRUD/options, sequence management, role/permission definition writes, generic space creation, global space admins, integrations registry, invite settings, role capability settings, and workspace setting metadata.
-- Integrations: GitHub repository/project mappings and sync metadata (deferred), Google Calendar connect/configure/sync controls, Bitrix entity/field mappings and sync status, Gmail/email channel messages, Telegram messages, Huly Mail/Mail plugin behavior, AI assistant integration state, and AI bot configuration if server-side APIs expose stable behavior.
-- Templates, rating, support, billing, analytics, views, workbench, and preferences: read-only message template/category/field discovery is covered; message template writes/rendering remain deferred until provider semantics are proven. Generic saved filtered view discovery, filtered-view detail reads, viewlet metadata, and viewlet preference config discovery are covered by `views` tools; board-specific saved views, viewlets, and common board preference reads remain covered by `boards` tools. Document/person rating data is blocked by unpublished `@hcengineering/rating` SDK package (#90); support conversations, billing tier/status discovery, onboarding channels, tabs/widgets/apps, broader workbench state, and non-view module preference discovery/update remain future surfaces.
-- Document-specific gaps: snapshot restore, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships, and document printing/export once SDK support is safe.
-
-MCP resource roadmap:
-
-- Return resource links from list/search tool results for direct `resources/read` follow-up.
-- Add document resources when document reads have a stable URI shape and context-friendly payload.
-- Consider scoped/paginated issue listing only when filters prevent very large `resources/list` responses.
-- Consider resource `subscribe` and `listChanged` support after stateful sessions and a Huly change source are available.
-
-SDK upgrade revisit:
-
-- Revisit `@hcengineering/*` upgrades when a newer release is available after `0.7.423`.
-- Verify published tarballs, not only npm metadata, before accepting SDK upgrades.
-- Require valid published declaration files for direct Huly dependencies.
-- Upgrade direct Huly package declarations coherently in `package.json`; do not accept lockfile-only transitive rewrites.
-- Run `pnpm check-all` and local Huly integration tests before treating an SDK upgrade as viable.
+Feature backlog and SDK parity notes live in [docs/BACKLOG.md](docs/BACKLOG.md).
 
 <!-- tools:start -->
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog.
+When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog. Exact native tool names also dispatch when a client calls them directly, subject to `PROXY_OUTPUT_STRICT` scope rules, but hidden native tools are not advertised through `tools/list`.
 
 ### Proxy Meta-Tools
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ For a Smithery publish schema example, see [docs/SMITHERY_URL_PUBLISH.md](docs/S
 | `MCP_HTTP_PORT` | No | HTTP server port (falls back to `PORT`, then 3000) |
 | `MCP_HTTP_HOST` | No | HTTP server host. Omit to bind to the package default loopback host. |
 | `MCP_AUTH_TOKEN` | No | Optional bearer token required by HTTP clients for `/mcp`. This protects the MCP endpoint only; it is not a Huly API token. |
-| `TOOLSETS` | No | Comma-separated tool categories to expose. If unset, all tools are exposed. Example: `issues,projects,search` |
+| `HULY_TOOLSETS` | No | Comma-separated tool categories to expose. If neither `HULY_TOOLSETS`, `HULY_TOOLS`, nor `TOOLSETS` is set, all native Huly tools are exposed. Example: `issues,projects,search` |
+| `HULY_TOOLS` | No | Comma-separated exact tool names to expose in addition to selected toolsets. Example: `list_documents,create_issue` |
+| `TOOLSETS` | No | Deprecated alias for `HULY_TOOLSETS`. Ignored when `HULY_TOOLSETS` is set. |
 
 *Auth: Provide either `HULY_EMAIL` + `HULY_PASSWORD` or `HULY_TOKEN`.
 
@@ -247,7 +249,7 @@ For a Smithery publish schema example, see [docs/SMITHERY_URL_PUBLISH.md](docs/S
 
 `get_version` returns the current server version and latest npm version.
 
-`get_huly_context` returns sanitized runtime/configuration context for the current MCP session without connecting to Huly. It reports package version, transport, auth mode, sanitized Huly URL origin/host/protocol, workspace, timeout, config sources, and toolset filtering. Tokens, passwords, email values, credential headers, URL paths, URL query strings, and URL credentials are never returned.
+`get_huly_context` returns sanitized runtime/configuration context for the current MCP session without connecting to Huly. It reports package version, transport, auth mode, sanitized Huly URL origin/host/protocol, workspace, timeout, config sources, and native tool scope filtering. Tokens, passwords, email values, credential headers, URL paths, URL query strings, and URL credentials are never returned.
 
 ## MCP Resources
 
@@ -323,7 +325,7 @@ SDK upgrade revisit:
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
 
-**`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `approvals`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
+**`HULY_TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `approvals`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
 
 ### Projects
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ For a Smithery publish schema example, see [docs/SMITHERY_URL_PUBLISH.md](docs/S
 | `MCP_HTTP_PORT` | No | HTTP server port (falls back to `PORT`, then 3000) |
 | `MCP_HTTP_HOST` | No | HTTP server host. Omit to bind to the package default loopback host. |
 | `MCP_AUTH_TOKEN` | No | Optional bearer token required by HTTP clients for `/mcp`. This protects the MCP endpoint only; it is not a Huly API token. |
+| `HULY_TOOL_MODE` | No | Tool exposure mode: `auto` (default), `native`, or `proxy`. `auto` keeps exact `claude-code` native and resolves Codex, Cursor, Windsurf, Copilot, opencode, Claude AI, and unknown clients to proxy mode. |
+| `PROXY_OUTPUT_STRICT` | No | Proxy candidate strictness: `false` (default) keeps proxy discovery broad; `true` makes active `TOOLSETS` / `TOOLS` a hard allow-list for proxy search, schema lookup, and invocation. |
 | `TOOLSETS` | No | Comma-separated tool categories to expose. If neither `TOOLSETS` nor `TOOLS` is set, all native Huly tools are exposed. Example: `issues,projects,search` |
 | `TOOLS` | No | Comma-separated exact tool names to expose in addition to selected toolsets. Example: `list_documents,create_issue` |
 
@@ -248,7 +250,7 @@ For a Smithery publish schema example, see [docs/SMITHERY_URL_PUBLISH.md](docs/S
 
 `get_version` returns the current server version and latest npm version.
 
-`get_huly_context` returns sanitized runtime/configuration context for the current MCP session without connecting to Huly. It reports package version, transport, auth mode, sanitized Huly URL origin/host/protocol, workspace, timeout, config sources, and native tool scope filtering. Tokens, passwords, email values, credential headers, URL paths, URL query strings, and URL credentials are never returned.
+`get_huly_context` returns sanitized runtime/configuration context for the current MCP session without connecting to Huly. It reports package version, transport, auth mode, sanitized Huly URL origin/host/protocol, workspace, timeout, config sources, native tool scope filtering, and resolved native/proxy tool exposure. Tokens, passwords, email values, credential headers, URL paths, URL query strings, and URL credentials are never returned.
 
 ## MCP Resources
 
@@ -323,6 +325,17 @@ SDK upgrade revisit:
 <!-- tools:start -->
 <!-- AUTO-GENERATED from src/mcp/tools/ descriptions. Do not edit manually. Run `pnpm update-readme` to regenerate. -->
 ## Available Tools
+
+When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog.
+
+### Proxy Meta-Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_tool_categories` | Lists Huly tool categories available through this proxy. Use this first when you need a broad map of capabilities before searching for a specific Huly tool. |
+| `search_tools` | Searches the current proxy-visible Huly tool catalog by tool name, category, description, and parameter names. Returns exact tool names plus required and optional parameter names for single-call follow-up with get_tool_schema or invoke_tool. |
+| `get_tool_schema` | Returns the exact input and output schema for one proxy-visible Huly tool. Use this before invoke_tool when you are not certain about required argument names or result shape. |
+| `invoke_tool` | Invokes one proxy-visible Huly tool by exact name with its arguments. This tool can call read or write Huly operations; check get_tool_schema and the target tool annotations when safety matters. |
 
 **`TOOLSETS` categories:** `projects`, `issues`, `comments`, `milestones`, `documents`, `storage`, `attachments`, `contacts`, `channels`, `calendar`, `time tracking`, `search`, `associations`, `activity`, `notifications`, `workspace`, `approvals`, `boards`, `cards`, `collaborators`, `custom-fields`, `drive`, `inventory`, `labels`, `leads`, `templates`, `planner`, `preferences`, `processes`, `recruiting`, `sdk-discovery`, `spaces`, `tag-categories`, `tags`, `task-management`, `test-management`, `user-statuses`, `views`, `virtual-office`
 

--- a/docs/02_LAZY_TOOL_PRD.md
+++ b/docs/02_LAZY_TOOL_PRD.md
@@ -127,9 +127,10 @@ This remains useful as an opt-in mode for known-compatible stdio/session clients
 
 ### Approach E: Static Meta-Tool Proxy (RECOMMENDED DEFAULT)
 
-A static 3-tool approach (like [Stainless dynamic tools](https://www.stainless.com/changelog/mcp-dynamic-tools)):
+A static 4-tool approach (like [Stainless dynamic tools](https://www.stainless.com/changelog/mcp-dynamic-tools)):
 - `list_tool_categories` — browse categories
 - `search_tools` — find tools by query
+- `get_tool_schema` — fetch exact input/output schemas for selected tools
 - `invoke_tool` — proxy: takes `toolName` + `args`, dispatches to real handler
 
 This works with every client but loses native tool call UX (all calls go through `invoke_tool`).

--- a/docs/02_LAZY_TOOL_PRD.md
+++ b/docs/02_LAZY_TOOL_PRD.md
@@ -2,33 +2,57 @@
 
 ## Problem
 
-This MCP server exposes 114 tools across 15 categories. When a client (Claude Desktop, Cursor, etc.) connects, it receives all 114 tool definitions — names, descriptions, and full JSON schemas — in a single `tools/list` response. Estimated payload: 100-150KB of JSON, translating to roughly 30-60K tokens of LLM context consumed before any conversation begins.
+This MCP server exposes 470 tools across 39 categories. When a client (Claude Desktop, Cursor, etc.) connects, it receives all 470 tool definitions — names, descriptions, and full JSON schemas — in a single `tools/list` response. The generated `tools/list` payload is about 435KB of JSON. Measured with Claude's tokenizer (via `/context` against the published `@firfi/huly-mcp` server), the tool surface is roughly **170K tokens** before any conversation begins. The common 4-chars-per-token heuristic understates this at ~109K, because JSON schemas tokenize more densely than prose.
 
 This matters because:
-- LLMs have finite context windows (200K tokens for Claude). 30-60K tokens on tool definitions alone leaves less room for actual work.
-- LLMs can miscount or lose track of tools when there are too many in context. (The motivating observation: Claude claimed 97 tools when there were 184.)
+- LLMs have finite context windows. ~170K tokens on tool definitions alone leaves less room for actual work.
+- LLMs can miscount or lose track of tools when there are too many in context. (The motivating observation: Claude claimed 97 tools when there were 184.) Published evaluations show tool-selection accuracy degrades once a library exceeds roughly 30–50 tools; with on-demand tool search enabled on large libraries, Anthropic reports Claude Opus 4.5 improving from 79.5% to 88.1% and Opus 4 from 49% to 74%.
 - Most sessions use a small fraction of available tools. A user asking about issues doesn't need calendar, notification settings, or workspace admin schemas loaded.
+- Several clients hard-cap the number of MCP tools and silently truncate the rest: Cursor warns at ~40 (hard limit ~80), Windsurf's Cascade caps at 100, and GitHub Copilot at 128. At 470 tools, most of Huly's surface is not merely expensive on these clients — it is invisible, with no error surfaced to the user.
 
 ## Prior Art & Current Landscape
 
-### Claude Code's MCP Tool Search (Jan 2026, v2.1.7+)
+### Claude Code / Claude Agent SDK Tool Search
 
-Claude Code already implements **client-side** lazy loading. When MCP tool descriptions exceed 10% of context (~10K tokens), Claude Code replaces the full tool definitions with a lightweight search index and a `MCPSearch` meta-tool. Tools load on demand. Internal benchmarks show 85% token reduction and accuracy improvements (Opus 4: 49% → 74% on MCP evals).
+Claude's agent SDK already implements **client-side** lazy loading, enabled by default in Claude Code since January 2026. When tool search is active, tool definitions are withheld from context; the agent searches the catalog and loads the 3-5 most relevant tools on demand. `ENABLE_TOOL_SEARCH=auto` activates search when combined tool definitions exceed 10% of the context window, and tool search applies to remote MCP servers as well as custom SDK tools.
 
-However, this is **Claude Code-specific**. Claude Desktop, Cursor, and other MCP clients don't have this. A server-side solution benefits all clients.
+However, this is **Claude Code-specific**. Codex, opencode, and Claude Desktop load every enabled server's tools eagerly; Cursor, Windsurf, and Copilot cap the tool count and truncate. A server-side solution benefits all clients, and is the only thing that helps the non-Claude-Code clients at all.
 
 ### Claude API Tool Search Tool
 
-The Claude API offers a dedicated `tool_search` tool type for API users with 10+ tools or >10K tokens of definitions. Supports Sonnet 4.0+ and Opus 4.0+ only.
+The Claude API offers dedicated regex and BM25 `tool_search` tool types for API users with 10+ tools or >10K tokens of definitions. Deferred tools use `defer_loading: true`; Claude initially sees only the search tool and any non-deferred tools, then receives 3-5 `tool_reference` blocks for the matching tools.
 
 ### MCP Protocol Support
 
-The MCP spec (2025-06-18) supports relevant primitives:
+The MCP spec supports relevant primitives:
 - **`tools/list` pagination** via cursor-based pagination (`nextCursor` in response)
 - **`listChanged` notifications** for dynamic tool registration
 - **Tool annotations** for metadata (read-only, destructive, etc.)
 
-None of these are currently used by this server.
+Stable MCP does not define a `tools/list` search or filter parameter. The draft tools spec also makes session-state-based lazy loading a poor default: the available tool set may change over time, but must not vary per connection or as a side effect of other requests on that connection. Search-induced "enable these tools for this session, then emit `tools/list_changed`" depends on exactly that kind of implicit connection state.
+
+None of the protocol primitives are currently used by this server for on-demand discovery.
+
+### Emerging MCP Tool Groups / Toolsets
+
+[MCP Discussion #1567](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/1567) proposes primitive groups for tools, resources, and prompts. The useful part for Huly is group-level metadata: a group can have a stable name, title, and description intended for model use, distinct from individual tool descriptions. Later comments note community practice around "toolsets" such as GitHub MCP's `X-MCP-Toolsets` header/path parameter, Datadog's `toolsets` parameter, and FastMCP tag/tool filtering.
+
+This does not change the filtering recommendation by itself. It strengthens the case for stable category/toolset metadata and for naming Huly's categories consistently with emerging ToolGroup/toolset terminology, but it is not a finalized `tools/list` filter API and does not make `tools/list_changed` reliable across clients.
+
+The official `github/github-mcp-server` (~100+ tools) ships two static mitigations worth mirroring: toolset selection (`--toolsets` / `GITHUB_TOOLSETS`, with only `context`, `repos`, `issues`, `pull_requests`, `users` enabled by default), and per-tool selection (remote `X-MCP-Tools` header / local `--tools` flag, added December 2025). GitHub reports that loading 3–10 of the most-used tools instead of the default toolsets yields a ~60–90% context-window reduction. Both are static, request-scoped configuration — not per-session mutation — so they sidestep the `tools/list_changed` reliability problem entirely.
+
+[MCP SEP #1888](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1888) proposes standardizing an optional `searchTools` meta-tool for progressive disclosure of typed operations. If adopted, it would give Approach E a protocol-blessed shape rather than a bespoke meta-tool surface.
+
+### Server-Side Search / Proxy Prior Art
+
+Several ecosystems solve large MCP/API surfaces by exposing a small model-facing search and invocation surface:
+
+- **FastMCP Tool Search Transform**: `list_tools()` returns `search_tools` and `call_tool`; original tools are hidden from listing but remain callable. Search covers tool names, descriptions, parameter names, and parameter descriptions, with regex and BM25 modes.
+- **Stainless dynamic tools**: exposes `list_api_endpoints`, `get_api_endpoint_schema`, and `invoke_api_endpoint` instead of loading an entire API schema into the model context.
+- **Cloudflare Code Mode**: exposes a compact code execution surface where `codemode.search` and `codemode.describe` fetch the connector method/type information needed by the running code rather than putting the whole API in the prompt.
+- **OBS competitor research**: the local OBS MCP competitor uses a two-tool `search` + `execute` surface over an internal registry. Its safety model should not be copied where it evaluates arbitrary JavaScript, but the discover-then-execute shape matches the broader pattern.
+- **Anthropic "Code execution with MCP"**: presents MCP servers as a generated filesystem of code modules (one file per tool) that the agent explores on demand, instead of loading tool definitions into context. Anthropic reports a workflow dropping from ~150K to ~2K tokens (98.7%). The pattern also keeps large intermediate tool *results* out of context — a dimension the meta-tool proxy approaches here do not address — at the cost of requiring a code sandbox.
+- **Notion MCP (hosted, 18 tools)**: ships exactly the recommended shape — tool scoping plus `search_tools` / `execute_tool` meta-tools for runtime discovery.
 
 ### SDK Support (v1.25.3)
 
@@ -46,14 +70,14 @@ The installed `@modelcontextprotocol/sdk` v1.25.3 has **full support** for dynam
 | Claude Code | Disputed | Docs claim support, but [Issue #4118](https://github.com/anthropics/claude-code/issues/4118) (58 upvotes) reports it doesn't work mid-conversation |
 | Claude Desktop | **Not supported** | Confirmed by MCP maintainer ([Discussion #76](https://github.com/orgs/modelcontextprotocol/discussions/76)) |
 | GitHub Copilot (VS Code) | **Supported** | Confirmed working |
-| Cursor | Unknown | Unverified claims of support |
+| Cursor | Reported unsupported mid-session | Community reports say `notifications/tools/list_changed` is ignored in Cursor CLI |
 | Vercel AI SDK | **Not supported** | Docs confirm no notification support |
 
 ## Existing Infrastructure
 
 The codebase is well-positioned for this change:
 
-- **Every tool already has a `category` field** — `ToolDefinition` includes `readonly category: string`, and each tool file defines `const CATEGORY = "Issues" as const` (etc.). 15 categories exist: Activity, Attachments, Calendar, Channels, Comments, Contacts, Documents, Issues, Milestones, Notifications, Projects, Search, Storage, Time Tracking, Workspace.
+- **Every tool already has a `category` field** — `ToolDefinition` includes `readonly category: string`, and each tool file defines a stable category such as `issues`, `documents`, or `channels`. 39 categories currently exist.
 - **Tool registry** (`src/mcp/tools/index.ts`) aggregates all tools into a `Map<string, RegisteredTool>` with a `handleToolCall` dispatcher.
 - **JSON schemas** are pre-generated at import time via `makeJsonSchema()` from Effect Schema.
 - **`tools/list` handler** (`src/mcp/server.ts:72-82`) maps over `toolRegistry.definitions` to produce the response.
@@ -62,15 +86,15 @@ The codebase is well-positioned for this change:
 
 ### ~~Approach A: All Tools Listed, Schemas Stripped~~ (REJECTED)
 
-`tools/list` returns all 114 tools with `inputSchema: { type: "object" }` (no property definitions) plus 3 meta-tools for schema discovery.
+`tools/list` returns all 470 tools with `inputSchema: { type: "object" }` (no property definitions) plus 3 meta-tools for schema discovery.
 
-**Why rejected:** Does not solve the core problem. The LLM still sees 117 tool entries in context — it saves schema payload tokens but the tool count (what causes LLMs to miscount/lose track) is unchanged. An LLM seeing `create_issue` with `inputSchema: { type: "object" }` will likely just call it directly without fetching the schema, since the server validates via Effect Schema anyway. The meta-tools become unused overhead.
+**Why rejected:** Does not solve the core problem. The LLM still sees 473 tool entries in context — it saves schema payload tokens but the tool count (what causes LLMs to miscount/lose track) is unchanged. An LLM seeing `create_issue` with `inputSchema: { type: "object" }` will likely just call it directly without fetching the schema, since the server validates via Effect Schema anyway. The meta-tools become unused overhead.
 
 ### ~~Approach B: Only Meta-Tools Listed, Real Tools Hidden~~ (REJECTED as primary)
 
 `tools/list` returns only 3 meta-tools. Real tools unlisted but callable.
 
-**Why rejected as primary:** Some MCP clients reject calls to tools not in `tools/list`. Protocol compliance varies. However, elements of this approach survive in Approach D.
+**Why rejected as primary:** Some MCP clients reject calls to tools not in `tools/list`. Protocol compliance varies. However, elements of this approach survive in Approach E because all hidden calls go through a listed `invoke_tool` proxy.
 
 ### ~~Approach C: Hybrid — Core Tools + Meta-Tools~~ (REJECTED)
 
@@ -78,11 +102,11 @@ Curated set of ~20-30 "core" tools plus meta-tools.
 
 **Why rejected:** Maintenance burden of curating "core" list. Inconsistent UX.
 
-### Approach D: Dynamic Tool Loading via `tools/list_changed` (RECOMMENDED)
+### Approach D: Dynamic Tool Loading via `tools/list_changed` (CLIENT-GATED / EXPERIMENTAL)
 
-The MCP-native pattern for tool filtering:
+The MCP-native-looking pattern for tool filtering:
 
-1. Server starts with a small set of always-available tools + 1 `search_tools` meta-tool
+1. Server starts with a small listed surface: built-ins, proxy tools, and any scoped native pins
 2. LLM calls `search_tools` with a query describing what it needs
 3. Server enables matching tools (adds them to what `tools/list` returns)
 4. Server sends `tools/list_changed` notification
@@ -91,26 +115,141 @@ The MCP-native pattern for tool filtering:
 
 **Tradeoffs:**
 - (+) Minimal initial context — only a few tools + search
-- (+) Uses MCP-native primitives, not custom workarounds
 - (+) Tools appear as first-class MCP tools once enabled (full client compatibility)
 - (+) SDK already supports everything needed
 - (-) Client must support `tools/list_changed` (Claude Desktop doesn't, Claude Code disputed)
 - (-) Extra round-trip: search → notification → list → call (vs direct call)
+- (-) Ties discovery to per-session tool state, which conflicts with the draft spec's direction that `tools/list` must not vary per connection or as a side effect of other requests on the connection
+- (-) Fails silently in clients that cache the initial tool list or ignore `notifications/tools/list_changed`
+- (-) Mutating the tool list mid-session invalidates the provider's prompt cache for the tools-array prefix; the resulting cache miss can cost more tokens than the deferred definitions save. The static proxy (Approach E) never mutates `tools/list`, so it keeps that prefix cacheable.
 
-### Fallback: Static Meta-Tool Proxy (for incompatible clients)
+This remains useful as an opt-in mode for known-compatible stdio/session clients, but it should not be the default compatibility strategy.
 
-For clients that don't support `tools/list_changed`, a static 3-tool approach (like [Stainless dynamic tools](https://www.stainless.com/changelog/mcp-dynamic-tools)):
+### Approach E: Static Meta-Tool Proxy (RECOMMENDED DEFAULT)
+
+A static 3-tool approach (like [Stainless dynamic tools](https://www.stainless.com/changelog/mcp-dynamic-tools)):
 - `list_tool_categories` — browse categories
 - `search_tools` — find tools by query
 - `invoke_tool` — proxy: takes `toolName` + `args`, dispatches to real handler
 
 This works with every client but loses native tool call UX (all calls go through `invoke_tool`).
 
-## Design: Approach D
+## Two-Axis Configuration Model
+
+The design splits two concerns that should not be coupled:
+
+### Axis 1: Exposure Mode
+
+`HULY_TOOL_MODE` selects how tools are presented to the MCP client:
+
+- `native`: return native Huly tools from `tools/list`; clients that implement their own lazy loading can defer tool definitions.
+- `proxy`: return a small meta-tool surface for discovery/invocation, such as `search_tools`, `get_tool_schema`, and `invoke_tool`.
+- `auto` (default): choose from `clientInfo` at initialize time, with `HULY_TOOL_MODE=native` or `HULY_TOOL_MODE=proxy` as an explicit override.
+
+Initial auto-selection rule should be conservative:
+
+| Client match | Auto mode | Rationale |
+|--------------|-----------|-----------|
+| exact `claude-code` | `native` | Claude Code has client-side tool search and can defer remote MCP tools |
+| `claude-ai`, including `claude-ai (via ...)` | `proxy` | Ambiguous between Claude Desktop / Claude.ai / remote bridges; do not assume Claude Code tool search |
+| `cursor-vscode`, `cursor*` | `proxy` | Cursor eagerly loads/caps MCP tools |
+| `windsurf*`, `cascade*` | `proxy` | Cascade/Windsurf caps MCP tools |
+| `github-copilot*`, `copilot*`, `vscode*` | `proxy` | GitHub Copilot / VS Code has finite tool limits; proxy avoids truncation |
+| `codex*`, `openai-codex*` | `proxy` | Treat as eager unless/until Codex advertises client-side tool search |
+| `opencode*` | `proxy` | Treat as eager unless/until opencode advertises client-side tool search |
+| unknown / missing clientInfo | `proxy` | Avoid exposing a 470-tool, ~170K-token surface by default |
+
+For protocol versions with an initialize handshake, read `params.clientInfo` from `initialize`. The SDK stores this as `server.getClientVersion()` after initialization. For the 2026 stateless HTTP path, read `_meta["io.modelcontextprotocol/clientInfo"]` on each request; the current dispatcher already validates that this field exists.
+
+This logic should live in a dedicated typesafe module, not inline string checks:
+
+```typescript
+// src/mcp/tool-mode.ts
+export const ToolExposureModeSchema = Schema.Literal("native", "proxy")
+export type ToolExposureMode = Schema.Schema.Type<typeof ToolExposureModeSchema>
+
+export const ToolModeConfigSchema = Schema.Literal("auto", "native", "proxy")
+export type ToolModeConfig = Schema.Schema.Type<typeof ToolModeConfigSchema>
+
+export const ClientKindSchema = Schema.Literal(
+  "claude-code",
+  "claude-ai",
+  "cursor",
+  "windsurf",
+  "github-copilot",
+  "codex",
+  "opencode",
+  "unknown"
+)
+export type ClientKind = Schema.Schema.Type<typeof ClientKindSchema>
+
+export const DEFAULT_MODE_BY_CLIENT_KIND = {
+  "claude-code": "native",
+  "claude-ai": "proxy",
+  cursor: "proxy",
+  windsurf: "proxy",
+  "github-copilot": "proxy",
+  codex: "proxy",
+  opencode: "proxy",
+  unknown: "proxy"
+} as const satisfies Record<ClientKind, ToolExposureMode>
+```
+
+The module should expose pure functions such as `classifyMcpClient(clientInfo)` and `resolveToolExposureMode({ configuredMode, clientInfo })`. Tests should cover exact matches, prefixed bridge names like `claude-ai (via mcp-remote 0.1.37)`, casing/whitespace normalization, unknown names, and env override precedence.
+
+### Axis 2: Scope Filter
+
+`TOOLSETS` and `TOOLS` decide which native tools are in the explicitly scoped set. This applies underneath either exposure mode.
+
+If neither env var is set, no scope filter is applied.
+
+If either env var is set, the selected set is the union of:
+
+- every tool whose category/toolset is listed in `TOOLSETS`
+- every exact tool name listed in `TOOLS`, including tools from categories not listed in `TOOLSETS`
+
+Examples:
+
+```bash
+TOOLSETS=issues,projects
+# selects every issues/projects tool
+
+TOOLS=create_issue,fulltext_search
+# selects exactly those tools
+
+TOOLSETS=issues TOOLS=list_documents
+# selects all issue tools plus list_documents
+```
+
+Unknown toolset/tool names should be reported in `get_huly_context` and warned to stderr. To honor "env set means filtering is active", a set-but-all-invalid scope should produce an empty scoped set rather than silently falling back to all 470 tools.
+
+`TOOLSETS` is the primary category scope env var; `TOOLS` is the primary exact-tool scope env var.
+
+### Scope And Proxy Strictness
+
+In `native` mode, the scope filter is strict: `tools/list` returns the scoped native tools when a scope is active, or all native tools when no scope is active. Direct `tools/call` should only dispatch to tools in that native visible set.
+
+In `proxy` mode, proxy meta-tools are always visible. `PROXY_OUTPUT_STRICT` controls how the axis-2 scoped set affects proxy behavior:
+
+| `PROXY_OUTPUT_STRICT` | `tools/list` in proxy mode | Proxy search/schema/invoke candidates |
+|-----------------------|----------------------------|---------------------------------------|
+| `false` (default) | proxy tools plus any scoped native tools, when a scope is active | all registered Huly tools |
+| `true` | proxy tools only | scoped Huly tools only when a scope is active; all Huly tools when no scope is active |
+
+This default gives users a way to pin a small set of high-frequency tools as native first-class tools while still keeping the rest of Huly discoverable through proxy meta-tools. Strict mode turns `TOOLSETS`/`TOOLS` into a hard allow-list for proxy search results, schema lookup, and invocation.
+
+Implementation should keep these as separate registries/views over one registry source:
+
+- full registry: all Huly tools
+- scoped registry: union from `TOOLSETS` and `TOOLS`, or full registry when scope is inactive
+- native visible registry: what direct native `tools/list` and direct native `tools/call` use
+- proxy candidate registry: what `search_tools`, `get_tool_schema`, and `invoke_tool` index and dispatch through
+
+## Design: Proxy Default, Native Client-Selected
 
 ### Search Organization
 
-The `search_tools` tool performs keyword matching against tool names, descriptions, and categories:
+The `search_tools` tool performs keyword matching against tool names, descriptions, parameter metadata, and categories:
 
 ```
 Input:  { query: "create an issue" }
@@ -119,50 +258,54 @@ Output: [
   { name: "create_issue_from_template", description: "...", category: "Issues" },
   ...
 ]
-Side effect: matched tools enabled in tools/list, notification sent
+No default side effect. In Approach D compatibility mode only, matched tools may also be enabled in `tools/list` and a notification sent.
 ```
 
 Search strategy (simple, no vector DB needed):
 - Tokenize query into keywords
 - Score each tool: exact name match > keyword in name > keyword in description > category match
-- Enable top N matches (e.g., top 20)
-- Return matched tools with names + descriptions (no schemas — those come via `tools/list`)
+- Return top N matches (e.g., top 20) with names, descriptions, categories, and optionally compact parameter summaries
+- In static proxy mode, provide `get_tool_schema` or include the selected full input schema before `invoke_tool`
+- In dynamic mode only, enable matched tools and rely on `tools/list_changed`
 
-### Always-Available Tools
+### Proxy Tool Surface And Native Pins
 
-A small set of high-frequency tools always listed in `tools/list`:
-- `search_tools` (the meta-tool)
-- `list_projects` (nearly every session needs this)
-- `fulltext_search` (general-purpose discovery)
+The built-in `get_version` and `get_huly_context` tools remain visible in every mode.
 
-Possibly also: `list_issues`, `create_issue`, `get_issue` (the most common operations).
+In `proxy` mode, the proxy meta-tools are always listed:
 
-The exact set should be determined by usage data. Configurable via env var:
-```
-ALWAYS_AVAILABLE_TOOLS=list_projects,fulltext_search,list_issues,create_issue,get_issue
-```
+- `list_tool_categories` (browse categories/toolsets)
+- `search_tools` (find tools by query)
+- `get_tool_schema` (fetch exact schema for a selected tool)
+- `invoke_tool` (proxy execution)
+
+When `proxy` mode is combined with an active scope and `PROXY_OUTPUT_STRICT=false`, the scoped native Huly tools are also listed as first-class tools. This makes `TOOLSETS=issues TOOLS=fulltext_search` behave like "pin issue tools and fulltext_search natively, but keep the full Huly surface discoverable through proxy."
+
+When `PROXY_OUTPUT_STRICT=true`, the proxy tools are the only model-facing tools in proxy mode, and the scoped set becomes the proxy allow-list.
 
 ### Session Tool State
 
-Tools enabled by `search_tools` accumulate during a session — once enabled, a tool stays enabled for the rest of the connection. This avoids the LLM losing access to tools it already discovered.
+In the recommended static proxy mode, there is no session tool state: `tools/list` stays small and stable, and `invoke_tool` dispatches to hidden registry entries after validating arguments with the target tool's existing schema.
 
-For HTTP transport (stateless, new server per request), all tools are always available (lazy loading doesn't apply since there's no persistent session).
+In optional `tools/list_changed` mode, tools enabled by `search_tools` accumulate during a session — once enabled, a tool stays enabled for the rest of the connection. This avoids the LLM losing access to tools it already discovered, but it must only be used for clients proven to re-list and expose newly enabled tools to the model.
+
+For HTTP transport, prefer the static proxy mode. Stateless or cache-oriented clients are a bad fit for connection-local tool state.
 
 ### LLM Interaction Flow
 
 ```
 User: "Create an issue in HULY project for the login bug"
 
-tools/list returns: search_tools, list_projects, fulltext_search
-LLM sees 3 tools.
+tools/list returns: get_version, get_huly_context, list_tool_categories, search_tools, get_tool_schema, invoke_tool
+If `TOOLSETS` or `TOOLS` is set and `PROXY_OUTPUT_STRICT=false`, the scoped native tools are also listed.
 
-Option A (tool name already known):
+Default static proxy flow:
   1. LLM calls search_tools({ query: "create issue" })
-  2. Server enables create_issue + related tools, sends list_changed
-  3. Client re-fetches tools/list → now includes create_issue with full schema
-  4. LLM calls create_issue({ project: "HULY", title: "Login bug", ... })
+  2. Server returns create_issue + related matches with compact metadata
+  3. LLM calls get_tool_schema({ toolName: "create_issue" })
+  4. LLM calls invoke_tool({ toolName: "create_issue", arguments: { project: "HULY", title: "Login bug", ... } })
 
-Option B (exploring):
+Optional dynamic flow:
   1. LLM calls search_tools({ query: "issue management" })
   2. Server enables all Issues category tools, sends list_changed
   3. Client re-fetches → 18 issue tools now available with full schemas
@@ -173,11 +316,11 @@ Option B (exploring):
 
 | Mode | Initial Context | Per-Search Overhead |
 |------|----------------|---------------------|
-| Current (eager) | ~30-60K tokens | 0 |
+| Current (eager) | ~170K measured tokens | 0 |
 | Approach D (lazy) | ~1-2K tokens | ~500-2K tokens (search result + newly enabled tool schemas) |
-| Static proxy fallback | ~500 tokens | ~200-500 tokens per invoke_tool call |
+| Approach E (proxy) | ~500 tokens | ~200-500 tokens per `invoke_tool` call |
 
-### `tools/list_changed` Integration
+### `tools/list_changed` Integration (Optional)
 
 ```typescript
 // In search_tools handler:
@@ -200,44 +343,59 @@ The `Server` instance (low-level API currently used in `server.ts`) exposes `sen
 
 | File | Change |
 |------|--------|
-| `src/mcp/server.ts` | Modified `ListToolsRequestSchema` to filter by enabled tools; `search_tools` handler; `tools/list_changed` notification; session state for enabled tools |
-| `src/mcp/tools/meta.ts` (new) | `search_tools` definition, search logic, category descriptions |
-| `src/domain/schemas/meta.ts` (new) | Schema for search_tools parameters |
-| `src/mcp/tools/index.ts` | Export meta-tools, expose tool search index |
+| `src/mcp/tool-mode.ts` (new) | Typesafe client classification and `HULY_TOOL_MODE=auto/native/proxy` resolution from `clientInfo` |
+| `src/mcp/tool-scope.ts` (new) | Parse `TOOLSETS` and `TOOLS`; resolve the union into scoped/native/proxy registries |
+| `src/mcp/server.ts` | Build the shared tool scope once at startup; pass native/proxy registry views into protocol handlers; include scope data in telemetry/context |
+| `src/mcp/huly-context-tool.ts` | Replace category-only `parseToolsets` summary with scope summary including requested/enabled/ignored toolsets and tools |
+| `src/mcp/tools/index.ts` | Add registry builders that filter by category union and exact tool names, while preserving the full registry for proxy non-strict mode |
+| `src/mcp/protocol-handlers.ts` | Use the native visible registry for direct `tools/list`/native `tools/call`; later, route proxy meta-tools through the proxy candidate registry |
+| `src/mcp/tools/meta.ts` (new, proxy phase) | `list_tool_categories`, `search_tools`, `get_tool_schema`, and `invoke_tool` definitions plus search logic and category descriptions |
+| `src/domain/schemas/meta.ts` (new, proxy phase) | Schemas for meta-tool inputs and outputs |
 
 ### Category Metadata
 
-Each of the 15 tool files defines `const CATEGORY = "..." as const`. A mapping from category → description is needed for search scoring:
+Each tool definition already carries a category. A mapping from category → description is needed for search scoring:
 
 ```typescript
 const CATEGORY_DESCRIPTIONS: Record<string, string> = {
-  "Issues": "Issue tracking: create, update, search, manage issues, components, labels, templates",
-  "Documents": "Document management: teamspaces, create/read/update documents with markdown",
-  "Channels": "Messaging: channels, direct messages, thread replies",
+  issues: "Issue tracking: create, update, search, manage issues, components, labels, templates",
+  documents: "Document management: teamspaces, create/read/update documents with markdown",
+  channels: "Messaging: channels, direct messages, thread replies",
   // ...
 }
 ```
 
 ## Open Questions
 
-1. **Which tools are "always available"?** Need usage data or a reasonable starting set. Configurable via env var mitigates the decision.
+1. **All-invalid scope behavior.** Proposed behavior is strict: if `TOOLSETS` or `TOOLS` is set but every requested entry is unknown, the scoped native set is empty and the warning/context summary explains why.
 
 2. **Search quality.** Simple keyword matching may miss semantic connections ("bug report" → `create_issue`). Should we embed synonyms/aliases per tool? Or is keyword matching on name + description sufficient?
 
-3. **Client compatibility strategy.** Given that Claude Desktop doesn't support `tools/list_changed` and Claude Code's support is disputed, should we:
-   - Default to eager mode and only enable lazy for confirmed-compatible clients?
-   - Auto-detect client capabilities from the `initialize` handshake?
-   - Provide the static proxy fallback (`invoke_tool`) alongside?
+3. **Client auto-detection map.** The initial map should be intentionally small and env-overridable. Unknown client names should probably default to `proxy`.
 
-4. **Tool accumulation limit.** If `search_tools` is called many times, enabled tools grow unbounded. Should there be a cap or LRU eviction?
+4. **Approach D.** Given client and cache behavior, should `tools/list_changed` be deferred entirely, or offered only behind an explicit experimental config?
 
-5. **HTTP transport.** Stateless HTTP transport creates a new server per request — lazy loading is meaningless. Should HTTP always use eager mode?
+5. **HTTP transport.** Stateless and cache-oriented clients are a bad fit for connection-local tool state. HTTP should use `clientInfo` from request `_meta` for `auto`, and should not rely on session-local `tools/list_changed`.
 
 ## References
 
-- [MCP Specification: Tools (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) — protocol spec for `tools/list`, pagination, `listChanged`
+- [MCP Specification: Tools (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) — protocol spec for `tools/list`, pagination, `listChanged`
+- [MCP Draft Tools Spec](https://modelcontextprotocol.io/specification/draft/server/tools) — draft language about deterministic tool lists and avoiding per-connection/request-side-effect variation
+- [MCP Discussion #1567: Primitive Groups for Tools, Resources, Prompts](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/1567) — emerging ToolGroup/toolset metadata discussion; useful for category/search metadata, not a finalized filtering protocol
+- [FastMCP Tool Search Transform](https://gofastmcp.com/servers/transforms/tool-search) — server-side `search_tools` and `call_tool` transform with regex/BM25 search
+- [Cloudflare Code Mode](https://developers.cloudflare.com/agents/model-context-protocol/protocol/codemode/) — single model-facing code tool with on-demand connector method discovery
 - [Claude Code Issue #4118: tools/list_changed not working](https://github.com/anthropics/claude-code/issues/4118) — 58 upvotes, reports notification not processed mid-conversation
 - [MCP Discussion #76: Dynamic tool registration](https://github.com/orgs/modelcontextprotocol/discussions/76) — Claude Desktop confirmed unsupported
 - [Stainless MCP Dynamic Tools](https://www.stainless.com/changelog/mcp-dynamic-tools) — static 3-meta-tool proxy pattern
-- [Claude Code MCP Tool Search](https://claudefa.st/blog/tools/mcp-extensions/mcp-tool-search) — client-side lazy loading
+- [Claude Code / Agent SDK Tool Search](https://code.claude.com/docs/en/agent-sdk/tool-search) — client-side lazy loading
 - [Claude API Tool Search Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) — API-level tool search
+- [Anthropic: Advanced tool use](https://www.anthropic.com/engineering/advanced-tool-use) — tool search accuracy benchmarks (Opus 4.5 79.5%→88.1%), `defer_loading`
+- [Anthropic: Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) — servers-as-code-APIs progressive disclosure, ~150K→2K tokens
+- [MCP SEP #1888: `searchTools` meta-tool](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1888) — proposed standardization of progressive-disclosure discovery
+- [GitHub MCP Server: tool-specific configuration](https://github.blog/changelog/2025-12-10-the-github-mcp-server-adds-support-for-tool-specific-configuration-and-more/) — `X-MCP-Tools` header / `--tools`, ~60–90% context reduction
+- [Notion MCP deep dive (StackOne)](https://www.stackone.com/blog/notion-mcp-deep-dive/) — hosted server tool scoping + `search_tools`/`execute_tool`
+- [FutureSearch MCP widgets article](https://futuresearch.ai/blog/mcp-results-widget/) — observed `clientInfo.name` values: `claude-code` vs `claude-ai`
+- [Claude Code issue #27159](https://github.com/anthropics/claude-code/issues/27159) — observed `claude-ai` and `claude-ai (via mcp-remote ...)` initialize payloads
+- [Cursor remote MCP forum thread](https://forum.cursor.com/t/remote-mcp-is-not-available-in-the-pro-plan/139053) — observed `cursor-vscode (via mcp-remote ...)` initialize payloads
+- [Cursor MCP 40-tool limit (community forum)](https://forum.cursor.com/t/mcp-server-40-tool-limit-in-cursor-is-this-frustrating-your-workflow/81627) — client-side tool cap / silent truncation
+- [Windsurf Cascade MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) — 100-tool cap

--- a/docs/02_LAZY_TOOL_PRD.md
+++ b/docs/02_LAZY_TOOL_PRD.md
@@ -155,7 +155,7 @@ Initial auto-selection rule should be conservative:
 | `claude-ai`, including `claude-ai (via ...)` | `proxy` | Ambiguous between Claude Desktop / Claude.ai / remote bridges; do not assume Claude Code tool search |
 | `cursor-vscode`, `cursor*` | `proxy` | Cursor eagerly loads/caps MCP tools |
 | `windsurf*`, `cascade*` | `proxy` | Cascade/Windsurf caps MCP tools |
-| `github-copilot*`, `copilot*`, `vscode*` | `proxy` | GitHub Copilot / VS Code has finite tool limits; proxy avoids truncation |
+| `github-copilot*`, `copilot*`, `visual studio code*`, `visual-studio-code*` | `proxy` | GitHub Copilot / VS Code has finite tool limits; proxy avoids truncation |
 | `codex*`, `openai-codex*` | `proxy` | Treat as eager unless/until Codex advertises client-side tool search |
 | `opencode*` | `proxy` | Treat as eager unless/until opencode advertises client-side tool search |
 | unknown / missing clientInfo | `proxy` | Avoid exposing a 470-tool, ~170K-token surface by default |

--- a/docs/AGENT_TOOL_DISCOVERY_CHECKLIST.md
+++ b/docs/AGENT_TOOL_DISCOVERY_CHECKLIST.md
@@ -1,0 +1,125 @@
+# Agent Tool-Discovery Checklist
+
+Per-agent survey of how each MCP client handles the published `@firfi/huly-mcp`
+default surface (**472 native tools, native mode, `clientInfo` ignored**), and what
+the tool-scope PR's auto-mode resolves to for that client.
+
+## Rubric
+
+A client has a **tool-discovery problem** at 472 tools if either:
+
+- **Eager**: it loads all 472 definitions into model context at connect (context bloat), or
+- **Cap**: it truncates to N tools and the rest become undiscoverable.
+
+Both are equally bad. A client is **problem-free only if** it defers tool definitions
+*and can still discover all 472 on demand* (client-side tool search). Problem-free → `native`
+is fine; otherwise → `proxy`.
+
+## What can actually break the PR
+
+Auto-mode keys solely off `clientInfo.name` via `classifyMcpClient` (`src/mcp/tool-mode.ts`).
+The classifier emits `native` **only** on exact `claude-code`; every other name resolves to
+`proxy` (matched name or `unknown`). So the failure direction is one-sided:
+
+- A **false `native`** would hide the discovery fix from an agent that needs it — only
+  reachable via literal `claude-code`, which is the one agent that wants native.
+- A **false `proxy`** only costs a native-capable agent the nicer UX; discovery still works.
+
+Therefore the only regression risk is an agent that gains client-side tool search yet is
+**not** named `claude-code` (would get proxy instead of native) — currently none.
+
+## Auto-mode map (from `classifyMcpClient`)
+
+Matched prefixes → `proxy`: `claude-ai`, `cursor*`, `windsurf*`/`cascade*`,
+`github-copilot*`/`copilot*`/`visual studio code*`/`visual-studio-code*`, `codex*`/`openai-codex*`, `opencode*`.
+Exact `claude-code` → `native`. Everything else → `unknown` → `proxy`.
+A `(via …)` remote suffix is stripped before matching (so `claude-code (via mcp-remote)` → `unknown` → proxy).
+
+## Per-agent matrix
+
+`clientInfo.name` strings are from the apify `mcp-client-capabilities` registry unless noted.
+Verify empirically on first connect (column = Status).
+
+| Agent | `clientInfo.name` | 472-tool behavior | Problem? | PR auto-mode | Correct? | Status |
+|---|---|---|---|---|---|---|
+| Claude Code | `claude-code` (exact) | Client-side tool search; defers defs, discovers all | **No** | `native` | yes | Verify tool search still on for remote MCP |
+| Claude Desktop / Claude.ai | `claude-ai`, `claude-ai (via mcp-remote …)` | Eager, no tool search | Yes (eager) | `proxy` | yes | docs/PRD |
+| Cursor | `cursor-vscode` | Cap ~40 (hard ~80), silent truncate | Yes (cap) | `proxy` | yes | docs/forum |
+| Windsurf / Cascade | `Windsurf`, `windsurf-client` | Cap 100 | Yes (cap) | `proxy` | yes | docs |
+| GitHub Copilot CLI | `github-copilot-developer` | Cap 128 | Yes (cap) | `proxy` | yes | docs |
+| Copilot agent in VS Code | `Visual Studio Code` / `Visual-Studio-Code` | Cap 128 | Yes (cap) | `proxy` (github-copilot) | yes | |
+| OpenAI Codex | `Codex`, `codex-mcp-client` | Eager | Yes (eager) | `proxy` | yes | Confirm no tool search |
+| ChatGPT (connectors) | `ChatGPT` | Eager/limited | Yes | `proxy` (unknown) | yes | low priority |
+| Cline | `Cline` | No cap → eager all 472 | Yes (eager) | `proxy` (unknown) | yes | runs in VS Code |
+| Roo Code | `Roo-Code` | Cline fork → eager | Yes (eager) | `proxy` (unknown) | yes | |
+| Kilo Code | `Kilo-Code` | Cline-family → eager | Yes (eager) | `proxy` (unknown) | yes | |
+| opencode | `opencode` (v1.14.33, verified) | Eager-loads all 472 (verified: connected, 472 tools served) | Yes (eager) | `proxy` | yes | verified here against 0.43.0 |
+| Gemini CLI | `gemini-cli-mcp-client` | Loads all (<512 fn-decl hard cap); eager | Yes (eager, near 512 ceiling) | `proxy` (unknown) | yes | installed but no creds here |
+| Google Antigravity | `antigravity-client` | Hard `MAX_LIMIT=100` → **blocks load** at 472 | Yes (block) | `proxy` (unknown) | yes | severe |
+| goose | `goose` (v1.0.24, verified) | Connects, **no** schema rejection (unlike opencode); full tool-load unconfirmed (anthropic credits exhausted mid-turn) | Yes (eager, inferred) | `proxy` (unknown) | yes | clientInfo verified here |
+| Kiro (IDE/CLI) | unverified (likely `kiro-cli`) | Warns >50, eager into context | Yes (eager + soft cap) | `proxy` (unknown, assumed) | yes if name unmatched | **Capture real name** |
+| Zed | `Zed` | Eager | Yes (eager) | `proxy` (unknown) | yes | |
+| Continue CLI | `continue-cli-client` | Eager | Yes (eager) | `proxy` (unknown) | yes | |
+| Amazon Q Dev CLI | `Q-DEV-CLI` | Eager | Yes (eager) | `proxy` (unknown) | yes | |
+| JetBrains AI Assistant | `JetBrains-*-copilot-intellij` | Eager/cap | Yes | `proxy` (unknown) | yes | |
+| AmpCode | `amp-mcp-client` | Eager | Yes | `proxy` (unknown) | yes | |
+| Crush | `crush` | Eager | Yes | `proxy` (unknown) | yes | |
+| Raycast | `com.raycast.macos` | Eager | Yes | `proxy` (unknown) | yes | |
+
+Conclusion: at 472 tools **every agent except Claude Code has a discovery problem**, so the
+`proxy`-by-default / `native`-only-for-`claude-code` policy is correct under the rubric.
+
+## Server-side schema note: duplicate `$id:/schemas/unknown`
+
+Observed against published `@firfi/huly-mcp@0.43.0`. The generated `tools/list` payload emits
+inline `{"$id":"/schemas/unknown","title":"unknown"}` (Effect Schema's encoding of
+`Schema.Unknown`/`Schema.Any`) plus `/schemas/{}` for empty structs, in ~24 of 472 tools
+(1 input: `add_approval_request.tx`; ~23 outputs, e.g. `list_inventory_product_attachments`).
+Reusing one `$id` across distinct inline nodes is invalid per JSON Schema (`$id` must be unique
+in scope), so a strict `$id`/`$ref` resolver *can* reject the aggregated tool set.
+
+Reproduction status: **not a confirmed client failure.** opencode (v1.14.33) loads all 472 tools
+fine with these ids present (verified: connected, two successful `tools/list` calls). A single
+earlier "failed to get tools — `/schemas/unknown` resolves to more than one schema" coincided with
+a transient Huly first-connect race ("no document found, failed to apply model transaction") and
+did not reproduce on warm reconnect. Treat the duplicate `$id` as spec-correctness hardening for
+strict clients, not as a fix for a known outage.
+
+## Notes on classifier rules
+
+- **VS Code** is matched by `visual studio code` / `visual-studio-code` (its real
+  `clientInfo.name`), classified as `github-copilot`. Cline/Roo/Kilo running *inside* VS Code
+  send their own names, not the editor's, so they classify as `unknown`.
+- **Named proxy matches are redundant with `unknown → proxy`** for outcome; they exist to make
+  the decision explicit in telemetry/context rather than to change the resulting mode.
+- The only name that changes outcome vs the default is exact `claude-code` (→ native).
+
+## Test procedure (per agent, published 0.43.0 baseline)
+
+Goal: record (a) the literal `clientInfo.name`, (b) tool count the agent actually exposes,
+(c) whether it eager-loads or caps, (d) whether all 472 remain discoverable.
+
+1. Configure the agent's MCP config to run the published server:
+   ```json
+   { "command": "npx", "args": ["-y", "@firfi/huly-mcp@0.43.0"],
+     "env": { "HULY_URL": "…", "HULY_EMAIL": "…", "HULY_PASSWORD": "…", "HULY_WORKSPACE": "…" } }
+   ```
+2. Capture `clientInfo.name`: connect once and read it from the agent's MCP trace/logs
+   (e.g. Kiro: `KIRO_LOG_LEVEL=trace`), or point the agent at a JSON-RPC stdio process whose
+   only job is to echo the `initialize` params to stderr.
+3. In the agent, list available MCP tools and record the count. Compare to 472.
+   - Count ≈ 472 and visible in context → **eager** (problem).
+   - Count < 472 with no way to reach the rest → **cap** (problem).
+   - Few tools listed but a search/discovery affordance reaches all 472 → **tool search** (ok → native).
+4. Record the row in the matrix: name, behavior, problem?, and whether the PR auto-mode matches.
+
+## Open empirical items
+
+- [ ] Kiro: capture real MCP `clientInfo.name`; confirm it does not start with a matched prefix
+      (`cursor`/`windsurf`/`cascade`/`copilot`/`github-copilot`/`visual studio code`/`codex`/`opencode`).
+- [ ] Claude Code: confirm client-side tool search is on by default for **remote** MCP servers
+      (so `native` is genuinely problem-free, not eager).
+- [ ] opencode / Codex / Gemini CLI: confirm none has added client-side tool search (else they'd
+      warrant `native` but currently get `proxy`).
+- [x] opencode emits `opencode`; goose emits `goose` (verified here against 0.43.0).
+- [ ] Gemini CLI: not verifiable in this environment (no Google credentials configured).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,54 @@
+# Backlog
+
+The backlog is driven by SDK parity and the project principle that this server should expose LLM-first tools: clear names, self-contained parameters, automatic identifier resolution, and single-call correctness. The audited source of truth lives in [../plans/huly-sdk-gap-matrix.md](../plans/huly-sdk-gap-matrix.md), with machine-checkable classifications in [../plans/sdk-parity-ledger.json](../plans/sdk-parity-ledger.json).
+
+## Highest-Value Additions For Coding Agents
+
+- Generic space follow-ups: role/permission definition writes, generic space creation, and module-specific wrappers above the shared space foundation. Generic space metadata, member/owner mutations, and typed-space role member mutations are covered by the shared spaces tools.
+- Core schema/admin follow-ups: guarded attribute/enum writes, role/permission definition writes, generic space creation, global space admins, and module-specific wrappers above the shared space foundation.
+- Drive follow-ups: drive create/update/delete, item move/rename/delete, adding new versions to existing files, permissions, and comments/activity.
+- Team planner/reporting: team agendas, workload/capacity summaries, visibility-aware free/busy views, document action items, and planner automation diagnostics.
+- Recruiting: vacancies, candidates, applications, application statuses, recruiter assignment, reviews, opinions, skills, and related comments/attachments/activity.
+- Controlled documents and trainings: controlled document spaces/projects, review/approval workflows, templates, categories, snapshots/history, training assignments, attempts, scoring, and results.
+- Module-specific tag wrappers for tag-backed concepts such as recruiting skills, controlled-document labels, and contact tags. Board-label definitions and board-card label attachment are covered by the `boards` tools.
+
+## Planned Feature Surfaces
+
+- Implemented foundation: generic space discovery and safe existing-space administration are covered by `spaces` tools for listing/getting spaces, listing/getting space types, reading permissions, updating common metadata, adding/removing members, and replacing owners.
+- Controlled Documents / TraceX documents: controlled spaces/projects, controlled document CRUD, quality/technical docs, co-authors/reviewers/approvers, e-signature workflows, release/effective-date metadata, change control, training linkage, controlled-document comments, and snapshots/history.
+- Products and product versions: product spaces, members, descriptions, attachments, versions, version state transitions, and change-control links.
+- Trainings, questions, and assessments: training revisions, releases, requests, due dates, max attempts, question banks, answer options, correct-answer data, submissions, scoring, and reporting.
+- Drive: first slice covers listing/getting drives, path traversal/list/get items, idempotent folder creation, uploads with parent creation, version listing, and restoring existing versions. Remaining gaps are drive create/update/delete, item move/rename/delete, adding new versions to existing files, comments/activity, and permissions/members.
+- HR: departments, nested departments, staff mixins, managers, subscribers, team leads, request types, PTO/sick/overtime/remote requests, public holidays, and schedule/table reports.
+- Recruiting: vacancies, talents/candidates, applications, matches, reviews, verdicts/opinions, vacancy-company lists, skills, and recruiting-specific custom fields/relations.
+- Surveys and polls: survey CRUD, poll creation/attachment, survey question data, completion status, and results.
+- Generic approval requests: create/list/approve/reject/cancel approval requests, decision comments, required approval counts, request status, and requested/approved/rejected people.
+- Boards: board CRUD, board cards, status workflows, members/assignees, location, cover/archive fields, board labels, menu/archive views, saved views, viewlets, and common board preference reads.
+- Inventory: category hierarchy CRUD, product CRUD, variant/SKU CRUD, and product-scoped photo, attachment, comment, and activity wrappers are covered by first-class tools; category/variant discussion wrappers remain outside this slice.
+- Leads write surface: create/update/delete funnels and leads, status changes, assignment, start dates, customer descriptions, person customer support, and lead comments/attachments/labels/relations.
+- Contacts: person channels, social identities, provider discovery, contact statuses, notes/comments, person attachments, person merge, employee invite/create/kick/reinvite, and inactive employee management.
+- Calendar: calendar CRUD/config, external calendar sync metadata, primary calendar management, schedule objects, participant mutations, and RSVP/status support when stable.
+- Team planner and schedule reporting: team agendas, workload/capacity summaries, and visibility-aware free/busy views across members/projects.
+- Virtual office and meetings: offices, floors, rooms, access/language/default recording/transcription settings, meeting schedules, active participants, room info, meeting notes/transcript records (minutes), recordings, and device preferences.
+- Chat and communication: request-access flows if Huly exposes a stable model, pinned messages, translation, applets, in-message polls, guest communication settings, and external Gmail/Telegram/Huly Mail surfaces plus provider-specific attachments once compatible packages/APIs are proven.
+- Notifications and activity: browser/push subscription internals, provider defaults, UI presenter/viewlet metadata, and activity control/extension metadata.
+- Attachments and media: previews/preview metadata and friendly wrappers for additional object types beyond issue/document/inventory product.
+- Core schema and workspace administration: attribute/property create/update/delete/hide, enum CRUD/options, sequence management, role/permission definition writes, generic space creation, global space admins, integrations registry, invite settings, role capability settings, and workspace setting metadata.
+- Integrations: GitHub repository/project mappings and sync metadata (deferred), Google Calendar connect/configure/sync controls, Bitrix entity/field mappings and sync status, Gmail/email channel messages, Telegram messages, Huly Mail/Mail plugin behavior, AI assistant integration state, and AI bot configuration if server-side APIs expose stable behavior.
+- Templates, rating, support, billing, analytics, views, workbench, and preferences: read-only message template/category/field discovery is covered; message template writes/rendering remain deferred until provider semantics are proven. Generic saved filtered view discovery, filtered-view detail reads, viewlet metadata, and viewlet preference config discovery are covered by `views` tools; board-specific saved views, viewlets, and common board preference reads remain covered by `boards` tools. Document/person rating data is blocked by unpublished `@hcengineering/rating` SDK package (#90); support conversations, billing tier/status discovery, onboarding channels, tabs/widgets/apps, broader workbench state, and non-view module preference discovery/update remain future surfaces.
+- Document-specific gaps: snapshot restore, backlinks, notes, structured action items/tables, PDF/export, advanced document relationships, and document printing/export once SDK support is safe.
+
+## MCP Resource Roadmap
+
+- Return resource links from list/search tool results for direct `resources/read` follow-up.
+- Add document resources when document reads have a stable URI shape and context-friendly payload.
+- Consider scoped/paginated issue listing only when filters prevent very large `resources/list` responses.
+- Consider resource `subscribe` and `listChanged` support after stateful sessions and a Huly change source are available.
+
+## SDK Upgrade Revisit
+
+- Revisit `@hcengineering/*` upgrades when a newer release is available after `0.7.423`.
+- Verify published tarballs, not only npm metadata, before accepting SDK upgrades.
+- Require valid published declaration files for direct Huly dependencies.
+- Upgrade direct Huly package declarations coherently in `package.json`; do not accept lockfile-only transitive rewrites.
+- Run `pnpm check-all` and local Huly integration tests before treating an SDK upgrade as viable.

--- a/docs/NPM_NEXT_RELEASE.md
+++ b/docs/NPM_NEXT_RELEASE.md
@@ -1,0 +1,131 @@
+# NPM Next Release
+
+Use this flow to publish a branch build to npm without moving the `latest` dist-tag.
+
+The goal is to make the version installable for testers as `@firfi/huly-mcp@next` and by exact version, while users on `@firfi/huly-mcp@latest` remain on the previous stable release.
+
+Do not use `pnpm local-release` for this flow. That script publishes without a dist-tag override and creates the GitHub release with `--latest`.
+
+## Preflight
+
+- Start from the branch or release commit you want to publish. For the tool-scope filtering PR, that is `codex/tool-scope-filtering`.
+- Confirm the worktree is clean except for intentional release metadata.
+- Confirm `gh auth status` and npm publish access before the final publish step.
+- Keep OTP/2FA values out of shell history and logs.
+- Decide the release type before creating the changeset. The tool-scope filtering branch changes default tool exposure semantics, so a minor release is expected from `0.43.0` to `0.44.0`.
+
+```bash
+git checkout codex/tool-scope-filtering
+git pull --ff-only
+git status --short
+gh auth status
+npm whoami
+npm dist-tag ls @firfi/huly-mcp
+```
+
+## Version Without Publishing
+
+Create the Changeset entry and apply it to package metadata. This updates `package.json`, `CHANGELOG.md`, and any generated registry metadata, but does not publish.
+
+```bash
+pnpm exec changeset
+pnpm dlx @changesets/cli@2.30.0 version
+pnpm sync-registry-metadata
+git add package.json CHANGELOG.md server.json .changeset
+HUSKY=0 git commit -m "RELEASING: Releasing 1 package(s)"
+```
+
+After this commit, record the version:
+
+```bash
+PKG_VERSION=$(node -p "require('./package.json').version")
+echo "$PKG_VERSION"
+```
+
+## Validate The Release Commit
+
+Run the normal gate on the exact commit that will be published.
+
+```bash
+pnpm check-all
+pnpm build
+pnpm verify-version
+```
+
+For this branch, also run local Huly integration with the container URL override:
+
+```bash
+set -a && source .env.local && set +a
+HULY_URL="${HULY_URL/localhost/host.docker.internal}" pnpm integration:tool-scope
+HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh
+```
+
+## Publish Under `next`
+
+This is the first command that publishes to npm. The `--tag next` flag is the important part: it prevents npm from moving `latest`.
+
+```bash
+PKG_VERSION=$(node -p "require('./package.json').version")
+npm_config_ignore_scripts=true pnpm dlx @changesets/cli@2.30.0 publish --tag next
+```
+
+Verify npm tags immediately after publish:
+
+```bash
+npm dist-tag ls @firfi/huly-mcp
+npm view @firfi/huly-mcp@next version
+npm view @firfi/huly-mcp@latest version
+```
+
+Expected result:
+
+- `next` points to `$PKG_VERSION`.
+- `latest` still points to the previous stable version.
+
+## Push Release Metadata
+
+Changesets creates the git tag after a successful publish. Push both the branch and the tag.
+
+```bash
+PKG_VERSION=$(node -p "require('./package.json').version")
+git push origin codex/tool-scope-filtering
+git push origin "v$PKG_VERSION"
+```
+
+Create the GitHub release as a prerelease, not latest:
+
+```bash
+gh release create "v$PKG_VERSION" --generate-notes --prerelease --verify-tag
+```
+
+## Tester Install Command
+
+Give testers the dist-tag or exact version:
+
+```bash
+npx -y @firfi/huly-mcp@next
+npx -y @firfi/huly-mcp@$PKG_VERSION
+```
+
+## Promote Later
+
+When the `next` build is ready for all users, move `latest` to the same version. Do not republish.
+
+```bash
+PKG_VERSION=<the-tested-version>
+npm dist-tag add @firfi/huly-mcp@$PKG_VERSION latest
+npm dist-tag ls @firfi/huly-mcp
+gh release edit "v$PKG_VERSION" --prerelease=false --latest
+```
+
+Leaving `next` pointing at the promoted version is fine. Move it again on the next staged release.
+
+## If `latest` Moves By Mistake
+
+Do not unpublish. Put `latest` back on the previous stable version:
+
+```bash
+npm dist-tag ls @firfi/huly-mcp
+npm dist-tag add @firfi/huly-mcp@<previous-stable-version> latest
+npm dist-tag ls @firfi/huly-mcp
+```

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "verify-schema-boundaries": "node scripts/verify-schema-boundaries.mjs",
     "verify-sdk-parity": "node scripts/audit-sdk-parity.mjs",
     "smoke:http-no-config": "node scripts/smoke-http-no-config.mjs",
+    "integration:tool-scope": "bash scripts/integration_test_tool_scope.sh",
     "sync-registry-metadata": "node scripts/sync-registry-metadata.mjs",
     "prepack": "pnpm build && pnpm verify-version",
     "prepublishOnly": "pnpm check-all && pnpm verify-version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firfi/huly-mcp",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Huly MCP: feature-complete MCP server for Huly integration",
   "mcpName": "io.github.dearlordylord/huly-mcp",
   "type": "module",

--- a/scripts/benchmark_edit_context.sh
+++ b/scripts/benchmark_edit_context.sh
@@ -2,6 +2,7 @@
 # Benchmark: edit_document search-and-replace vs full replace context savings.
 # Measures input payload sizes and validates correctness against local Huly.
 # Usage: pnpm build && set -a && source .env.local && set +a && bash scripts/benchmark_edit_context.sh
+# Defaults HULY_TOOL_MODE to native because it calls native Huly tools directly.
 # Requires: jq, node, HULY_URL/HULY_WORKSPACE/HULY_EMAIL+HULY_PASSWORD env vars
 set -o pipefail
 
@@ -15,6 +16,14 @@ fi
 
 if [ -z "$HULY_URL" ]; then
   echo "ERROR: HULY_URL not set. Run: set -a && source .env.local && set +a"
+  exit 1
+fi
+
+if [ -z "${HULY_TOOL_MODE+x}" ]; then
+  export HULY_TOOL_MODE=native
+elif [ "$HULY_TOOL_MODE" != "native" ]; then
+  echo "ERROR: benchmark_edit_context.sh requires HULY_TOOL_MODE=native because it calls native Huly tools directly."
+  echo "Unset HULY_TOOL_MODE to let the script select native mode automatically."
   exit 1
 fi
 

--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Full integration test suite for Huly MCP server.
 # Usage: set -a && source .env.local && set +a && bash scripts/integration_test_full.sh
+# This suite defaults HULY_TOOL_MODE to native because it calls native Huly tools directly.
 # Requires: jq, node, HULY_URL/HULY_WORKSPACE/HULY_EMAIL+HULY_PASSWORD env vars
 set -o pipefail
 
@@ -51,6 +52,18 @@ WORKFLOW_CLEANED=false
 
 if [ -z "$HULY_URL" ]; then
   echo "ERROR: HULY_URL not set. Run: set -a && source .env.local && set +a"
+  exit 1
+fi
+
+# This suite calls native Huly tools directly. In auto mode, generic integration
+# client identities intentionally resolve to proxy mode, where those tools are
+# reachable only through invoke_tool. Keep proxy/auto surface checks in
+# scripts/integration_test_tool_scope.sh and force this suite to native mode.
+if [ -z "${HULY_TOOL_MODE+x}" ]; then
+  export HULY_TOOL_MODE=native
+elif [ "$HULY_TOOL_MODE" != "native" ]; then
+  echo "ERROR: integration_test_full.sh requires HULY_TOOL_MODE=native because it calls native Huly tools directly."
+  echo "Unset HULY_TOOL_MODE to let the script select native mode automatically."
   exit 1
 fi
 

--- a/scripts/integration_test_tool_scope.sh
+++ b/scripts/integration_test_tool_scope.sh
@@ -145,7 +145,7 @@ assert_tool_names_exact "$default_proxy_output" \
 assert_context "$default_proxy_output" '.toolExposure.configuredMode == "auto"'
 assert_context "$default_proxy_output" '.toolExposure.resolvedMode == "proxy"'
 assert_context "$default_proxy_output" '.toolExposure.clientKind == "codex"'
-assert_call_error "$default_proxy_output" 4
+assert_call_success "$default_proxy_output" 4
 assert_search_has "$default_proxy_output" "list_projects"
 assert_call_success "$default_proxy_output" 7
 assert_call_success "$default_proxy_output" 8
@@ -172,7 +172,7 @@ assert_tool_names_exact "$proxy_override_output" \
   "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
 assert_context "$proxy_override_output" '.toolExposure.configuredMode == "proxy"'
 assert_context "$proxy_override_output" '.toolExposure.resolvedMode == "proxy"'
-assert_call_error "$proxy_override_output" 4
+assert_call_success "$proxy_override_output" 4
 assert_call_success "$proxy_override_output" 8
 
 pins_output="$(run_case "proxy-pins" "codex-cli" "projects" "" "" "")"
@@ -181,7 +181,7 @@ assert_tool_absent "$pins_output" "list_teamspaces"
 assert_context "$pins_output" '.toolScope.enabledToolsets == ["projects"]'
 assert_context "$pins_output" '.toolExposure.proxyOutputStrict == false'
 assert_call_success "$pins_output" 4
-assert_call_error "$pins_output" 5
+assert_call_success "$pins_output" 5
 assert_call_success "$pins_output" 9
 
 tools_pin_output="$(run_case "proxy-tools-pin" "codex-cli" "" "list_teamspaces" "" "")"
@@ -189,7 +189,7 @@ assert_tool_present "$tools_pin_output" "list_teamspaces"
 assert_tool_absent "$tools_pin_output" "list_projects"
 assert_context "$tools_pin_output" '.toolScope.enabledTools == ["list_teamspaces"]'
 assert_context "$tools_pin_output" '.toolExposure.proxyOutputStrict == false'
-assert_call_error "$tools_pin_output" 4
+assert_call_success "$tools_pin_output" 4
 assert_call_success "$tools_pin_output" 5
 assert_call_success "$tools_pin_output" 7
 assert_call_success "$tools_pin_output" 8
@@ -199,7 +199,7 @@ strict_output="$(run_case "proxy-strict" "codex-cli" "projects" "" "" "true")"
 assert_tool_names_exact "$strict_output" \
   "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
 assert_context "$strict_output" '.toolExposure.proxyOutputStrict == true'
-assert_call_error "$strict_output" 4
+assert_call_success "$strict_output" 4
 assert_call_success "$strict_output" 7
 assert_call_success "$strict_output" 8
 assert_call_error "$strict_output" 9
@@ -210,7 +210,7 @@ assert_tool_names_exact "$strict_tools_output" \
 assert_context "$strict_tools_output" '.toolScope.enabledTools == ["list_teamspaces"]'
 assert_context "$strict_tools_output" '.toolExposure.proxyOutputStrict == true'
 assert_call_error "$strict_tools_output" 4
-assert_call_error "$strict_tools_output" 5
+assert_call_success "$strict_tools_output" 5
 assert_search_absent "$strict_tools_output" "list_projects"
 assert_search_has "$strict_tools_output" "list_teamspaces"
 assert_call_error "$strict_tools_output" 7

--- a/scripts/integration_test_tool_scope.sh
+++ b/scripts/integration_test_tool_scope.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tool-scope integration matrix for stdio MCP discovery.
+# Usage: set -a && source .env.local && set +a && pnpm integration:tool-scope
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+if [[ -z "${HULY_URL:-}" ]]; then
+  echo "ERROR: HULY_URL must be set; source .env.local first" >&2
+  exit 1
+fi
+
+TOOL_TIMEOUT="${TOOL_TIMEOUT:-30}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+json_string() {
+  jq -Rn --arg value "$1" '$value'
+}
+
+run_case() {
+  local case_name="$1"
+  local client_name="$2"
+  local toolsets="$3"
+  local tools="$4"
+  local input_file="$TMP_DIR/$case_name.input.jsonl"
+  local raw_file="$TMP_DIR/$case_name.raw"
+  local output_file="$TMP_DIR/$case_name.jsonl"
+  local client_json
+  client_json="$(json_string "$client_name")"
+
+  cat >"$input_file" <<EOF
+{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":$client_json,"version":"1.0"}},"id":1}
+{"jsonrpc":"2.0","method":"tools/list","id":2}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_huly_context","arguments":{}},"id":3}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_projects","arguments":{}},"id":4}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_teamspaces","arguments":{}},"id":5}
+EOF
+
+  env \
+    TOOLSETS="$toolsets" \
+    TOOLS="$tools" \
+    MCP_AUTO_EXIT=true \
+    timeout "$TOOL_TIMEOUT" node dist/index.cjs <"$input_file" >"$raw_file"
+
+  grep '^{' "$raw_file" >"$output_file"
+  printf '%s\n' "$output_file"
+}
+
+response_by_id() {
+  local output_file="$1"
+  local id="$2"
+  jq -c "select(.id == $id)" "$output_file" | tail -n 1
+}
+
+assert_tool_present() {
+  local output_file="$1"
+  local tool_name="$2"
+  response_by_id "$output_file" 2 | jq -e --arg tool "$tool_name" '.result.tools | any(.name == $tool)' >/dev/null
+}
+
+assert_tool_absent() {
+  local output_file="$1"
+  local tool_name="$2"
+  response_by_id "$output_file" 2 | jq -e --arg tool "$tool_name" '.result.tools | all(.name != $tool)' >/dev/null
+}
+
+assert_tool_names_exact() {
+  local output_file="$1"
+  shift
+  local expected_json
+  expected_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+  response_by_id "$output_file" 2 \
+    | jq -e --argjson expected "$expected_json" '[.result.tools[].name] == $expected' >/dev/null
+}
+
+assert_context() {
+  local output_file="$1"
+  local jq_expression="$2"
+  response_by_id "$output_file" 3 \
+    | jq -e ".result.structuredContent.result | $jq_expression" >/dev/null
+}
+
+assert_call_success() {
+  local output_file="$1"
+  local id="$2"
+  response_by_id "$output_file" "$id" | jq -e '.result.isError != true' >/dev/null
+}
+
+assert_call_error() {
+  local output_file="$1"
+  local id="$2"
+  response_by_id "$output_file" "$id" | jq -e '.result.isError == true' >/dev/null
+}
+
+echo "Running tool-scope integration matrix..."
+
+default_output="$(run_case "default" "claude-code" "" "")"
+assert_tool_present "$default_output" "list_projects"
+assert_tool_present "$default_output" "list_teamspaces"
+assert_context "$default_output" '.toolScope.active == false'
+assert_call_success "$default_output" 4
+assert_call_success "$default_output" 5
+
+projects_output="$(run_case "toolsets-projects" "claude-ai (via mcp-remote)" "projects" "")"
+assert_tool_present "$projects_output" "list_projects"
+assert_tool_absent "$projects_output" "list_teamspaces"
+assert_context "$projects_output" '.toolScope.active == true'
+assert_context "$projects_output" '.toolScope.enabledToolsets == ["projects"]'
+assert_call_success "$projects_output" 4
+assert_call_error "$projects_output" 5
+
+documents_output="$(run_case "tools-documents" "cursor-vscode" "" "list_teamspaces")"
+assert_tool_present "$documents_output" "list_teamspaces"
+assert_tool_absent "$documents_output" "list_projects"
+assert_context "$documents_output" '.toolScope.enabledTools == ["list_teamspaces"]'
+assert_call_error "$documents_output" 4
+assert_call_success "$documents_output" 5
+
+union_output="$(run_case "union" "codex-cli" "issues" "list_teamspaces")"
+assert_tool_present "$union_output" "list_issues"
+assert_tool_present "$union_output" "list_teamspaces"
+assert_tool_absent "$union_output" "list_projects"
+assert_context "$union_output" '.toolScope.enabledToolsets == ["issues"]'
+assert_context "$union_output" '.toolScope.enabledTools == ["list_teamspaces"]'
+assert_call_error "$union_output" 4
+assert_call_success "$union_output" 5
+
+invalid_output="$(run_case "invalid" "opencode" "missing_category" "missing_tool")"
+assert_tool_names_exact "$invalid_output" "get_version" "get_huly_context"
+assert_context "$invalid_output" '.toolScope.active == true'
+assert_context "$invalid_output" '.toolScope.ignoredToolsets == ["missing_category"]'
+assert_context "$invalid_output" '.toolScope.ignoredTools == ["missing_tool"]'
+assert_call_error "$invalid_output" 4
+assert_call_error "$invalid_output" 5
+
+echo "Tool-scope integration matrix passed."

--- a/scripts/integration_test_tool_scope.sh
+++ b/scripts/integration_test_tool_scope.sh
@@ -27,6 +27,8 @@ run_case() {
   local client_name="$2"
   local toolsets="$3"
   local tools="$4"
+  local tool_mode="$5"
+  local proxy_output_strict="$6"
   local input_file="$TMP_DIR/$case_name.input.jsonl"
   local raw_file="$TMP_DIR/$case_name.raw"
   local output_file="$TMP_DIR/$case_name.jsonl"
@@ -39,13 +41,29 @@ run_case() {
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_huly_context","arguments":{}},"id":3}
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_projects","arguments":{}},"id":4}
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_teamspaces","arguments":{}},"id":5}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_tools","arguments":{"query":"list projects"}},"id":6}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_tool_schema","arguments":{"toolName":"list_projects"}},"id":7}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"invoke_tool","arguments":{"toolName":"list_projects","arguments":{}}},"id":8}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_tool_schema","arguments":{"toolName":"list_teamspaces"}},"id":9}
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_tools","arguments":{"query":"teamspaces"}},"id":10}
 EOF
 
-  env \
-    TOOLSETS="$toolsets" \
-    TOOLS="$tools" \
-    MCP_AUTO_EXIT=true \
+  (
+    export TOOLSETS="$toolsets"
+    export TOOLS="$tools"
+    export MCP_AUTO_EXIT=true
+    if [[ -n "$tool_mode" ]]; then
+      export HULY_TOOL_MODE="$tool_mode"
+    else
+      unset HULY_TOOL_MODE
+    fi
+    if [[ -n "$proxy_output_strict" ]]; then
+      export PROXY_OUTPUT_STRICT="$proxy_output_strict"
+    else
+      unset PROXY_OUTPUT_STRICT
+    fi
     timeout "$TOOL_TIMEOUT" node dist/index.cjs <"$input_file" >"$raw_file"
+  )
 
   grep '^{' "$raw_file" >"$output_file"
   printf '%s\n' "$output_file"
@@ -97,45 +115,119 @@ assert_call_error() {
   response_by_id "$output_file" "$id" | jq -e '.result.isError == true' >/dev/null
 }
 
+assert_search_has() {
+  local output_file="$1"
+  local tool_name="$2"
+  local id="${3:-6}"
+  response_by_id "$output_file" "$id" \
+    | jq -e --arg tool "$tool_name" '.result.structuredContent.result.matches | any(.name == $tool)' >/dev/null
+}
+
+assert_search_absent() {
+  local output_file="$1"
+  local tool_name="$2"
+  local id="${3:-6}"
+  response_by_id "$output_file" "$id" \
+    | jq -e --arg tool "$tool_name" '.result.structuredContent.result.matches | all(.name != $tool)' >/dev/null
+}
+
+assert_search_empty() {
+  local output_file="$1"
+  response_by_id "$output_file" 6 \
+    | jq -e '.result.structuredContent.result.matches == []' >/dev/null
+}
+
 echo "Running tool-scope integration matrix..."
 
-default_output="$(run_case "default" "claude-code" "" "")"
-assert_tool_present "$default_output" "list_projects"
-assert_tool_present "$default_output" "list_teamspaces"
-assert_context "$default_output" '.toolScope.active == false'
-assert_call_success "$default_output" 4
-assert_call_success "$default_output" 5
+default_proxy_output="$(run_case "default-codex-proxy" "codex-cli" "" "" "" "")"
+assert_tool_names_exact "$default_proxy_output" \
+  "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
+assert_context "$default_proxy_output" '.toolExposure.configuredMode == "auto"'
+assert_context "$default_proxy_output" '.toolExposure.resolvedMode == "proxy"'
+assert_context "$default_proxy_output" '.toolExposure.clientKind == "codex"'
+assert_call_error "$default_proxy_output" 4
+assert_search_has "$default_proxy_output" "list_projects"
+assert_call_success "$default_proxy_output" 7
+assert_call_success "$default_proxy_output" 8
 
-projects_output="$(run_case "toolsets-projects" "claude-ai (via mcp-remote)" "projects" "")"
-assert_tool_present "$projects_output" "list_projects"
-assert_tool_absent "$projects_output" "list_teamspaces"
-assert_context "$projects_output" '.toolScope.active == true'
-assert_context "$projects_output" '.toolScope.enabledToolsets == ["projects"]'
-assert_call_success "$projects_output" 4
-assert_call_error "$projects_output" 5
+claude_native_output="$(run_case "claude-code-native" "claude-code" "" "" "" "")"
+assert_tool_present "$claude_native_output" "list_projects"
+assert_tool_present "$claude_native_output" "list_teamspaces"
+assert_tool_absent "$claude_native_output" "search_tools"
+assert_context "$claude_native_output" '.toolExposure.resolvedMode == "native"'
+assert_context "$claude_native_output" '.toolExposure.clientKind == "claude-code"'
+assert_call_success "$claude_native_output" 4
+assert_call_success "$claude_native_output" 5
+assert_call_error "$claude_native_output" 6
 
-documents_output="$(run_case "tools-documents" "cursor-vscode" "" "list_teamspaces")"
-assert_tool_present "$documents_output" "list_teamspaces"
-assert_tool_absent "$documents_output" "list_projects"
-assert_context "$documents_output" '.toolScope.enabledTools == ["list_teamspaces"]'
-assert_call_error "$documents_output" 4
-assert_call_success "$documents_output" 5
+native_override_output="$(run_case "codex-native-override" "codex-cli" "" "" "native" "")"
+assert_tool_present "$native_override_output" "list_projects"
+assert_tool_absent "$native_override_output" "search_tools"
+assert_context "$native_override_output" '.toolExposure.configuredMode == "native"'
+assert_context "$native_override_output" '.toolExposure.resolvedMode == "native"'
+assert_call_success "$native_override_output" 4
 
-union_output="$(run_case "union" "codex-cli" "issues" "list_teamspaces")"
-assert_tool_present "$union_output" "list_issues"
-assert_tool_present "$union_output" "list_teamspaces"
-assert_tool_absent "$union_output" "list_projects"
-assert_context "$union_output" '.toolScope.enabledToolsets == ["issues"]'
-assert_context "$union_output" '.toolScope.enabledTools == ["list_teamspaces"]'
-assert_call_error "$union_output" 4
-assert_call_success "$union_output" 5
+proxy_override_output="$(run_case "claude-proxy-override" "claude-code" "" "" "proxy" "")"
+assert_tool_names_exact "$proxy_override_output" \
+  "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
+assert_context "$proxy_override_output" '.toolExposure.configuredMode == "proxy"'
+assert_context "$proxy_override_output" '.toolExposure.resolvedMode == "proxy"'
+assert_call_error "$proxy_override_output" 4
+assert_call_success "$proxy_override_output" 8
 
-invalid_output="$(run_case "invalid" "opencode" "missing_category" "missing_tool")"
-assert_tool_names_exact "$invalid_output" "get_version" "get_huly_context"
+pins_output="$(run_case "proxy-pins" "codex-cli" "projects" "" "" "")"
+assert_tool_present "$pins_output" "list_projects"
+assert_tool_absent "$pins_output" "list_teamspaces"
+assert_context "$pins_output" '.toolScope.enabledToolsets == ["projects"]'
+assert_context "$pins_output" '.toolExposure.proxyOutputStrict == false'
+assert_call_success "$pins_output" 4
+assert_call_error "$pins_output" 5
+assert_call_success "$pins_output" 9
+
+tools_pin_output="$(run_case "proxy-tools-pin" "codex-cli" "" "list_teamspaces" "" "")"
+assert_tool_present "$tools_pin_output" "list_teamspaces"
+assert_tool_absent "$tools_pin_output" "list_projects"
+assert_context "$tools_pin_output" '.toolScope.enabledTools == ["list_teamspaces"]'
+assert_context "$tools_pin_output" '.toolExposure.proxyOutputStrict == false'
+assert_call_error "$tools_pin_output" 4
+assert_call_success "$tools_pin_output" 5
+assert_call_success "$tools_pin_output" 7
+assert_call_success "$tools_pin_output" 8
+assert_search_has "$tools_pin_output" "list_teamspaces" 10
+
+strict_output="$(run_case "proxy-strict" "codex-cli" "projects" "" "" "true")"
+assert_tool_names_exact "$strict_output" \
+  "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
+assert_context "$strict_output" '.toolExposure.proxyOutputStrict == true'
+assert_call_error "$strict_output" 4
+assert_call_success "$strict_output" 7
+assert_call_success "$strict_output" 8
+assert_call_error "$strict_output" 9
+
+strict_tools_output="$(run_case "proxy-strict-tools" "codex-cli" "" "list_teamspaces" "" "true")"
+assert_tool_names_exact "$strict_tools_output" \
+  "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
+assert_context "$strict_tools_output" '.toolScope.enabledTools == ["list_teamspaces"]'
+assert_context "$strict_tools_output" '.toolExposure.proxyOutputStrict == true'
+assert_call_error "$strict_tools_output" 4
+assert_call_error "$strict_tools_output" 5
+assert_search_absent "$strict_tools_output" "list_projects"
+assert_search_has "$strict_tools_output" "list_teamspaces"
+assert_call_error "$strict_tools_output" 7
+assert_call_error "$strict_tools_output" 8
+assert_call_success "$strict_tools_output" 9
+assert_search_has "$strict_tools_output" "list_teamspaces" 10
+
+invalid_output="$(run_case "invalid-strict" "opencode" "missing_category" "missing_tool" "" "true")"
+assert_tool_names_exact "$invalid_output" \
+  "get_version" "get_huly_context" "list_tool_categories" "search_tools" "get_tool_schema" "invoke_tool"
 assert_context "$invalid_output" '.toolScope.active == true'
 assert_context "$invalid_output" '.toolScope.ignoredToolsets == ["missing_category"]'
 assert_context "$invalid_output" '.toolScope.ignoredTools == ["missing_tool"]'
+assert_context "$invalid_output" '.toolExposure.proxyCandidateToolCount == 0'
 assert_call_error "$invalid_output" 4
-assert_call_error "$invalid_output" 5
+assert_search_empty "$invalid_output"
+assert_call_error "$invalid_output" 7
+assert_call_error "$invalid_output" 8
 
 echo "Tool-scope integration matrix passed."

--- a/scripts/update-readme-tools.mjs
+++ b/scripts/update-readme-tools.mjs
@@ -227,6 +227,13 @@ const expressionValue = (node, filePath, localBindings = new Map()) => {
       return Array.isArray(values) ? values.join(", ") : undefined
     }
 
+    if (
+      ["makeToolCategory", "makeToolDescription", "makeToolName"].includes(node.expression.text)
+      && node.arguments.length === 1
+    ) {
+      return expressionValue(node.arguments[0], filePath, localBindings)
+    }
+
     const fn = functionValue(node.expression, filePath, localBindings)
     if (fn !== undefined) {
       return fn(...node.arguments.map((argument) => expressionValue(argument, filePath, localBindings)))
@@ -236,6 +243,15 @@ const expressionValue = (node, filePath, localBindings = new Map()) => {
   if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
     const target = expressionValue(node.expression.expression, filePath, localBindings)
     const method = node.expression.name.text
+
+    if (
+      method === "make"
+      && node.arguments.length === 1
+      && ts.isIdentifier(node.expression.expression)
+      && ["ToolCategory", "ToolDescription", "ToolName"].includes(node.expression.expression.text)
+    ) {
+      return expressionValue(node.arguments[0], filePath, localBindings)
+    }
 
     if (method === "join" && Array.isArray(target)) {
       const separator = node.arguments.length > 0

--- a/scripts/update-readme-tools.mjs
+++ b/scripts/update-readme-tools.mjs
@@ -373,7 +373,7 @@ const generateToolsSection = () => {
     ...[...toolsByCategory.keys()].filter((category) => !categoryOrder.includes(category))
   ]
   let output = "## Available Tools\n\n"
-  output += `**\`TOOLSETS\` categories:** ${categories.map((category) => `\`${category}\``).join(", ")}\n\n`
+  output += `**\`HULY_TOOLSETS\` categories:** ${categories.map((category) => `\`${category}\``).join(", ")}\n\n`
 
   for (const categoryName of categoryOrder) {
     const tools = toolsByCategory.get(categoryName)

--- a/scripts/update-readme-tools.mjs
+++ b/scripts/update-readme-tools.mjs
@@ -397,7 +397,7 @@ const generateToolsSection = () => {
   ]
   let output = "## Available Tools\n\n"
   output +=
-    "When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog.\n\n"
+    "When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog. Exact native tool names also dispatch when a client calls them directly, subject to `PROXY_OUTPUT_STRICT` scope rules, but hidden native tools are not advertised through `tools/list`.\n\n"
   output += "### Proxy Meta-Tools\n\n"
   output += "| Tool | Description |\n"
   output += "|------|-------------|\n"

--- a/scripts/update-readme-tools.mjs
+++ b/scripts/update-readme-tools.mjs
@@ -373,7 +373,7 @@ const generateToolsSection = () => {
     ...[...toolsByCategory.keys()].filter((category) => !categoryOrder.includes(category))
   ]
   let output = "## Available Tools\n\n"
-  output += `**\`HULY_TOOLSETS\` categories:** ${categories.map((category) => `\`${category}\``).join(", ")}\n\n`
+  output += `**\`TOOLSETS\` categories:** ${categories.map((category) => `\`${category}\``).join(", ")}\n\n`
 
   for (const categoryName of categoryOrder) {
     const tools = toolsByCategory.get(categoryName)

--- a/scripts/update-readme-tools.mjs
+++ b/scripts/update-readme-tools.mjs
@@ -32,7 +32,7 @@ const sourceFor = (filePath) => {
 }
 
 const resolveModulePath = (fromFile, specifier) => {
-  if (!specifier.startsWith(".")) return specifier
+  if (!specifier.startsWith(".")) return undefined
 
   const basePath = resolve(dirname(fromFile), specifier)
   if (basePath.endsWith(".js")) {
@@ -75,6 +75,7 @@ const moduleBindingsFor = (filePath) => {
   for (const statement of source.statements) {
     if (ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)) {
       const modulePath = resolveModulePath(resolved, statement.moduleSpecifier.text)
+      if (modulePath === undefined) continue
       const namedBindings = statement.importClause?.namedBindings
       if (namedBindings !== undefined && ts.isNamedImports(namedBindings)) {
         for (const element of namedBindings.elements) {
@@ -293,10 +294,16 @@ const toolFiles = readdirSync(toolsDir)
   .filter((file) => file.endsWith(".ts") && file !== "index.ts" && file !== "registry.ts")
 
 const allTools = toolFiles.flatMap((file) => parseToolsFromFile(join(toolsDir, file)))
+const proxyTools = parseToolsFromFile(join(process.cwd(), "src/mcp/proxy-tools.ts"))
+  .filter((tool) => tool.category === "proxy")
 const resourceTemplates = parseResourceTemplatesFromFile(join(process.cwd(), "src/mcp/resources.ts"))
 
 if (allTools.length === 0) {
   throw new Error("README tool generation found no tools")
+}
+
+if (proxyTools.length === 0) {
+  throw new Error("README proxy tool generation found no proxy meta-tools")
 }
 
 if (resourceTemplates.length === 0) {
@@ -373,6 +380,15 @@ const generateToolsSection = () => {
     ...[...toolsByCategory.keys()].filter((category) => !categoryOrder.includes(category))
   ]
   let output = "## Available Tools\n\n"
+  output +=
+    "When resolved tool exposure is `proxy`, clients see the built-in tools plus these proxy meta-tools. Native Huly tools are then discovered and invoked through the proxy candidate catalog.\n\n"
+  output += "### Proxy Meta-Tools\n\n"
+  output += "| Tool | Description |\n"
+  output += "|------|-------------|\n"
+  for (const tool of proxyTools) {
+    output += `| \`${tool.name}\` | ${escapeTableCell(tool.description)} |\n`
+  }
+  output += "\n"
   output += `**\`TOOLSETS\` categories:** ${categories.map((category) => `\`${category}\``).join(", ")}\n\n`
 
   for (const categoryName of categoryOrder) {
@@ -446,12 +462,12 @@ if (checkMode) {
   }
 
   console.log(
-    `✅ README.md is up to date with ${allTools.length} tools in ${toolsByCategory.size} categories and ${resourceTemplates.length} resource templates`
+    `✅ README.md is up to date with ${allTools.length} native tools, ${proxyTools.length} proxy tools, ${toolsByCategory.size} categories, and ${resourceTemplates.length} resource templates`
   )
   process.exit(0)
 }
 
 writeFileSync(readmePath, content, "utf-8")
 console.log(
-  `✅ README.md updated with ${allTools.length} tools in ${toolsByCategory.size} categories and ${resourceTemplates.length} resource templates`
+  `✅ README.md updated with ${allTools.length} native tools, ${proxyTools.length} proxy tools, ${toolsByCategory.size} categories, and ${resourceTemplates.length} resource templates`
 )

--- a/server.json
+++ b/server.json
@@ -61,6 +61,27 @@
           "isRequired": false,
           "format": "string",
           "isSecret": false
+        },
+        {
+          "name": "HULY_TOOLSETS",
+          "description": "Comma-separated native Huly tool categories to expose, such as issues,projects,search. If unset with HULY_TOOLS and TOOLSETS, all native tools are exposed.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "HULY_TOOLS",
+          "description": "Comma-separated exact native Huly tool names to expose in addition to selected HULY_TOOLSETS, such as list_documents,create_issue.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "TOOLSETS",
+          "description": "Deprecated alias for HULY_TOOLSETS. Ignored when HULY_TOOLSETS is set.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -17,12 +17,12 @@
     "url": "https://github.com/dearlordylord/huly-mcp",
     "source": "github"
   },
-  "version": "0.42.0",
+  "version": "0.43.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@firfi/huly-mcp",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -63,22 +63,15 @@
           "isSecret": false
         },
         {
-          "name": "HULY_TOOLSETS",
-          "description": "Comma-separated native Huly tool categories to expose, such as issues,projects,search. If unset with HULY_TOOLS and TOOLSETS, all native tools are exposed.",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false
-        },
-        {
-          "name": "HULY_TOOLS",
-          "description": "Comma-separated exact native Huly tool names to expose in addition to selected HULY_TOOLSETS, such as list_documents,create_issue.",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false
-        },
-        {
           "name": "TOOLSETS",
-          "description": "Deprecated alias for HULY_TOOLSETS. Ignored when HULY_TOOLSETS is set.",
+          "description": "Comma-separated native Huly tool categories to expose, such as issues,projects,search. If unset with TOOLS, all native tools are exposed.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "TOOLS",
+          "description": "Comma-separated exact native Huly tool names to expose in addition to selected TOOLSETS, such as list_documents,create_issue.",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/server.json
+++ b/server.json
@@ -63,6 +63,20 @@
           "isSecret": false
         },
         {
+          "name": "HULY_TOOL_MODE",
+          "description": "Tool exposure mode: auto (default), native, or proxy. Auto keeps exact claude-code native and resolves Codex, Cursor, Windsurf, Copilot, opencode, Claude AI, and unknown clients to proxy mode.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXY_OUTPUT_STRICT",
+          "description": "Set true to make active TOOLSETS / TOOLS a hard allow-list for proxy search, schema lookup, and invocation. Defaults to false.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
           "name": "TOOLSETS",
           "description": "Comma-separated native Huly tool categories to expose, such as issues,projects,search. If unset with TOOLS, all native tools are exposed.",
           "isRequired": false,

--- a/src/domain/schemas/huly-context.ts
+++ b/src/domain/schemas/huly-context.ts
@@ -84,6 +84,27 @@ const ToolsetsContextSchema = Schema.Struct({
   builtinTools: Schema.Array(Schema.Literal("get_version", "get_huly_context"))
 })
 
+const LegacyToolsetsAliasUsageSchema = Schema.Struct({
+  provided: Schema.Boolean,
+  used: Schema.Boolean,
+  ignored: Schema.Boolean
+})
+
+const ToolScopeContextSchema = Schema.Struct({
+  active: Schema.Boolean,
+  requestedToolsets: Schema.Array(NonEmptyTrimmedString),
+  enabledToolsets: Schema.Array(NonEmptyTrimmedString),
+  ignoredToolsets: Schema.Array(NonEmptyTrimmedString),
+  requestedTools: Schema.Array(NonEmptyTrimmedString),
+  enabledTools: Schema.Array(NonEmptyTrimmedString),
+  ignoredTools: Schema.Array(NonEmptyTrimmedString),
+  legacyToolsets: LegacyToolsetsAliasUsageSchema,
+  availableCategories: Schema.Array(NonEmptyTrimmedString),
+  visibleRegisteredToolCount: Count,
+  totalRegisteredToolCount: Count,
+  builtinTools: Schema.Array(Schema.Literal("get_version", "get_huly_context"))
+})
+
 export const GetHulyContextResultSchema = Schema.Struct({
   package: Schema.Struct({
     name: Schema.Literal("@firfi/huly-mcp"),
@@ -99,7 +120,8 @@ export const GetHulyContextResultSchema = Schema.Struct({
   huly: HulyRuntimeContextSchema,
   auth: AuthContextSchema,
   configSources: ConfigSourcesSchema,
-  toolsets: ToolsetsContextSchema
+  toolsets: ToolsetsContextSchema,
+  toolScope: ToolScopeContextSchema
 })
 
 export type GetHulyContextResult = Schema.Schema.Type<typeof GetHulyContextResultSchema>

--- a/src/domain/schemas/huly-context.ts
+++ b/src/domain/schemas/huly-context.ts
@@ -84,12 +84,6 @@ const ToolsetsContextSchema = Schema.Struct({
   builtinTools: Schema.Array(Schema.Literal("get_version", "get_huly_context"))
 })
 
-const LegacyToolsetsAliasUsageSchema = Schema.Struct({
-  provided: Schema.Boolean,
-  used: Schema.Boolean,
-  ignored: Schema.Boolean
-})
-
 const ToolScopeContextSchema = Schema.Struct({
   active: Schema.Boolean,
   requestedToolsets: Schema.Array(NonEmptyTrimmedString),
@@ -98,7 +92,6 @@ const ToolScopeContextSchema = Schema.Struct({
   requestedTools: Schema.Array(NonEmptyTrimmedString),
   enabledTools: Schema.Array(NonEmptyTrimmedString),
   ignoredTools: Schema.Array(NonEmptyTrimmedString),
-  legacyToolsets: LegacyToolsetsAliasUsageSchema,
   availableCategories: Schema.Array(NonEmptyTrimmedString),
   visibleRegisteredToolCount: Count,
   totalRegisteredToolCount: Count,

--- a/src/domain/schemas/huly-context.ts
+++ b/src/domain/schemas/huly-context.ts
@@ -98,6 +98,26 @@ const ToolScopeContextSchema = Schema.Struct({
   builtinTools: Schema.Array(Schema.Literal("get_version", "get_huly_context"))
 })
 
+const ToolExposureContextSchema = Schema.Struct({
+  configuredMode: Schema.Literal("auto", "native", "proxy"),
+  resolvedMode: Schema.Literal("native", "proxy"),
+  clientKind: Schema.Literal(
+    "claude-code",
+    "claude-ai",
+    "cursor",
+    "windsurf",
+    "github-copilot",
+    "codex",
+    "opencode",
+    "unknown"
+  ),
+  proxyOutputStrict: Schema.Boolean,
+  visibleToolCount: Count,
+  nativeVisibleToolCount: Count,
+  proxyCandidateToolCount: Count,
+  proxyToolNames: Schema.Array(NonEmptyTrimmedString)
+})
+
 export const GetHulyContextResultSchema = Schema.Struct({
   package: Schema.Struct({
     name: Schema.Literal("@firfi/huly-mcp"),
@@ -114,7 +134,8 @@ export const GetHulyContextResultSchema = Schema.Struct({
   auth: AuthContextSchema,
   configSources: ConfigSourcesSchema,
   toolsets: ToolsetsContextSchema,
-  toolScope: ToolScopeContextSchema
+  toolScope: ToolScopeContextSchema,
+  toolExposure: ToolExposureContextSchema
 })
 
 export type GetHulyContextResult = Schema.Schema.Type<typeof GetHulyContextResultSchema>

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,7 @@ const buildAppLayer = (
   resolveClientsForHttpRequest: (req: Request) => Promise<ClientBundle>
 ): Layer.Layer<
   McpServerService | HttpServerFactoryService,
-  never,
+  McpServerError,
   never
 > => {
   const mcpServerConfig = {

--- a/src/mcp/create-mcp-server.ts
+++ b/src/mcp/create-mcp-server.ts
@@ -13,15 +13,18 @@ import type { ToolExposureContext } from "./huly-context-tool.js"
 import { type ClientBundle, createMcpProtocolHandlers } from "./protocol-handlers.js"
 import { type ProtocolExposureOptions, type ProtocolToolRegistries } from "./protocol-tool-exposure.js"
 import { createDefaultMcpSdkServer } from "./sdk-server.js"
+import { parseMcpClientInfo } from "./tool-mode.js"
 import type { ToolRegistry } from "./tools/index.js"
 
 export type { ClientBundle } from "./protocol-handlers.js"
 
 type McpServerHandle = readonly [server: Server, drainInflight: () => Promise<void>]
 
-const currentClientInfoFromServer = (server: Server): ReturnType<Server["getClientVersion"]> => {
+const currentClientInfoFromServer = (
+  server: Server
+): ReturnType<NonNullable<ProtocolExposureOptions["currentClientInfo"]>> => {
   const maybeServer: { readonly getClientVersion?: () => ReturnType<Server["getClientVersion"]> } = server
-  return maybeServer.getClientVersion?.()
+  return parseMcpClientInfo(maybeServer.getClientVersion?.())
 }
 
 export const createMcpServer = (

--- a/src/mcp/create-mcp-server.ts
+++ b/src/mcp/create-mcp-server.ts
@@ -9,7 +9,9 @@ import {
 
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import type { TelemetryOperations } from "../telemetry/telemetry.js"
+import type { ToolExposureContext } from "./huly-context-tool.js"
 import { type ClientBundle, createMcpProtocolHandlers } from "./protocol-handlers.js"
+import { type ProtocolExposureOptions, type ProtocolToolRegistries } from "./protocol-tool-exposure.js"
 import { createDefaultMcpSdkServer } from "./sdk-server.js"
 import type { ToolRegistry } from "./tools/index.js"
 
@@ -17,15 +19,34 @@ export type { ClientBundle } from "./protocol-handlers.js"
 
 type McpServerHandle = readonly [server: Server, drainInflight: () => Promise<void>]
 
+const currentClientInfoFromServer = (server: Server): ReturnType<Server["getClientVersion"]> => {
+  const maybeServer: { readonly getClientVersion?: () => ReturnType<Server["getClientVersion"]> } = server
+  return maybeServer.getClientVersion?.()
+}
+
 export const createMcpServer = (
   resolveClients: () => Promise<ClientBundle>,
   telemetry: TelemetryOperations,
-  registry: ToolRegistry,
-  getHulyContext: () => GetHulyContextResult,
-  createServer: () => Server = createDefaultMcpSdkServer
+  registry: ToolRegistry | ProtocolToolRegistries,
+  getHulyContext: (toolExposure: ToolExposureContext) => GetHulyContextResult,
+  createServer: () => Server = createDefaultMcpSdkServer,
+  exposureOptions: Partial<ProtocolExposureOptions> = {}
 ): McpServerHandle => {
   const server = createServer()
-  const handlers = createMcpProtocolHandlers(resolveClients, telemetry, registry, getHulyContext)
+  const currentClientInfo = (): ReturnType<NonNullable<ProtocolExposureOptions["currentClientInfo"]>> =>
+    exposureOptions.currentClientInfo?.() ?? currentClientInfoFromServer(server)
+  const handlers = createMcpProtocolHandlers(
+    resolveClients,
+    telemetry,
+    registry,
+    getHulyContext,
+    undefined,
+    undefined,
+    {
+      ...exposureOptions,
+      currentClientInfo
+    }
+  )
 
   server.setRequestHandler(ListToolsRequestSchema, handlers.listTools)
   server.setRequestHandler(CallToolRequestSchema, handlers.callTool)

--- a/src/mcp/huly-context-tool.ts
+++ b/src/mcp/huly-context-tool.ts
@@ -8,12 +8,14 @@ import type { ClientKind, ToolExposureMode, ToolModeConfig } from "./tool-mode.j
 import { createToolOutputSchema, hulyContextToolOutputSchema } from "./tool-output-schema.js"
 import { resolveToolScope, type ToolScopeSummary } from "./tool-scope.js"
 import { type ToolRegistry, toolRegistry } from "./tools/index.js"
+import { makeToolDescription, makeToolName, type ToolName } from "./tools/registry.js"
 
 const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
-export const VERSION_TOOL_NAME = "get_version"
-export const GET_HULY_CONTEXT_TOOL_NAME = "get_huly_context"
+const BUILTIN_TOOL_NAME_LITERALS = ["get_version", "get_huly_context"] as const
+export const VERSION_TOOL_NAME = makeToolName(BUILTIN_TOOL_NAME_LITERALS[0])
+export const GET_HULY_CONTEXT_TOOL_NAME = makeToolName(BUILTIN_TOOL_NAME_LITERALS[1])
 
-type BuiltinToolName = typeof VERSION_TOOL_NAME | typeof GET_HULY_CONTEXT_TOOL_NAME
+type BuiltinToolName = (typeof BUILTIN_TOOL_NAME_LITERALS)[number]
 
 const emptyInputSchema: {
   readonly type: "object"
@@ -28,7 +30,9 @@ export const VersionToolResultSchema = Schema.Struct({
 
 export const versionToolDefinition = {
   name: VERSION_TOOL_NAME,
-  description: "Returns the current version of this Huly MCP server and the latest version available on npm.",
+  description: makeToolDescription(
+    "Returns the current version of this Huly MCP server and the latest version available on npm."
+  ),
   inputSchema: emptyInputSchema,
   outputSchema: createToolOutputSchema(VersionToolResultSchema),
   annotations: {
@@ -42,8 +46,9 @@ export const versionToolDefinition = {
 
 export const getHulyContextToolDefinition = {
   name: GET_HULY_CONTEXT_TOOL_NAME,
-  description:
-    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, native tool scope filtering, and resolved native/proxy tool exposure. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned.",
+  description: makeToolDescription(
+    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, native tool scope filtering, and resolved native/proxy tool exposure. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned."
+  ),
   inputSchema: emptyInputSchema,
   outputSchema: hulyContextToolOutputSchema,
   annotations: {
@@ -68,7 +73,7 @@ export const parseToolsets = (
     writeError
   )
 
-const builtinToolNames: ReadonlyArray<BuiltinToolName> = [VERSION_TOOL_NAME, GET_HULY_CONTEXT_TOOL_NAME]
+const builtinToolNames: ReadonlyArray<BuiltinToolName> = BUILTIN_TOOL_NAME_LITERALS
 
 const nonEmptyOrDefault = (value: string | undefined, fallback: string): string => {
   const trimmed = value?.trim()
@@ -83,7 +88,7 @@ export interface ToolExposureContext {
   readonly visibleToolCount: number
   readonly nativeVisibleToolCount: number
   readonly proxyCandidateToolCount: number
-  readonly proxyToolNames: ReadonlyArray<string>
+  readonly proxyToolNames: ReadonlyArray<ToolName>
 }
 
 const defaultToolExposureContext = (registry: ToolRegistry): ToolExposureContext => ({

--- a/src/mcp/huly-context-tool.ts
+++ b/src/mcp/huly-context-tool.ts
@@ -5,7 +5,8 @@ import { Count, NonEmptyString } from "../domain/schemas/index.js"
 import { VERSION } from "../version.js"
 import { DEFAULT_HTTP_PORT } from "./http-transport.js"
 import { createToolOutputSchema, hulyContextToolOutputSchema } from "./tool-output-schema.js"
-import { CATEGORY_NAMES, type ToolRegistry, toolRegistry } from "./tools/index.js"
+import { resolveToolScope, type ToolScopeSummary } from "./tool-scope.js"
+import { type ToolRegistry, toolRegistry } from "./tools/index.js"
 
 const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
 export const VERSION_TOOL_NAME = "get_version"
@@ -41,7 +42,7 @@ export const versionToolDefinition = {
 export const getHulyContextToolDefinition = {
   name: GET_HULY_CONTEXT_TOOL_NAME,
   description:
-    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, and toolset filtering. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned.",
+    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, and native tool scope filtering. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned.",
   inputSchema: emptyInputSchema,
   outputSchema: hulyContextToolOutputSchema,
   annotations: {
@@ -53,54 +54,19 @@ export const getHulyContextToolDefinition = {
   }
 }
 
-interface ToolsetFilterSummary {
-  readonly enabledCategories: ReadonlySet<string> | undefined
-  readonly requestedCategories: ReadonlyArray<string>
-  readonly ignoredCategories: ReadonlyArray<string>
-}
-
 export const parseToolsets = (
   raw: string | undefined,
   writeError: (message: string) => void
-): ToolsetFilterSummary => {
-  if (raw === undefined || raw.trim() === "") {
-    return {
-      enabledCategories: undefined,
-      requestedCategories: [],
-      ignoredCategories: []
-    }
-  }
-  const requested = raw.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
-  const parsed = requested.reduce<{
-    readonly enabledCategories: ReadonlyArray<string>
-    readonly ignoredCategories: ReadonlyArray<string>
-  }>((acc, category) => {
-    if (CATEGORY_NAMES.has(category)) {
-      return {
-        ...acc,
-        enabledCategories: [...acc.enabledCategories, category]
-      }
-    }
-
-    writeError(
-      `Warning: unknown toolset category "${category}", ignoring. Valid categories: ${[...CATEGORY_NAMES].join(", ")}`
-    )
-    return {
-      ...acc,
-      ignoredCategories: [...acc.ignoredCategories, category]
-    }
-  }, {
-    enabledCategories: [],
-    ignoredCategories: []
-  })
-  const enabled = new Set(parsed.enabledCategories)
-
-  return {
-    enabledCategories: enabled.size > 0 ? enabled : undefined,
-    requestedCategories: requested,
-    ignoredCategories: parsed.ignoredCategories
-  }
-}
+): ToolScopeSummary =>
+  resolveToolScope(
+    {
+      hulyToolsets: raw ?? "",
+      hulyTools: "",
+      legacyToolsets: ""
+    },
+    toolRegistry.definitions,
+    writeError
+  )
 
 const builtinToolNames: ReadonlyArray<BuiltinToolName> = [VERSION_TOOL_NAME, GET_HULY_CONTEXT_TOOL_NAME]
 
@@ -116,7 +82,7 @@ export const buildHulyContext = (
     readonly httpHost?: string
   },
   registry: ToolRegistry,
-  toolsetSummary: ToolsetFilterSummary,
+  toolScope: ToolScopeSummary,
   runtimeConfig: SanitizedHulyRuntimeConfigContext
 ): GetHulyContextResult => ({
   package: {
@@ -138,13 +104,27 @@ export const buildHulyContext = (
   auth: runtimeConfig.auth,
   configSources: runtimeConfig.configSources,
   toolsets: {
-    filteringActive: toolsetSummary.enabledCategories !== undefined,
-    requestedCategories: toolsetSummary.requestedCategories,
-    enabledCategories: toolsetSummary.enabledCategories === undefined ? [] : [...toolsetSummary.enabledCategories],
-    ignoredCategories: toolsetSummary.ignoredCategories,
-    availableCategories: [...CATEGORY_NAMES],
+    filteringActive: toolScope.filteringActive,
+    requestedCategories: toolScope.requestedToolsets,
+    enabledCategories: toolScope.enabledToolsets,
+    ignoredCategories: toolScope.ignoredToolsets,
+    availableCategories: toolScope.availableCategories,
     visibleRegisteredToolCount: Count.make(registry.definitions.length),
-    totalRegisteredToolCount: Count.make(toolRegistry.definitions.length),
+    totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
+    builtinTools: builtinToolNames
+  },
+  toolScope: {
+    active: toolScope.filteringActive,
+    requestedToolsets: toolScope.requestedToolsets,
+    enabledToolsets: toolScope.enabledToolsets,
+    ignoredToolsets: toolScope.ignoredToolsets,
+    requestedTools: toolScope.requestedTools,
+    enabledTools: toolScope.enabledTools,
+    ignoredTools: toolScope.ignoredTools,
+    legacyToolsets: toolScope.legacyToolsets,
+    availableCategories: toolScope.availableCategories,
+    visibleRegisteredToolCount: Count.make(registry.definitions.length),
+    totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
     builtinTools: builtinToolNames
   }
 })

--- a/src/mcp/huly-context-tool.ts
+++ b/src/mcp/huly-context-tool.ts
@@ -60,9 +60,8 @@ export const parseToolsets = (
 ): ToolScopeSummary =>
   resolveToolScope(
     {
-      hulyToolsets: raw ?? "",
-      hulyTools: "",
-      legacyToolsets: ""
+      toolsets: raw ?? "",
+      tools: ""
     },
     toolRegistry.definitions,
     writeError
@@ -121,7 +120,6 @@ export const buildHulyContext = (
     requestedTools: toolScope.requestedTools,
     enabledTools: toolScope.enabledTools,
     ignoredTools: toolScope.ignoredTools,
-    legacyToolsets: toolScope.legacyToolsets,
     availableCategories: toolScope.availableCategories,
     visibleRegisteredToolCount: Count.make(registry.definitions.length),
     totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),

--- a/src/mcp/huly-context-tool.ts
+++ b/src/mcp/huly-context-tool.ts
@@ -4,6 +4,7 @@ import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import { Count, NonEmptyString } from "../domain/schemas/index.js"
 import { VERSION } from "../version.js"
 import { DEFAULT_HTTP_PORT } from "./http-transport.js"
+import type { ClientKind, ToolExposureMode, ToolModeConfig } from "./tool-mode.js"
 import { createToolOutputSchema, hulyContextToolOutputSchema } from "./tool-output-schema.js"
 import { resolveToolScope, type ToolScopeSummary } from "./tool-scope.js"
 import { type ToolRegistry, toolRegistry } from "./tools/index.js"
@@ -42,7 +43,7 @@ export const versionToolDefinition = {
 export const getHulyContextToolDefinition = {
   name: GET_HULY_CONTEXT_TOOL_NAME,
   description:
-    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, and native tool scope filtering. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned.",
+    "Returns sanitized runtime and configuration context for this Huly MCP session, including package version, transport, auth mode, Huly URL origin/host, workspace, timeout, native tool scope filtering, and resolved native/proxy tool exposure. Does not connect to Huly. Secret values such as tokens, passwords, and credential headers are never returned.",
   inputSchema: emptyInputSchema,
   outputSchema: hulyContextToolOutputSchema,
   annotations: {
@@ -74,6 +75,28 @@ const nonEmptyOrDefault = (value: string | undefined, fallback: string): string 
   return trimmed === undefined || trimmed === "" ? fallback : trimmed
 }
 
+export interface ToolExposureContext {
+  readonly configuredMode: ToolModeConfig
+  readonly resolvedMode: ToolExposureMode
+  readonly clientKind: ClientKind
+  readonly proxyOutputStrict: boolean
+  readonly visibleToolCount: number
+  readonly nativeVisibleToolCount: number
+  readonly proxyCandidateToolCount: number
+  readonly proxyToolNames: ReadonlyArray<string>
+}
+
+const defaultToolExposureContext = (registry: ToolRegistry): ToolExposureContext => ({
+  configuredMode: "auto",
+  resolvedMode: "native",
+  clientKind: "unknown",
+  proxyOutputStrict: false,
+  visibleToolCount: builtinToolNames.length + registry.definitions.length,
+  nativeVisibleToolCount: registry.definitions.length,
+  proxyCandidateToolCount: toolRegistry.definitions.length,
+  proxyToolNames: []
+})
+
 export const buildHulyContext = (
   config: {
     readonly transport: "stdio" | "http"
@@ -82,47 +105,61 @@ export const buildHulyContext = (
   },
   registry: ToolRegistry,
   toolScope: ToolScopeSummary,
-  runtimeConfig: SanitizedHulyRuntimeConfigContext
-): GetHulyContextResult => ({
-  package: {
-    name: NPM_PACKAGE_NAME,
-    version: nonEmptyOrDefault(VERSION, "0.0.0-dev")
-  },
-  transport: {
-    type: config.transport,
-    ...(config.transport === "http"
-      ? {
-        http: {
-          host: nonEmptyOrDefault(config.httpHost, "127.0.0.1"),
-          port: config.httpPort ?? DEFAULT_HTTP_PORT
-        }
-      }
-      : {})
-  },
-  huly: runtimeConfig.huly,
-  auth: runtimeConfig.auth,
-  configSources: runtimeConfig.configSources,
-  toolsets: {
-    filteringActive: toolScope.filteringActive,
-    requestedCategories: toolScope.requestedToolsets,
-    enabledCategories: toolScope.enabledToolsets,
-    ignoredCategories: toolScope.ignoredToolsets,
-    availableCategories: toolScope.availableCategories,
-    visibleRegisteredToolCount: Count.make(registry.definitions.length),
-    totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
-    builtinTools: builtinToolNames
-  },
-  toolScope: {
-    active: toolScope.filteringActive,
-    requestedToolsets: toolScope.requestedToolsets,
-    enabledToolsets: toolScope.enabledToolsets,
-    ignoredToolsets: toolScope.ignoredToolsets,
-    requestedTools: toolScope.requestedTools,
-    enabledTools: toolScope.enabledTools,
-    ignoredTools: toolScope.ignoredTools,
-    availableCategories: toolScope.availableCategories,
-    visibleRegisteredToolCount: Count.make(registry.definitions.length),
-    totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
-    builtinTools: builtinToolNames
+  runtimeConfig: SanitizedHulyRuntimeConfigContext,
+  exposureContext: ToolExposureContext = defaultToolExposureContext(registry)
+): GetHulyContextResult => {
+  const toolExposure = {
+    configuredMode: exposureContext.configuredMode,
+    resolvedMode: exposureContext.resolvedMode,
+    clientKind: exposureContext.clientKind,
+    proxyOutputStrict: exposureContext.proxyOutputStrict,
+    visibleToolCount: Count.make(exposureContext.visibleToolCount),
+    nativeVisibleToolCount: Count.make(exposureContext.nativeVisibleToolCount),
+    proxyCandidateToolCount: Count.make(exposureContext.proxyCandidateToolCount),
+    proxyToolNames: exposureContext.proxyToolNames
   }
-})
+  return {
+    package: {
+      name: NPM_PACKAGE_NAME,
+      version: nonEmptyOrDefault(VERSION, "0.0.0-dev")
+    },
+    transport: {
+      type: config.transport,
+      ...(config.transport === "http"
+        ? {
+          http: {
+            host: nonEmptyOrDefault(config.httpHost, "127.0.0.1"),
+            port: config.httpPort ?? DEFAULT_HTTP_PORT
+          }
+        }
+        : {})
+    },
+    huly: runtimeConfig.huly,
+    auth: runtimeConfig.auth,
+    configSources: runtimeConfig.configSources,
+    toolsets: {
+      filteringActive: toolScope.filteringActive,
+      requestedCategories: toolScope.requestedToolsets,
+      enabledCategories: toolScope.enabledToolsets,
+      ignoredCategories: toolScope.ignoredToolsets,
+      availableCategories: toolScope.availableCategories,
+      visibleRegisteredToolCount: Count.make(registry.definitions.length),
+      totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
+      builtinTools: builtinToolNames
+    },
+    toolScope: {
+      active: toolScope.filteringActive,
+      requestedToolsets: toolScope.requestedToolsets,
+      enabledToolsets: toolScope.enabledToolsets,
+      ignoredToolsets: toolScope.ignoredToolsets,
+      requestedTools: toolScope.requestedTools,
+      enabledTools: toolScope.enabledTools,
+      ignoredTools: toolScope.ignoredTools,
+      availableCategories: toolScope.availableCategories,
+      visibleRegisteredToolCount: Count.make(registry.definitions.length),
+      totalRegisteredToolCount: Count.make(toolScope.totalRegisteredToolCount),
+      builtinTools: builtinToolNames
+    },
+    toolExposure
+  }
+}

--- a/src/mcp/json-schema-refs.ts
+++ b/src/mcp/json-schema-refs.ts
@@ -27,3 +27,41 @@ export const collectJsonSchemaDefinitions = (value: unknown): Record<string, unk
 
 export const omitJsonSchemaDocumentMetadata = (schema: object): Record<string, unknown> =>
   Object.fromEntries(Object.entries(schema).filter(([key]) => key !== "$defs" && key !== "$schema"))
+
+const EFFECT_PSEUDO_ID_PREFIX = "/schemas/"
+
+const isCollidingSchemaId = (key: string, value: unknown): boolean =>
+  key === "$id" && typeof value === "string" && value.startsWith(EFFECT_PSEUDO_ID_PREFIX)
+
+/**
+ * Effect's JSON Schema encoder tags inline `unknown`/`any`/empty-struct nodes with a fixed
+ * `$id` such as `/schemas/unknown` or `/schemas/{}`. Those ids repeat across many tools, so a
+ * client that dereferences `$id`/`$ref` across the aggregated tool set sees a single id resolve
+ * to more than one schema and rejects the whole server (observed: opencode loads 0 tools). The
+ * ids are self-identifying inline nodes that nothing `$ref`s, so removing them clears the
+ * collision without changing validation.
+ */
+export const stripCollidingSchemaIds = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(stripCollidingSchemaIds)
+  if (!isJsonObject(value)) return value
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key, nested]) => !isCollidingSchemaId(key, nested))
+      .map(([key, nested]) => [key, stripCollidingSchemaIds(nested)])
+  )
+}
+
+export const stripCollidingSchemaIdsRecord = (record: Record<string, unknown>): Record<string, unknown> => {
+  const stripped = stripCollidingSchemaIds(record)
+  return isJsonObject(stripped) ? stripped : record
+}
+
+export const stripCollidingSchemaIdsProperties = (
+  properties: Record<string, object>
+): Record<string, object> =>
+  Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => {
+      const stripped = stripCollidingSchemaIds(value)
+      return [key, isJsonObject(stripped) ? stripped : value]
+    })
+  )

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -323,7 +323,12 @@ export const createMcpProtocolHandlers = (
       const hulyToolName = parseToolName(name)
       if (hulyToolName === undefined) return returnError(createUnknownToolError(name))
 
-      const tool = exposure.visibleNativeRegistry.tools.get(hulyToolName)
+      const nativeCallRegistry = exposure.visibleNativeRegistry.tools.has(hulyToolName)
+        ? exposure.visibleNativeRegistry
+        : exposure.context.resolvedMode === "proxy"
+        ? exposure.proxyCandidateRegistry
+        : exposure.visibleNativeRegistry
+      const tool = nativeCallRegistry.tools.get(hulyToolName)
       if (tool === undefined) return returnError(createUnknownToolError(name))
 
       if (isNoArgumentTool(tool) && !isEmptyArgumentsObject(args)) {
@@ -346,7 +351,7 @@ export const createMcpProtocolHandlers = (
         return returnError(errorResponse, editMode)
       }
 
-      const response = await exposure.visibleNativeRegistry.handleToolCall(
+      const response = await nativeCallRegistry.handleToolCall(
         hulyToolName,
         args,
         clients.hulyClient,

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -1,8 +1,10 @@
 import type {
+  CallToolRequestParams,
   CallToolResult,
   ListResourcesResult,
   ListResourceTemplatesResult,
   ListToolsResult,
+  ReadResourceRequestParams,
   ReadResourceResult
 } from "@modelcontextprotocol/sdk/types.js"
 import { Clock, Effect, Schema } from "effect"
@@ -42,6 +44,7 @@ import {
   createUnexpectedArgumentsError,
   isEmptyArgumentsObject,
   isNoArgumentTool,
+  parseToolName,
   requiresArgumentsObject
 } from "./tools/registry.js"
 
@@ -53,15 +56,13 @@ export interface ClientBundle {
 
 interface ToolCallRequest {
   readonly params: {
-    readonly name: string
+    readonly name: CallToolRequestParams["name"]
     readonly arguments?: unknown
   }
 }
 
 interface ResourceReadRequest {
-  readonly params: {
-    readonly uri: string
-  }
+  readonly params: ReadResourceRequestParams
 }
 
 type ListToolsProtocolResult = ListToolsResult
@@ -226,7 +227,7 @@ export const createMcpProtocolHandlers = (
       }
 
       if (name === VERSION_TOOL_NAME) {
-        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
+        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(VERSION_TOOL_NAME))
 
         const latest = await fetchLatestVersion()
         let versionResult: Schema.Schema.Type<typeof VersionToolResultSchema>
@@ -248,7 +249,9 @@ export const createMcpProtocolHandlers = (
       }
 
       if (name === GET_HULY_CONTEXT_TOOL_NAME) {
-        if (!isEmptyArgumentsObject(args)) return returnError(createUnexpectedArgumentsError(name))
+        if (!isEmptyArgumentsObject(args)) {
+          return returnError(createUnexpectedArgumentsError(GET_HULY_CONTEXT_TOOL_NAME))
+        }
 
         let context: GetHulyContextResult
         try {
@@ -317,18 +320,21 @@ export const createMcpProtocolHandlers = (
         return toMcpResponse(response)
       }
 
-      const tool = exposure.visibleNativeRegistry.tools.get(name)
+      const hulyToolName = parseToolName(name)
+      if (hulyToolName === undefined) return returnError(createUnknownToolError(name))
+
+      const tool = exposure.visibleNativeRegistry.tools.get(hulyToolName)
       if (tool === undefined) return returnError(createUnknownToolError(name))
 
       if (isNoArgumentTool(tool) && !isEmptyArgumentsObject(args)) {
-        return returnError(createUnexpectedArgumentsError(name))
+        return returnError(createUnexpectedArgumentsError(hulyToolName))
       }
 
       if (args === undefined && requiresArgumentsObject(tool)) {
-        return returnError(createMissingArgumentsError(name))
+        return returnError(createMissingArgumentsError(hulyToolName))
       }
 
-      const editMode = deriveEditMode(name, args)
+      const editMode = deriveEditMode(hulyToolName, args)
 
       let clients: ClientBundle
       try {
@@ -341,7 +347,7 @@ export const createMcpProtocolHandlers = (
       }
 
       const response = await exposure.visibleNativeRegistry.handleToolCall(
-        name,
+        hulyToolName,
         args,
         clients.hulyClient,
         clients.storageClient,
@@ -351,7 +357,7 @@ export const createMcpProtocolHandlers = (
       if (response === null) return returnError(createUnknownToolError(name), editMode)
 
       telemetry.toolCalled({
-        toolName: name,
+        toolName: hulyToolName,
         status: response.isError === true ? "error" : "success",
         errorTag: response._meta?.errorTag,
         durationMs,

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -5,14 +5,10 @@ import type {
   ListToolsResult,
   ReadResourceResult
 } from "@modelcontextprotocol/sdk/types.js"
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Chunk, Clock, Effect, Exit, Runtime, Schema } from "effect"
+import { Clock, Effect, Schema } from "effect"
 
-import { ConfigValidationError } from "../config/config.js"
 import { type GetHulyContextResult, GetHulyContextResultSchema } from "../domain/schemas/index.js"
-import type { ToolWarning } from "../domain/schemas/tool-warnings.js"
-import { HulyClient } from "../huly/client.js"
-import { Diagnostics, makeDiagnosticsScope } from "../huly/diagnostics.js"
+import type { HulyClient } from "../huly/client.js"
 import { HulyError } from "../huly/errors-base.js"
 import type { HulyStorageClient } from "../huly/storage.js"
 import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
@@ -23,14 +19,24 @@ import { createSuccessResponse, createUnknownToolError, mapDomainErrorToMcp, toM
 import {
   GET_HULY_CONTEXT_TOOL_NAME,
   getHulyContextToolDefinition,
+  type ToolExposureContext,
   VERSION_TOOL_NAME,
   versionToolDefinition,
   VersionToolResultSchema
 } from "./huly-context-tool.js"
-import { toClientCompatibleInputSchema } from "./input-schema-compat.js"
-import { listResources, listResourceTemplates, readHulyResource } from "./resources.js"
+import { createResourceProtocolHandlers } from "./protocol-resource-handlers.js"
+import {
+  defaultExposureOptions,
+  normalizeRegistries,
+  type ProtocolExposureOptions,
+  type ProtocolToolRegistries,
+  resolveProtocolExposure,
+  toListedHulyTool,
+  toListedTool
+} from "./protocol-tool-exposure.js"
+import { handleProxyToolCall, INVOKE_TOOL_TOOL_NAME, isProxyToolName, proxyToolDefinitions } from "./proxy-tools.js"
+import { listResourceTemplates } from "./resources.js"
 import type { ToolRegistry } from "./tools/index.js"
-import { resolveAnnotations } from "./tools/index.js"
 import {
   createMissingArgumentsError,
   createUnexpectedArgumentsError,
@@ -59,6 +65,8 @@ interface ResourceReadRequest {
 }
 
 type ListToolsProtocolResult = ListToolsResult
+
+type HulyContextProvider = (toolExposure: ToolExposureContext) => GetHulyContextResult
 
 export interface McpProtocolHandlers {
   readonly listTools: () => Promise<ListToolsProtocolResult>
@@ -90,20 +98,6 @@ const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
 
 const computeOutputBytes = (response: McpToolResponse): number =>
   response.content.reduce((sum, c) => sum + c.text.length, 0)
-
-const withResourceWarnings = (
-  result: ReadResourceResult,
-  warnings: ReadonlyArray<ToolWarning>
-): ReadResourceResult =>
-  warnings.length === 0
-    ? result
-    : {
-      ...result,
-      _meta: {
-        ...result._meta,
-        warnings
-      }
-    }
 
 export const deriveEditMode = (name: string, args: unknown): string | undefined => {
   if (name !== "edit_document" || args === undefined) return undefined
@@ -168,99 +162,25 @@ export const fetchLatestNpmVersion = async (fetchImpl: typeof fetch = fetch): Pr
   }
 }
 
-interface ProtocolObjectSchemaSource {
-  readonly type: "object"
-  readonly properties?: Record<string, unknown> | undefined
-  readonly required?: ReadonlyArray<string> | undefined
-  readonly [key: string]: unknown
-}
-
-type ProtocolObjectSchema = ListToolsResult["tools"][number]["inputSchema"]
-
-const isObjectPropertyEntry = (entry: [string, unknown]): entry is [string, object] => {
-  const value = entry[1]
-  return typeof value === "object" && value !== null
-}
-
-const objectProperties = (properties: Record<string, unknown> | undefined): Record<string, object> | undefined => {
-  if (properties === undefined) return undefined
-
-  return Object.entries(properties).filter(isObjectPropertyEntry).reduce<Record<string, object>>(
-    (acc, [key, value]) => ({ ...acc, [key]: value }),
-    {}
-  )
-}
-
-const toProtocolObjectSchema = (schema: ProtocolObjectSchemaSource): ProtocolObjectSchema => {
-  const { properties, required, ...rest } = schema
-  const convertedProperties = objectProperties(properties)
-  return {
-    ...rest,
-    type: "object",
-    ...(convertedProperties === undefined ? {} : { properties: convertedProperties }),
-    ...(required === undefined ? {} : { required: [...required] })
-  }
-}
-
-const createResourceClientResolutionError = (uri: string, _error: unknown): McpError =>
-  new McpError(
-    ErrorCode.InternalError,
-    `Failed to initialize Huly clients while reading resource "${uri}". Verify Huly URL, workspace, and authentication configuration.`
-  )
-
-const createResourceListClientResolutionError = (_error: unknown): McpError =>
-  new McpError(
-    ErrorCode.InternalError,
-    "Failed to initialize Huly clients while listing resources. Verify Huly URL, workspace, and authentication configuration."
-  )
-
-const isConfigValidationFailure = (error: unknown): boolean => {
-  if (error instanceof ConfigValidationError) return true
-  if (!Runtime.isFiberFailure(error)) return false
-
-  return Chunk.toArray(Cause.failures(error[Runtime.FiberFailureCauseId])).some(
-    (failure) => failure instanceof ConfigValidationError
-  )
-}
-
-const shouldReturnEmptyResourceListOnClientResolutionFailure = (
-  error: unknown,
-  _getHulyContext: () => GetHulyContextResult
-): boolean => isConfigValidationFailure(error)
-
-const resolveResourceClientsOrThrow = async (
-  resolveClients: () => Promise<ClientBundle>,
-  mapError: (error: unknown) => McpError
-): Promise<ClientBundle> => {
-  try {
-    return await resolveClients()
-  } catch (e) {
-    throw mapError(e)
-  }
-}
-
-const throwResourceReadError = (uri: string, cause: Cause.Cause<McpError>): never => {
-  const failures = Chunk.toArray(Cause.failures(cause))
-  const failure = failures[0]
-  if (failure instanceof McpError) throw failure
-  throw new McpError(ErrorCode.InternalError, `Failed to read Huly resource "${uri}"`)
-}
-
-const throwResourceListError = (cause: Cause.Cause<McpError>): never => {
-  const failures = Chunk.toArray(Cause.failures(cause))
-  const failure = failures[0]
-  if (failure instanceof McpError) throw failure
-  throw new McpError(ErrorCode.InternalError, "Failed to list Huly resources")
-}
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
 
 export const createMcpProtocolHandlers = (
   resolveClients: () => Promise<ClientBundle>,
   telemetry: TelemetryOperations,
-  registry: ToolRegistry,
-  getHulyContext: () => GetHulyContextResult,
+  registry: ToolRegistry | ProtocolToolRegistries,
+  getHulyContext: HulyContextProvider,
   clock: NowClock = liveNowClock,
-  fetchLatestVersion: () => Promise<string> = fetchLatestNpmVersion
+  fetchLatestVersion: () => Promise<string> = fetchLatestNpmVersion,
+  exposureOptions: Partial<ProtocolExposureOptions> = {}
 ): McpProtocolHandlers => {
+  const registries = normalizeRegistries(registry)
+  const defaults = defaultExposureOptions()
+  const protocolExposureOptions: ProtocolExposureOptions = {
+    exposureConfig: exposureOptions.exposureConfig ?? defaults.exposureConfig,
+    currentClientInfo: exposureOptions.currentClientInfo ?? defaults.currentClientInfo,
+    toolScopeFilteringActive: exposureOptions.toolScopeFilteringActive ?? defaults.toolScopeFilteringActive
+  }
   let inflight = 0
   const drainInflight = createDrainInflight(() => inflight, clock)
   const enter = () => {
@@ -272,22 +192,13 @@ export const createMcpProtocolHandlers = (
 
   const listTools = async (): Promise<ListToolsProtocolResult> => {
     telemetry.firstListTools()
+    const exposure = resolveProtocolExposure(registries, protocolExposureOptions)
     return {
       tools: [
-        versionToolDefinition,
-        getHulyContextToolDefinition,
-        ...registry.definitions.map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
-          outputSchema: tool.outputSchema,
-          annotations: resolveAnnotations(tool)
-        }))
-      ].map(tool => ({
-        ...tool,
-        inputSchema: toProtocolObjectSchema(tool.inputSchema),
-        outputSchema: toProtocolObjectSchema(tool.outputSchema)
-      }))
+        ...[versionToolDefinition, getHulyContextToolDefinition].map(toListedTool),
+        ...(exposure.context.resolvedMode === "proxy" ? proxyToolDefinitions.map(toListedHulyTool) : []),
+        ...exposure.visibleNativeRegistry.definitions.map(toListedHulyTool)
+      ]
     }
   }
 
@@ -295,6 +206,7 @@ export const createMcpProtocolHandlers = (
     enter()
     try {
       const { arguments: args, name } = request.params
+      const exposure = resolveProtocolExposure(registries, protocolExposureOptions)
 
       const start = clock.currentTimeMillis()
       const inputBytes = JSON.stringify(args ?? {}).length
@@ -340,7 +252,7 @@ export const createMcpProtocolHandlers = (
 
         let context: GetHulyContextResult
         try {
-          context = validateHulyContextResult(getHulyContext())
+          context = validateHulyContextResult(getHulyContext(exposure.context))
         } catch {
           return returnError(mapDomainErrorToMcp(new HulyError({ message: "Failed to build Huly context" })))
         }
@@ -357,7 +269,55 @@ export const createMcpProtocolHandlers = (
         return toMcpResponse(contextResponse)
       }
 
-      const tool = registry.tools.get(name)
+      if (isProxyToolName(name)) {
+        if (exposure.context.resolvedMode !== "proxy") return returnError(createUnknownToolError(name))
+
+        const editMode = name === INVOKE_TOOL_TOOL_NAME && isRecord(args) && typeof args.toolName === "string"
+          ? deriveEditMode(args.toolName, args.arguments)
+          : undefined
+
+        let clients: ClientBundle | undefined
+        if (name === INVOKE_TOOL_TOOL_NAME) {
+          try {
+            clients = await resolveClients()
+          } catch (e) {
+            const errorResponse = mapDomainErrorToMcp(
+              new HulyError({
+                message: `Failed to initialize Huly clients: ${e instanceof Error ? e.message : String(e)}`
+              })
+            )
+            return returnError(errorResponse, editMode)
+          }
+        }
+
+        const response = await handleProxyToolCall({
+          toolName: name,
+          args,
+          proxyCandidateRegistry: exposure.proxyCandidateRegistry,
+          ...(clients === undefined
+            ? {}
+            : {
+              clients: {
+                hulyClient: clients.hulyClient,
+                storageClient: clients.storageClient,
+                ...(clients.workspaceClient === undefined ? {} : { workspaceClient: clients.workspaceClient })
+              }
+            })
+        })
+        const durationMs = clock.currentTimeMillis() - start
+        telemetry.toolCalled({
+          toolName: name,
+          status: response.isError === true ? "error" : "success",
+          errorTag: response._meta?.errorTag,
+          durationMs,
+          inputBytes,
+          outputBytes: computeOutputBytes(response),
+          editMode
+        })
+        return toMcpResponse(response)
+      }
+
+      const tool = exposure.visibleNativeRegistry.tools.get(name)
       if (tool === undefined) return returnError(createUnknownToolError(name))
 
       if (isNoArgumentTool(tool) && !isEmptyArgumentsObject(args)) {
@@ -380,7 +340,7 @@ export const createMcpProtocolHandlers = (
         return returnError(errorResponse, editMode)
       }
 
-      const response = await registry.handleToolCall(
+      const response = await exposure.visibleNativeRegistry.handleToolCall(
         name,
         args,
         clients.hulyClient,
@@ -406,58 +366,14 @@ export const createMcpProtocolHandlers = (
     }
   }
 
-  const listResourcesHandler = async (): Promise<ListResourcesResult> => {
-    enter()
-    try {
-      let clients: ClientBundle
-      try {
-        clients = await resolveClients()
-      } catch (e) {
-        if (shouldReturnEmptyResourceListOnClientResolutionFailure(e, getHulyContext)) return { resources: [] }
-        throw createResourceListClientResolutionError(e)
-      }
-
-      const resourceList = await Effect.runPromiseExit(
-        listResources().pipe(
-          Effect.provideService(HulyClient, clients.hulyClient)
-        )
-      )
-      if (Exit.isSuccess(resourceList)) return resourceList.value
-      return throwResourceListError(resourceList.cause)
-    } finally {
-      leave()
-    }
-  }
-
-  const readResource = async (request: ResourceReadRequest): Promise<ReadResourceResult> => {
-    enter()
-    try {
-      const { uri } = request.params
-      const clients = await resolveResourceClientsOrThrow(
-        resolveClients,
-        error => createResourceClientResolutionError(uri, error)
-      )
-      const diagnosticsScope = await Effect.runPromise(makeDiagnosticsScope)
-      const resourceRead = await Effect.runPromiseExit(
-        readHulyResource(uri).pipe(
-          Effect.provideService(HulyClient, clients.hulyClient),
-          Effect.provideService(Diagnostics, diagnosticsScope.service)
-        )
-      )
-      const warnings = await Effect.runPromise(diagnosticsScope.drainWarnings)
-      if (Exit.isSuccess(resourceRead)) return withResourceWarnings(resourceRead.value, warnings)
-      return throwResourceReadError(uri, resourceRead.cause)
-    } finally {
-      leave()
-    }
-  }
+  const resourceHandlers = createResourceProtocolHandlers({ resolveClients, enter, leave })
 
   return {
     listTools,
     callTool,
-    listResources: listResourcesHandler,
+    listResources: resourceHandlers.listResources,
     listResourceTemplates,
-    readResource,
+    readResource: resourceHandlers.readResource,
     serverDiscover: () => ({
       resultType: "complete",
       supportedVersions: ["2026-07-28"],

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -192,8 +192,11 @@ export const createMcpProtocolHandlers = (
   }
 
   const listTools = async (): Promise<ListToolsProtocolResult> => {
-    telemetry.firstListTools()
     const exposure = resolveProtocolExposure(registries, protocolExposureOptions)
+    telemetry.firstListTools({
+      clientKind: exposure.context.clientKind,
+      resolvedMode: exposure.context.resolvedMode
+    })
     return {
       tools: [
         ...[versionToolDefinition, getHulyContextToolDefinition].map(toListedTool),
@@ -217,6 +220,8 @@ export const createMcpProtocolHandlers = (
         telemetry.toolCalled({
           toolName: name,
           status: "error",
+          clientKind: exposure.context.clientKind,
+          resolvedMode: exposure.context.resolvedMode,
           errorTag: errorResponse._meta?.errorTag,
           durationMs,
           inputBytes,
@@ -241,6 +246,8 @@ export const createMcpProtocolHandlers = (
         telemetry.toolCalled({
           toolName: name,
           status: "success",
+          clientKind: exposure.context.clientKind,
+          resolvedMode: exposure.context.resolvedMode,
           durationMs,
           inputBytes,
           outputBytes: computeOutputBytes(versionResponse)
@@ -265,6 +272,8 @@ export const createMcpProtocolHandlers = (
         telemetry.toolCalled({
           toolName: name,
           status: "success",
+          clientKind: exposure.context.clientKind,
+          resolvedMode: exposure.context.resolvedMode,
           durationMs,
           inputBytes,
           outputBytes: computeOutputBytes(contextResponse)
@@ -311,6 +320,8 @@ export const createMcpProtocolHandlers = (
         telemetry.toolCalled({
           toolName: name,
           status: response.isError === true ? "error" : "success",
+          clientKind: exposure.context.clientKind,
+          resolvedMode: exposure.context.resolvedMode,
           errorTag: response._meta?.errorTag,
           durationMs,
           inputBytes,
@@ -364,6 +375,8 @@ export const createMcpProtocolHandlers = (
       telemetry.toolCalled({
         toolName: hulyToolName,
         status: response.isError === true ? "error" : "success",
+        clientKind: exposure.context.clientKind,
+        resolvedMode: exposure.context.resolvedMode,
         errorTag: response._meta?.errorTag,
         durationMs,
         inputBytes,

--- a/src/mcp/protocol-resource-handlers.ts
+++ b/src/mcp/protocol-resource-handlers.ts
@@ -1,4 +1,8 @@
-import type { ListResourcesResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
+import type {
+  ListResourcesResult,
+  ReadResourceRequestParams,
+  ReadResourceResult
+} from "@modelcontextprotocol/sdk/types.js"
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Chunk, Effect, Exit, Runtime } from "effect"
 
@@ -17,9 +21,7 @@ interface ClientBundle {
 }
 
 interface ResourceReadRequest {
-  readonly params: {
-    readonly uri: string
-  }
+  readonly params: ReadResourceRequestParams
 }
 
 interface ResourceHandlerInput {

--- a/src/mcp/protocol-resource-handlers.ts
+++ b/src/mcp/protocol-resource-handlers.ts
@@ -1,0 +1,145 @@
+import type { ListResourcesResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Chunk, Effect, Exit, Runtime } from "effect"
+
+import { ConfigValidationError } from "../config/config.js"
+import type { ToolWarning } from "../domain/schemas/tool-warnings.js"
+import { HulyClient } from "../huly/client.js"
+import { Diagnostics, makeDiagnosticsScope } from "../huly/diagnostics.js"
+import type { HulyStorageClient } from "../huly/storage.js"
+import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
+import { listResources, readHulyResource } from "./resources.js"
+
+interface ClientBundle {
+  readonly hulyClient: HulyClient["Type"]
+  readonly storageClient: HulyStorageClient["Type"]
+  readonly workspaceClient?: WorkspaceClientOperations
+}
+
+interface ResourceReadRequest {
+  readonly params: {
+    readonly uri: string
+  }
+}
+
+interface ResourceHandlerInput {
+  readonly resolveClients: () => Promise<ClientBundle>
+  readonly enter: () => void
+  readonly leave: () => void
+}
+
+const withResourceWarnings = (
+  result: ReadResourceResult,
+  warnings: ReadonlyArray<ToolWarning>
+): ReadResourceResult =>
+  warnings.length === 0
+    ? result
+    : {
+      ...result,
+      _meta: {
+        ...result._meta,
+        warnings
+      }
+    }
+
+const createResourceClientResolutionError = (uri: string, _error: unknown): McpError =>
+  new McpError(
+    ErrorCode.InternalError,
+    `Failed to initialize Huly clients while reading resource "${uri}". Verify Huly URL, workspace, and authentication configuration.`
+  )
+
+const createResourceListClientResolutionError = (_error: unknown): McpError =>
+  new McpError(
+    ErrorCode.InternalError,
+    "Failed to initialize Huly clients while listing resources. Verify Huly URL, workspace, and authentication configuration."
+  )
+
+const isConfigValidationFailure = (error: unknown): boolean => {
+  if (error instanceof ConfigValidationError) return true
+  if (!Runtime.isFiberFailure(error)) return false
+
+  return Chunk.toArray(Cause.failures(error[Runtime.FiberFailureCauseId])).some(
+    (failure) => failure instanceof ConfigValidationError
+  )
+}
+
+const resolveResourceClientsOrThrow = async (
+  resolveClients: () => Promise<ClientBundle>,
+  mapError: (error: unknown) => McpError
+): Promise<ClientBundle> => {
+  try {
+    return await resolveClients()
+  } catch (e) {
+    throw mapError(e)
+  }
+}
+
+const throwResourceReadError = (uri: string, cause: Cause.Cause<McpError>): never => {
+  const failures = Chunk.toArray(Cause.failures(cause))
+  const failure = failures[0]
+  if (failure instanceof McpError) throw failure
+  throw new McpError(ErrorCode.InternalError, `Failed to read Huly resource "${uri}"`)
+}
+
+const throwResourceListError = (cause: Cause.Cause<McpError>): never => {
+  const failures = Chunk.toArray(Cause.failures(cause))
+  const failure = failures[0]
+  if (failure instanceof McpError) throw failure
+  throw new McpError(ErrorCode.InternalError, "Failed to list Huly resources")
+}
+
+export const createResourceProtocolHandlers = (input: ResourceHandlerInput): {
+  readonly listResources: () => Promise<ListResourcesResult>
+  readonly readResource: (request: ResourceReadRequest) => Promise<ReadResourceResult>
+} => {
+  const listResourcesHandler = async (): Promise<ListResourcesResult> => {
+    input.enter()
+    try {
+      let clients: ClientBundle
+      try {
+        clients = await input.resolveClients()
+      } catch (e) {
+        if (isConfigValidationFailure(e)) return { resources: [] }
+        throw createResourceListClientResolutionError(e)
+      }
+
+      const resourceList = await Effect.runPromiseExit(
+        listResources().pipe(
+          Effect.provideService(HulyClient, clients.hulyClient)
+        )
+      )
+      if (Exit.isSuccess(resourceList)) return resourceList.value
+      return throwResourceListError(resourceList.cause)
+    } finally {
+      input.leave()
+    }
+  }
+
+  const readResource = async (request: ResourceReadRequest): Promise<ReadResourceResult> => {
+    input.enter()
+    try {
+      const { uri } = request.params
+      const clients = await resolveResourceClientsOrThrow(
+        input.resolveClients,
+        error => createResourceClientResolutionError(uri, error)
+      )
+      const diagnosticsScope = await Effect.runPromise(makeDiagnosticsScope)
+      const resourceRead = await Effect.runPromiseExit(
+        readHulyResource(uri).pipe(
+          Effect.provideService(HulyClient, clients.hulyClient),
+          Effect.provideService(Diagnostics, diagnosticsScope.service)
+        )
+      )
+      const warnings = await Effect.runPromise(diagnosticsScope.drainWarnings)
+      if (Exit.isSuccess(resourceRead)) return withResourceWarnings(resourceRead.value, warnings)
+      return throwResourceReadError(uri, resourceRead.cause)
+    } finally {
+      input.leave()
+    }
+  }
+
+  return {
+    listResources: listResourcesHandler,
+    readResource
+  }
+}

--- a/src/mcp/protocol-tool-exposure.ts
+++ b/src/mcp/protocol-tool-exposure.ts
@@ -2,6 +2,7 @@ import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js"
 
 import type { ToolExposureContext } from "./huly-context-tool.js"
 import { toClientCompatibleInputSchema } from "./input-schema-compat.js"
+import { stripCollidingSchemaIdsProperties, stripCollidingSchemaIdsRecord } from "./json-schema-refs.js"
 import { PROXY_TOOL_NAMES, proxyToolDefinitions } from "./proxy-tools.js"
 import {
   classifyMcpClient,
@@ -80,9 +81,9 @@ const toProtocolObjectSchema = (schema: ProtocolObjectSchemaSource): ProtocolObj
   const { properties, required, ...rest } = schema
   const convertedProperties = objectProperties(properties)
   return {
-    ...rest,
+    ...stripCollidingSchemaIdsRecord(rest),
     type: "object",
-    ...(convertedProperties === undefined ? {} : { properties: convertedProperties }),
+    ...(convertedProperties === undefined ? {} : { properties: stripCollidingSchemaIdsProperties(convertedProperties) }),
     ...(required === undefined ? {} : { required: [...required] })
   }
 }

--- a/src/mcp/protocol-tool-exposure.ts
+++ b/src/mcp/protocol-tool-exposure.ts
@@ -11,6 +11,7 @@ import {
 } from "./tool-mode.js"
 import type { ToolRegistry } from "./tools/index.js"
 import { resolveAnnotations } from "./tools/index.js"
+import type { RegisteredTool, ToolDescription, ToolName } from "./tools/registry.js"
 
 export interface ProtocolToolRegistries {
   readonly fullRegistry: ToolRegistry
@@ -32,6 +33,7 @@ interface ResolvedProtocolExposure {
 
 interface ProtocolObjectSchemaSource {
   readonly type: "object"
+  // JSON Schema property names are string keys by protocol definition.
   readonly properties?: Record<string, unknown> | undefined
   readonly required?: ReadonlyArray<string> | undefined
   readonly [key: string]: unknown
@@ -41,8 +43,8 @@ type ProtocolObjectSchema = ListToolsResult["tools"][number]["inputSchema"]
 type ListedTool = ListToolsResult["tools"][number]
 
 interface ListedToolSource {
-  readonly name: string
-  readonly description: string
+  readonly name: ToolName
+  readonly description: ToolDescription
   readonly inputSchema: ProtocolObjectSchemaSource
   readonly outputSchema?: ProtocolObjectSchemaSource
   readonly annotations?: ListedTool["annotations"]
@@ -55,7 +57,7 @@ const DEFAULT_HANDLER_EXPOSURE_CONFIG: ToolExposureConfig = {
 }
 
 const emptyToolRegistry: ToolRegistry = {
-  tools: new Map(),
+  tools: new Map<ToolName, RegisteredTool>(),
   definitions: [],
   handleToolCall: async () => null
 }

--- a/src/mcp/protocol-tool-exposure.ts
+++ b/src/mcp/protocol-tool-exposure.ts
@@ -83,7 +83,9 @@ const toProtocolObjectSchema = (schema: ProtocolObjectSchemaSource): ProtocolObj
   return {
     ...stripCollidingSchemaIdsRecord(rest),
     type: "object",
-    ...(convertedProperties === undefined ? {} : { properties: stripCollidingSchemaIdsProperties(convertedProperties) }),
+    ...(convertedProperties === undefined
+      ? {}
+      : { properties: stripCollidingSchemaIdsProperties(convertedProperties) }),
     ...(required === undefined ? {} : { required: [...required] })
   }
 }

--- a/src/mcp/protocol-tool-exposure.ts
+++ b/src/mcp/protocol-tool-exposure.ts
@@ -1,0 +1,156 @@
+import type { ListToolsResult } from "@modelcontextprotocol/sdk/types.js"
+
+import type { ToolExposureContext } from "./huly-context-tool.js"
+import { toClientCompatibleInputSchema } from "./input-schema-compat.js"
+import { PROXY_TOOL_NAMES, proxyToolDefinitions } from "./proxy-tools.js"
+import {
+  classifyMcpClient,
+  type McpClientInfoLike,
+  resolveToolExposureMode,
+  type ToolExposureConfig
+} from "./tool-mode.js"
+import type { ToolRegistry } from "./tools/index.js"
+import { resolveAnnotations } from "./tools/index.js"
+
+export interface ProtocolToolRegistries {
+  readonly fullRegistry: ToolRegistry
+  readonly scopedNativeRegistry: ToolRegistry
+}
+
+// eslint-disable-next-line functional/no-mixed-types -- protocol exposure options bundle static config with a request-local client-info provider.
+export interface ProtocolExposureOptions {
+  readonly exposureConfig: ToolExposureConfig
+  readonly toolScopeFilteringActive: boolean
+  readonly currentClientInfo: () => McpClientInfoLike | undefined
+}
+
+interface ResolvedProtocolExposure {
+  readonly context: ToolExposureContext
+  readonly visibleNativeRegistry: ToolRegistry
+  readonly proxyCandidateRegistry: ToolRegistry
+}
+
+interface ProtocolObjectSchemaSource {
+  readonly type: "object"
+  readonly properties?: Record<string, unknown> | undefined
+  readonly required?: ReadonlyArray<string> | undefined
+  readonly [key: string]: unknown
+}
+
+type ProtocolObjectSchema = ListToolsResult["tools"][number]["inputSchema"]
+type ListedTool = ListToolsResult["tools"][number]
+
+interface ListedToolSource {
+  readonly name: string
+  readonly description: string
+  readonly inputSchema: ProtocolObjectSchemaSource
+  readonly outputSchema?: ProtocolObjectSchemaSource
+  readonly annotations?: ListedTool["annotations"]
+}
+
+const BUILTIN_TOOL_COUNT = 2
+const DEFAULT_HANDLER_EXPOSURE_CONFIG: ToolExposureConfig = {
+  configuredMode: "native",
+  proxyOutputStrict: false
+}
+
+const emptyToolRegistry: ToolRegistry = {
+  tools: new Map(),
+  definitions: [],
+  handleToolCall: async () => null
+}
+
+const isObjectPropertyEntry = (entry: [string, unknown]): entry is [string, object] => {
+  const value = entry[1]
+  return typeof value === "object" && value !== null
+}
+
+const objectProperties = (properties: Record<string, unknown> | undefined): Record<string, object> | undefined => {
+  if (properties === undefined) return undefined
+
+  return Object.entries(properties).filter(isObjectPropertyEntry).reduce<Record<string, object>>(
+    (acc, [key, value]) => ({ ...acc, [key]: value }),
+    {}
+  )
+}
+
+const toProtocolObjectSchema = (schema: ProtocolObjectSchemaSource): ProtocolObjectSchema => {
+  const { properties, required, ...rest } = schema
+  const convertedProperties = objectProperties(properties)
+  return {
+    ...rest,
+    type: "object",
+    ...(convertedProperties === undefined ? {} : { properties: convertedProperties }),
+    ...(required === undefined ? {} : { required: [...required] })
+  }
+}
+
+export const normalizeRegistries = (registry: ToolRegistry | ProtocolToolRegistries): ProtocolToolRegistries =>
+  "fullRegistry" in registry ? registry : { fullRegistry: registry, scopedNativeRegistry: registry }
+
+export const defaultExposureOptions = (): ProtocolExposureOptions => ({
+  exposureConfig: DEFAULT_HANDLER_EXPOSURE_CONFIG,
+  toolScopeFilteringActive: false,
+  currentClientInfo: () => undefined
+})
+
+const resolveProxyCandidateRegistry = (
+  registries: ProtocolToolRegistries,
+  options: ProtocolExposureOptions
+): ToolRegistry => {
+  if (!options.exposureConfig.proxyOutputStrict) return registries.fullRegistry
+  return options.toolScopeFilteringActive ? registries.scopedNativeRegistry : registries.fullRegistry
+}
+
+export const resolveProtocolExposure = (
+  registries: ProtocolToolRegistries,
+  options: ProtocolExposureOptions
+): ResolvedProtocolExposure => {
+  const clientInfo = options.currentClientInfo()
+  const clientKind = classifyMcpClient(clientInfo)
+  const resolvedMode = resolveToolExposureMode({
+    configuredMode: options.exposureConfig.configuredMode,
+    ...(clientInfo === undefined ? {} : { clientInfo })
+  })
+  const proxyCandidateRegistry = resolveProxyCandidateRegistry(registries, options)
+  const visibleNativeRegistry = resolvedMode === "native"
+    ? registries.scopedNativeRegistry
+    : options.toolScopeFilteringActive && !options.exposureConfig.proxyOutputStrict
+    ? registries.scopedNativeRegistry
+    : emptyToolRegistry
+  const visibleToolCount = BUILTIN_TOOL_COUNT
+    + visibleNativeRegistry.definitions.length
+    + (resolvedMode === "proxy" ? proxyToolDefinitions.length : 0)
+
+  return {
+    context: {
+      configuredMode: options.exposureConfig.configuredMode,
+      resolvedMode,
+      clientKind,
+      proxyOutputStrict: options.exposureConfig.proxyOutputStrict,
+      visibleToolCount,
+      nativeVisibleToolCount: visibleNativeRegistry.definitions.length,
+      proxyCandidateToolCount: proxyCandidateRegistry.definitions.length,
+      proxyToolNames: resolvedMode === "proxy" ? PROXY_TOOL_NAMES : []
+    },
+    visibleNativeRegistry,
+    proxyCandidateRegistry
+  }
+}
+
+export const toListedTool = (tool: ListedToolSource): ListedTool => ({
+  name: tool.name,
+  description: tool.description,
+  inputSchema: toProtocolObjectSchema(tool.inputSchema),
+  ...(tool.outputSchema === undefined ? {} : { outputSchema: toProtocolObjectSchema(tool.outputSchema) }),
+  ...(tool.annotations === undefined ? {} : { annotations: tool.annotations })
+})
+
+export const toListedHulyTool = (tool: ToolRegistry["definitions"][number]): ListedTool =>
+  toListedTool({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: toClientCompatibleInputSchema(tool.inputSchema),
+    outputSchema: tool.outputSchema,
+    annotations: resolveAnnotations(tool)
+  })

--- a/src/mcp/proxy-tool-catalog.ts
+++ b/src/mcp/proxy-tool-catalog.ts
@@ -1,0 +1,237 @@
+import { Either, Schema } from "effect"
+
+import { Count } from "../domain/schemas/index.js"
+import { createSuccessResponse, type McpToolResponse } from "./error-mapping.js"
+import type { ToolRegistry } from "./tools/index.js"
+import { makeToolCategory, makeToolDescription, ToolDescription } from "./tools/registry.js"
+import type { ToolCategory, ToolDefinition } from "./tools/registry.js"
+
+const SEARCH_DEFAULT_LIMIT = 10
+export const SEARCH_MAX_LIMIT = 50
+
+export const ToolSearchQuery = Schema.NonEmptyTrimmedString.pipe(Schema.brand("ToolSearchQuery"))
+export type ToolSearchQuery = Schema.Schema.Type<typeof ToolSearchQuery>
+
+export const ToolParameterName = Schema.NonEmptyTrimmedString.pipe(Schema.brand("ToolParameterName"))
+export type ToolParameterName = Schema.Schema.Type<typeof ToolParameterName>
+
+export const SearchToolLimit = Schema.Number.pipe(
+  Schema.int(),
+  Schema.positive(),
+  Schema.lessThanOrEqualTo(SEARCH_MAX_LIMIT),
+  Schema.brand("SearchToolLimit")
+)
+export type SearchToolLimit = Schema.Schema.Type<typeof SearchToolLimit>
+
+export const makeToolSearchQuery = (value: string): ToolSearchQuery => ToolSearchQuery.make(value)
+export const makeSearchToolLimit = (value: number): SearchToolLimit => SearchToolLimit.make(value)
+export const SEARCH_DEFAULT_LIMIT_VALUE = makeSearchToolLimit(SEARCH_DEFAULT_LIMIT)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const stringArray = (value: unknown): ReadonlyArray<string> =>
+  Array.isArray(value) && value.every((item) => typeof item === "string") ? value : []
+
+const parseToolParameterName = (value: string): ToolParameterName | undefined => {
+  const decoded = Schema.decodeUnknownEither(ToolParameterName)(value)
+  return Either.isRight(decoded) ? decoded.right : undefined
+}
+
+const schemaProperties = (schema: object): ReadonlyArray<ToolParameterName> => {
+  const properties = isRecord(schema) ? schema.properties : undefined
+  return isRecord(properties)
+    ? Object.keys(properties).map(parseToolParameterName).filter((name) => name !== undefined)
+    : []
+}
+
+const schemaRequired = (schema: unknown): ReadonlyArray<string> => isRecord(schema) ? stringArray(schema.required) : []
+
+export const toolParamSummary = (
+  tool: ToolDefinition
+): {
+  readonly requiredParams: ReadonlyArray<ToolParameterName>
+  readonly optionalParams: ReadonlyArray<ToolParameterName>
+} => {
+  const required = new Set(schemaRequired(tool.inputSchema))
+  const properties = schemaProperties(tool.inputSchema)
+  return {
+    requiredParams: properties.filter((name) => required.has(name)),
+    optionalParams: properties.filter((name) => !required.has(name))
+  }
+}
+
+const categoryDescriptionEntry = (category: string, description: string): readonly [ToolCategory, ToolDescription] => [
+  makeToolCategory(category),
+  makeToolDescription(description)
+]
+
+// Raw static category description declarations. The map constructor parses these
+// literals into branded category/description values before proxy results use them.
+const CATEGORY_DESCRIPTIONS: ReadonlyMap<ToolCategory, ToolDescription> = new Map([
+  categoryDescriptionEntry(
+    "projects",
+    "Project discovery, project metadata, project target preferences, and project-level settings."
+  ),
+  categoryDescriptionEntry(
+    "issues",
+    "Issue tracking: create, read, update, move, delete, relate, label, and organize Huly issues."
+  ),
+  categoryDescriptionEntry("labels", "Issue and workspace labels for classification and filtering."),
+  categoryDescriptionEntry("tags", "Generic tags that can be created, updated, attached, detached, and listed."),
+  categoryDescriptionEntry("tag-categories", "Tag category administration and tag grouping metadata."),
+  categoryDescriptionEntry(
+    "templates",
+    "Issue and message templates, including template fields, categories, children, and rendering."
+  ),
+  categoryDescriptionEntry("comments", "Comments and discussion content attached to Huly objects."),
+  categoryDescriptionEntry(
+    "collaborators",
+    "Collaborator discovery and participation metadata for documents and other shared objects."
+  ),
+  categoryDescriptionEntry("milestones", "Issue milestone lifecycle and milestone assignment."),
+  categoryDescriptionEntry(
+    "documents",
+    "Teamspaces and documents: create, read, edit, snapshot, inline comment, and delete document content."
+  ),
+  categoryDescriptionEntry(
+    "drive",
+    "Drive spaces, folders, files, versions, comments, and drive membership administration."
+  ),
+  categoryDescriptionEntry(
+    "associations",
+    "Generic associations and relations between Huly documents, issues, cards, and raw objects."
+  ),
+  categoryDescriptionEntry(
+    "inventory",
+    "Inventory products, categories, variants, product media, comments, and attachments."
+  ),
+  categoryDescriptionEntry(
+    "spaces",
+    "Generic Huly spaces, space types, space permissions, members, owners, roles, and preferences."
+  ),
+  categoryDescriptionEntry(
+    "sdk-discovery",
+    "SDK and model discovery helpers for Huly platform classes, attributes, mixins, and enums."
+  ),
+  categoryDescriptionEntry("storage", "Storage diagnostics and storage-backed object helpers."),
+  categoryDescriptionEntry(
+    "attachments",
+    "Issue, document, and generic attachment upload, download, pinning, updating, and deletion."
+  ),
+  categoryDescriptionEntry(
+    "contacts",
+    "People, employees, organizations, contact channels, channel providers, and contact ownership."
+  ),
+  categoryDescriptionEntry(
+    "channels",
+    "Messaging: channels, direct messages, group messages, thread replies, reactions, and saved messages."
+  ),
+  categoryDescriptionEntry(
+    "boards",
+    "Board administration, board labels, board cards, board views, menus, and archive workflows."
+  ),
+  categoryDescriptionEntry("views", "Saved and filtered views across boards and other view-capable Huly modules."),
+  categoryDescriptionEntry("cards", "Generic cards, card spaces, card relations, master tags, and card metadata."),
+  categoryDescriptionEntry("leads", "CRM funnels and leads discovery."),
+  categoryDescriptionEntry(
+    "recruiting",
+    "Recruiting vacancies, applicants, reviews, opinions, candidate skills, and recruiting media."
+  ),
+  categoryDescriptionEntry("custom-fields", "Custom field definitions and custom field values on Huly documents."),
+  categoryDescriptionEntry(
+    "calendar",
+    "Calendar events, recurring events, schedules, meeting rooms, and availability."
+  ),
+  categoryDescriptionEntry(
+    "time tracking",
+    "Time tracking, work logs, time reports, detailed time summaries, and estimates."
+  ),
+  categoryDescriptionEntry("planner", "Planner todos, schedules, work slots, priorities, and completion workflows."),
+  categoryDescriptionEntry(
+    "preferences",
+    "User and project preferences, notification preferences, and preference diagnostics."
+  ),
+  categoryDescriptionEntry(
+    "approvals",
+    "Approval request lifecycle, approval comments, approve/reject/cancel actions, and approval status."
+  ),
+  categoryDescriptionEntry("search", "Workspace-wide full-text and structured search across Huly content."),
+  categoryDescriptionEntry("activity", "Activity timelines and activity messages for Huly objects."),
+  categoryDescriptionEntry(
+    "notifications",
+    "Inbox notifications, notification counts, read state, and notification actions."
+  ),
+  categoryDescriptionEntry("user-statuses", "User status and online/presence status discovery."),
+  categoryDescriptionEntry("virtual-office", "Virtual office rooms, members, presence, and office room state."),
+  categoryDescriptionEntry(
+    "processes",
+    "Huly process definitions, executions, process cards, and process state transitions."
+  ),
+  categoryDescriptionEntry(
+    "workspace",
+    "Workspace metadata, members, settings, access links, invites, and administrative context."
+  ),
+  categoryDescriptionEntry(
+    "task-management",
+    "Task management project types, task types, issue statuses, workflow references, and process setup."
+  ),
+  categoryDescriptionEntry(
+    "test-management",
+    "Test management projects, suites, cases, plans, runs, results, and plan execution."
+  )
+])
+
+const categoryDescription = (category: ToolCategory): ToolDescription =>
+  CATEGORY_DESCRIPTIONS.get(category) ?? ToolDescription.make(`Huly ${category} tools.`)
+
+export const listCategories = (registry: ToolRegistry): McpToolResponse => {
+  const counts = new Map<ToolCategory, number>()
+  for (const tool of registry.definitions) {
+    counts.set(tool.category, (counts.get(tool.category) ?? 0) + 1)
+  }
+  return createSuccessResponse({
+    categories: [...counts.entries()].map(([name, toolCount]) => ({
+      name,
+      description: categoryDescription(name),
+      toolCount: Count.make(toolCount)
+    }))
+  })
+}
+
+const queryTokens = (query: string): ReadonlyArray<string> =>
+  query.toLowerCase().split(/[^a-z0-9]+/u).filter((token) => token !== "")
+
+const tokenHitCount = (tokens: ReadonlyArray<string>, text: string): number => {
+  const lower = text.toLowerCase()
+  return tokens.filter((token) => lower.includes(token)).length
+}
+
+const toolScore = (tool: ToolDefinition, tokens: ReadonlyArray<string>, normalizedQuery: string): number => {
+  const params = toolParamSummary(tool)
+  const paramText = [...params.requiredParams, ...params.optionalParams].join(" ")
+  const categoryText = `${tool.category} ${categoryDescription(tool.category)}`
+  const exactScore = tool.name.toLowerCase() === normalizedQuery ? 10_000 : 0
+  return exactScore
+    + tokenHitCount(tokens, tool.name) * 1_000
+    + tokenHitCount(tokens, categoryText) * 100
+    + tokenHitCount(tokens, tool.description) * 10
+    + tokenHitCount(tokens, paramText)
+}
+
+export const searchToolDefinitions = (
+  registry: ToolRegistry,
+  query: ToolSearchQuery,
+  limit: SearchToolLimit = SEARCH_DEFAULT_LIMIT_VALUE
+): ReadonlyArray<ToolDefinition> => {
+  const normalizedQuery = query.trim().toLowerCase()
+  const tokens = queryTokens(normalizedQuery)
+  if (tokens.length === 0) return []
+
+  return registry.definitions
+    .map((tool, index) => ({ index, score: toolScore(tool, tokens, normalizedQuery), tool }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, limit)
+    .map((match) => match.tool)
+}

--- a/src/mcp/proxy-tools.ts
+++ b/src/mcp/proxy-tools.ts
@@ -232,7 +232,50 @@ const toolParamSummary = (
   }
 }
 
-const categoryDescription = (category: string): string => `Huly ${category} tools.`
+const CATEGORY_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  projects: "Project discovery, project metadata, project target preferences, and project-level settings.",
+  issues: "Issue tracking: create, read, update, move, delete, relate, label, and organize Huly issues.",
+  labels: "Issue and workspace labels for classification and filtering.",
+  tags: "Generic tags that can be created, updated, attached, detached, and listed.",
+  "tag-categories": "Tag category administration and tag grouping metadata.",
+  templates: "Issue and message templates, including template fields, categories, children, and rendering.",
+  comments: "Comments and discussion content attached to Huly objects.",
+  collaborators: "Collaborator discovery and participation metadata for documents and other shared objects.",
+  milestones: "Issue milestone lifecycle and milestone assignment.",
+  documents: "Teamspaces and documents: create, read, edit, snapshot, inline comment, and delete document content.",
+  drive: "Drive spaces, folders, files, versions, comments, and drive membership administration.",
+  associations: "Generic associations and relations between Huly documents, issues, cards, and raw objects.",
+  inventory: "Inventory products, categories, variants, product media, comments, and attachments.",
+  spaces: "Generic Huly spaces, space types, space permissions, members, owners, roles, and preferences.",
+  "sdk-discovery": "SDK and model discovery helpers for Huly platform classes, attributes, mixins, and enums.",
+  storage: "Storage diagnostics and storage-backed object helpers.",
+  attachments: "Issue, document, and generic attachment upload, download, pinning, updating, and deletion.",
+  contacts: "People, employees, organizations, contact channels, channel providers, and contact ownership.",
+  channels: "Messaging: channels, direct messages, group messages, thread replies, reactions, and saved messages.",
+  boards: "Board administration, board labels, board cards, board views, menus, and archive workflows.",
+  views: "Saved and filtered views across boards and other view-capable Huly modules.",
+  cards: "Generic cards, card spaces, card relations, master tags, and card metadata.",
+  leads: "CRM funnels and leads discovery.",
+  recruiting: "Recruiting vacancies, applicants, reviews, opinions, candidate skills, and recruiting media.",
+  "custom-fields": "Custom field definitions and custom field values on Huly documents.",
+  calendar: "Calendar events, recurring events, schedules, meeting rooms, and availability.",
+  "time tracking": "Time tracking, work logs, time reports, detailed time summaries, and estimates.",
+  planner: "Planner todos, schedules, work slots, priorities, and completion workflows.",
+  preferences: "User and project preferences, notification preferences, and preference diagnostics.",
+  approvals: "Approval request lifecycle, approval comments, approve/reject/cancel actions, and approval status.",
+  search: "Workspace-wide full-text and structured search across Huly content.",
+  activity: "Activity timelines and activity messages for Huly objects.",
+  notifications: "Inbox notifications, notification counts, read state, and notification actions.",
+  "user-statuses": "User status and online/presence status discovery.",
+  "virtual-office": "Virtual office rooms, members, presence, and office room state.",
+  processes: "Huly process definitions, executions, process cards, and process state transitions.",
+  workspace: "Workspace metadata, members, settings, access links, invites, and administrative context.",
+  "task-management":
+    "Task management project types, task types, issue statuses, workflow references, and process setup.",
+  "test-management": "Test management projects, suites, cases, plans, runs, results, and plan execution."
+}
+
+const categoryDescription = (category: string): string => CATEGORY_DESCRIPTIONS[category] ?? `Huly ${category} tools.`
 
 const listCategories = (registry: ToolRegistry): McpToolResponse => {
   const counts = new Map<string, number>()
@@ -259,10 +302,11 @@ const tokenHitCount = (tokens: ReadonlyArray<string>, text: string): number => {
 const toolScore = (tool: ToolDefinition, tokens: ReadonlyArray<string>, normalizedQuery: string): number => {
   const params = toolParamSummary(tool)
   const paramText = [...params.requiredParams, ...params.optionalParams].join(" ")
+  const categoryText = `${tool.category} ${categoryDescription(tool.category)}`
   const exactScore = tool.name.toLowerCase() === normalizedQuery ? 10_000 : 0
   return exactScore
     + tokenHitCount(tokens, tool.name) * 1_000
-    + tokenHitCount(tokens, tool.category) * 100
+    + tokenHitCount(tokens, categoryText) * 100
     + tokenHitCount(tokens, tool.description) * 10
     + tokenHitCount(tokens, paramText)
 }

--- a/src/mcp/proxy-tools.ts
+++ b/src/mcp/proxy-tools.ts
@@ -11,78 +11,91 @@ import {
   mapParseErrorToMcp,
   type McpToolResponse
 } from "./error-mapping.js"
+import {
+  listCategories,
+  SEARCH_DEFAULT_LIMIT_VALUE,
+  SEARCH_MAX_LIMIT,
+  searchToolDefinitions,
+  SearchToolLimit,
+  ToolParameterName,
+  toolParamSummary,
+  ToolSearchQuery
+} from "./proxy-tool-catalog.js"
 import { createToolOutputSchema } from "./tool-output-schema.js"
 import type { ToolRegistry } from "./tools/index.js"
 import { resolveAnnotations } from "./tools/index.js"
-import type { ToolDefinition } from "./tools/registry.js"
+import {
+  createToolDefinition,
+  makeToolCategory,
+  ToolCategory,
+  type ToolDefinition,
+  ToolDescription,
+  ToolName
+} from "./tools/registry.js"
 
-const LIST_TOOL_CATEGORIES_TOOL_NAME = "list_tool_categories"
-const SEARCH_TOOLS_TOOL_NAME = "search_tools"
-const GET_TOOL_SCHEMA_TOOL_NAME = "get_tool_schema"
-export const INVOKE_TOOL_TOOL_NAME = "invoke_tool"
+export { makeSearchToolLimit, makeToolSearchQuery, searchToolDefinitions } from "./proxy-tool-catalog.js"
 
-export const PROXY_TOOL_NAMES: ReadonlyArray<string> = [
+const LIST_TOOL_CATEGORIES_TOOL_NAME = ToolName.make("list_tool_categories")
+const SEARCH_TOOLS_TOOL_NAME = ToolName.make("search_tools")
+const GET_TOOL_SCHEMA_TOOL_NAME = ToolName.make("get_tool_schema")
+export const INVOKE_TOOL_TOOL_NAME = ToolName.make("invoke_tool")
+const PROXY_TOOL_CATEGORY = makeToolCategory("proxy")
+
+export const PROXY_TOOL_NAMES: ReadonlyArray<ToolName> = [
   LIST_TOOL_CATEGORIES_TOOL_NAME,
   SEARCH_TOOLS_TOOL_NAME,
   GET_TOOL_SCHEMA_TOOL_NAME,
   INVOKE_TOOL_TOOL_NAME
 ]
 
-const SEARCH_DEFAULT_LIMIT = 10
-const SEARCH_MAX_LIMIT = 50
-
 const EmptyProxyParamsSchema = Schema.Record({ key: Schema.String, value: Schema.Never })
-const NonEmptyToolString = Schema.NonEmptyTrimmedString
 const SearchToolsParamsSchema = Schema.Struct({
-  query: NonEmptyToolString,
-  limit: Schema.optionalWith(
-    Schema.Number.pipe(Schema.int(), Schema.positive(), Schema.lessThanOrEqualTo(SEARCH_MAX_LIMIT)),
-    { exact: true }
-  )
+  query: ToolSearchQuery,
+  limit: Schema.optionalWith(SearchToolLimit, { exact: true })
 })
 const ToolNameParamsSchema = Schema.Struct({
-  toolName: NonEmptyToolString
+  toolName: ToolName
 })
 const InvokeToolParamsSchema = Schema.Struct({
-  toolName: NonEmptyToolString,
+  toolName: ToolName,
   arguments: Schema.optionalWith(Schema.Unknown, { exact: true })
 })
 
 const ProxyToolCategorySchema = Schema.Struct({
-  name: NonEmptyToolString,
-  description: NonEmptyToolString,
+  name: ToolCategory,
+  description: ToolDescription,
   toolCount: Count
 })
 const ListToolCategoriesResultSchema = Schema.Struct({
   categories: Schema.Array(ProxyToolCategorySchema)
 })
 const ToolSearchMatchSchema = Schema.Struct({
-  name: NonEmptyToolString,
-  category: NonEmptyToolString,
-  description: NonEmptyToolString,
-  requiredParams: Schema.Array(NonEmptyToolString),
-  optionalParams: Schema.Array(NonEmptyToolString)
+  name: ToolName,
+  category: ToolCategory,
+  description: ToolDescription,
+  requiredParams: Schema.Array(ToolParameterName),
+  optionalParams: Schema.Array(ToolParameterName)
 })
 const SearchToolsResultSchema = Schema.Struct({
   matches: Schema.Array(ToolSearchMatchSchema)
 })
 const ToolAnnotationsSchema = Schema.Struct({
-  title: Schema.optionalWith(NonEmptyToolString, { exact: true }),
+  title: Schema.optionalWith(Schema.NonEmptyTrimmedString, { exact: true }),
   readOnlyHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
   destructiveHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
   idempotentHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
   openWorldHint: Schema.optionalWith(Schema.Boolean, { exact: true })
 })
 const GetToolSchemaResultSchema = Schema.Struct({
-  name: NonEmptyToolString,
-  category: NonEmptyToolString,
-  description: NonEmptyToolString,
+  name: ToolName,
+  category: ToolCategory,
+  description: ToolDescription,
   inputSchema: Schema.Unknown,
   outputSchema: Schema.Unknown,
   annotations: ToolAnnotationsSchema
 })
 const InvokeToolResultSchema = Schema.Struct({
-  toolName: NonEmptyToolString,
+  toolName: ToolName,
   result: Schema.Unknown,
   warnings: Schema.optionalWith(Schema.Array(Schema.Unknown), { exact: true })
 })
@@ -150,40 +163,40 @@ const readOnlyProxyAnnotations = (title: string): ToolAnnotations => ({
 })
 
 export const proxyToolDefinitions: ReadonlyArray<ToolDefinition> = [
-  {
+  createToolDefinition({
     name: LIST_TOOL_CATEGORIES_TOOL_NAME,
     description:
       "Lists Huly tool categories available through this proxy. Use this first when you need a broad map of capabilities before searching for a specific Huly tool.",
     inputSchema: emptyInputSchema,
     outputSchema: createToolOutputSchema(ListToolCategoriesResultSchema),
-    category: "proxy",
+    category: PROXY_TOOL_CATEGORY,
     annotations: readOnlyProxyAnnotations("List Tool Categories")
-  },
-  {
+  }),
+  createToolDefinition({
     name: SEARCH_TOOLS_TOOL_NAME,
     description:
       "Searches the current proxy-visible Huly tool catalog by tool name, category, description, and parameter names. Returns exact tool names plus required and optional parameter names for single-call follow-up with get_tool_schema or invoke_tool.",
     inputSchema: searchToolsInputSchema,
     outputSchema: createToolOutputSchema(SearchToolsResultSchema),
-    category: "proxy",
+    category: PROXY_TOOL_CATEGORY,
     annotations: readOnlyProxyAnnotations("Search Tools")
-  },
-  {
+  }),
+  createToolDefinition({
     name: GET_TOOL_SCHEMA_TOOL_NAME,
     description:
       "Returns the exact input and output schema for one proxy-visible Huly tool. Use this before invoke_tool when you are not certain about required argument names or result shape.",
     inputSchema: toolNameInputSchema,
     outputSchema: createToolOutputSchema(GetToolSchemaResultSchema),
-    category: "proxy",
+    category: PROXY_TOOL_CATEGORY,
     annotations: readOnlyProxyAnnotations("Get Tool Schema")
-  },
-  {
+  }),
+  createToolDefinition({
     name: INVOKE_TOOL_TOOL_NAME,
     description:
       "Invokes one proxy-visible Huly tool by exact name with its arguments. This tool can call read or write Huly operations; check get_tool_schema and the target tool annotations when safety matters.",
     inputSchema: invokeToolInputSchema,
     outputSchema: createToolOutputSchema(InvokeToolResultSchema),
-    category: "proxy",
+    category: PROXY_TOOL_CATEGORY,
     annotations: {
       title: "Invoke Tool",
       readOnlyHint: false,
@@ -191,15 +204,16 @@ export const proxyToolDefinitions: ReadonlyArray<ToolDefinition> = [
       idempotentHint: false,
       openWorldHint: false
     }
-  }
+  })
 ]
 
-export const isProxyToolName = (name: string): boolean => PROXY_TOOL_NAMES.includes(name)
+export const isProxyToolName = (name: string): name is ToolName =>
+  PROXY_TOOL_NAMES.some((toolName) => toolName === name)
 
 const decodeOrError = <A, I>(
   schema: Schema.Schema<A, I, never>,
   input: unknown,
-  toolName: string
+  toolName: ToolName
 ): A | McpToolResponse => {
   const decoded = Schema.decodeUnknownEither(schema)(input ?? {})
   if (Either.isRight(decoded)) return decoded.right
@@ -211,127 +225,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isMcpToolResponse = (value: unknown): value is McpToolResponse => isRecord(value) && Array.isArray(value.content)
 
-const stringArray = (value: unknown): ReadonlyArray<string> =>
-  Array.isArray(value) && value.every((item) => typeof item === "string") ? value : []
-
-const schemaProperties = (schema: object): ReadonlyArray<string> => {
-  const properties = isRecord(schema) ? schema.properties : undefined
-  return isRecord(properties) ? Object.keys(properties) : []
-}
-
-const schemaRequired = (schema: unknown): ReadonlyArray<string> => isRecord(schema) ? stringArray(schema.required) : []
-
-const toolParamSummary = (
-  tool: ToolDefinition
-): { readonly requiredParams: ReadonlyArray<string>; readonly optionalParams: ReadonlyArray<string> } => {
-  const required = new Set(schemaRequired(tool.inputSchema))
-  const properties = schemaProperties(tool.inputSchema)
-  return {
-    requiredParams: properties.filter((name) => required.has(name)),
-    optionalParams: properties.filter((name) => !required.has(name))
-  }
-}
-
-const CATEGORY_DESCRIPTIONS: Readonly<Record<string, string>> = {
-  projects: "Project discovery, project metadata, project target preferences, and project-level settings.",
-  issues: "Issue tracking: create, read, update, move, delete, relate, label, and organize Huly issues.",
-  labels: "Issue and workspace labels for classification and filtering.",
-  tags: "Generic tags that can be created, updated, attached, detached, and listed.",
-  "tag-categories": "Tag category administration and tag grouping metadata.",
-  templates: "Issue and message templates, including template fields, categories, children, and rendering.",
-  comments: "Comments and discussion content attached to Huly objects.",
-  collaborators: "Collaborator discovery and participation metadata for documents and other shared objects.",
-  milestones: "Issue milestone lifecycle and milestone assignment.",
-  documents: "Teamspaces and documents: create, read, edit, snapshot, inline comment, and delete document content.",
-  drive: "Drive spaces, folders, files, versions, comments, and drive membership administration.",
-  associations: "Generic associations and relations between Huly documents, issues, cards, and raw objects.",
-  inventory: "Inventory products, categories, variants, product media, comments, and attachments.",
-  spaces: "Generic Huly spaces, space types, space permissions, members, owners, roles, and preferences.",
-  "sdk-discovery": "SDK and model discovery helpers for Huly platform classes, attributes, mixins, and enums.",
-  storage: "Storage diagnostics and storage-backed object helpers.",
-  attachments: "Issue, document, and generic attachment upload, download, pinning, updating, and deletion.",
-  contacts: "People, employees, organizations, contact channels, channel providers, and contact ownership.",
-  channels: "Messaging: channels, direct messages, group messages, thread replies, reactions, and saved messages.",
-  boards: "Board administration, board labels, board cards, board views, menus, and archive workflows.",
-  views: "Saved and filtered views across boards and other view-capable Huly modules.",
-  cards: "Generic cards, card spaces, card relations, master tags, and card metadata.",
-  leads: "CRM funnels and leads discovery.",
-  recruiting: "Recruiting vacancies, applicants, reviews, opinions, candidate skills, and recruiting media.",
-  "custom-fields": "Custom field definitions and custom field values on Huly documents.",
-  calendar: "Calendar events, recurring events, schedules, meeting rooms, and availability.",
-  "time tracking": "Time tracking, work logs, time reports, detailed time summaries, and estimates.",
-  planner: "Planner todos, schedules, work slots, priorities, and completion workflows.",
-  preferences: "User and project preferences, notification preferences, and preference diagnostics.",
-  approvals: "Approval request lifecycle, approval comments, approve/reject/cancel actions, and approval status.",
-  search: "Workspace-wide full-text and structured search across Huly content.",
-  activity: "Activity timelines and activity messages for Huly objects.",
-  notifications: "Inbox notifications, notification counts, read state, and notification actions.",
-  "user-statuses": "User status and online/presence status discovery.",
-  "virtual-office": "Virtual office rooms, members, presence, and office room state.",
-  processes: "Huly process definitions, executions, process cards, and process state transitions.",
-  workspace: "Workspace metadata, members, settings, access links, invites, and administrative context.",
-  "task-management":
-    "Task management project types, task types, issue statuses, workflow references, and process setup.",
-  "test-management": "Test management projects, suites, cases, plans, runs, results, and plan execution."
-}
-
-const categoryDescription = (category: string): string => CATEGORY_DESCRIPTIONS[category] ?? `Huly ${category} tools.`
-
-const listCategories = (registry: ToolRegistry): McpToolResponse => {
-  const counts = new Map<string, number>()
-  for (const tool of registry.definitions) {
-    counts.set(tool.category, (counts.get(tool.category) ?? 0) + 1)
-  }
-  return createSuccessResponse({
-    categories: [...counts.entries()].map(([name, toolCount]) => ({
-      name,
-      description: categoryDescription(name),
-      toolCount: Count.make(toolCount)
-    }))
-  })
-}
-
-const queryTokens = (query: string): ReadonlyArray<string> =>
-  query.toLowerCase().split(/[^a-z0-9]+/u).filter((token) => token !== "")
-
-const tokenHitCount = (tokens: ReadonlyArray<string>, text: string): number => {
-  const lower = text.toLowerCase()
-  return tokens.filter((token) => lower.includes(token)).length
-}
-
-const toolScore = (tool: ToolDefinition, tokens: ReadonlyArray<string>, normalizedQuery: string): number => {
-  const params = toolParamSummary(tool)
-  const paramText = [...params.requiredParams, ...params.optionalParams].join(" ")
-  const categoryText = `${tool.category} ${categoryDescription(tool.category)}`
-  const exactScore = tool.name.toLowerCase() === normalizedQuery ? 10_000 : 0
-  return exactScore
-    + tokenHitCount(tokens, tool.name) * 1_000
-    + tokenHitCount(tokens, categoryText) * 100
-    + tokenHitCount(tokens, tool.description) * 10
-    + tokenHitCount(tokens, paramText)
-}
-
-export const searchToolDefinitions = (
-  registry: ToolRegistry,
-  query: string,
-  limit: number = SEARCH_DEFAULT_LIMIT
-): ReadonlyArray<ToolDefinition> => {
-  const normalizedQuery = query.trim().toLowerCase()
-  const tokens = queryTokens(normalizedQuery)
-  if (tokens.length === 0) return []
-
-  return registry.definitions
-    .map((tool, index) => ({ index, score: toolScore(tool, tokens, normalizedQuery), tool }))
-    .filter((match) => match.score > 0)
-    .sort((a, b) => b.score - a.score || a.index - b.index)
-    .slice(0, limit)
-    .map((match) => match.tool)
-}
-
 const searchTools = (registry: ToolRegistry, args: unknown): McpToolResponse => {
   const params = decodeOrError(SearchToolsParamsSchema, args, SEARCH_TOOLS_TOOL_NAME)
   if (isMcpToolResponse(params)) return params
-  const limit = Math.min(params.limit ?? SEARCH_DEFAULT_LIMIT, SEARCH_MAX_LIMIT)
+  const limit = params.limit ?? SEARCH_DEFAULT_LIMIT_VALUE
   const matches = searchToolDefinitions(registry, params.query, limit).map((tool) => {
     const paramSummary = toolParamSummary(tool)
     return {
@@ -399,7 +296,7 @@ const invokeTool = async (
 }
 
 interface ProxyToolCallInput {
-  readonly toolName: string
+  readonly toolName: ToolName
   readonly args: unknown
   readonly proxyCandidateRegistry: ToolRegistry
   readonly clients?: InvokeToolClients

--- a/src/mcp/proxy-tools.ts
+++ b/src/mcp/proxy-tools.ts
@@ -1,0 +1,383 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
+import { Either, Schema } from "effect"
+
+import { Count } from "../domain/schemas/index.js"
+import type { HulyStorageClient } from "../huly/storage.js"
+import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
+import {
+  createInvalidParamsError,
+  createSuccessResponse,
+  createUnknownToolError,
+  mapParseErrorToMcp,
+  type McpToolResponse
+} from "./error-mapping.js"
+import { createToolOutputSchema } from "./tool-output-schema.js"
+import type { ToolRegistry } from "./tools/index.js"
+import { resolveAnnotations } from "./tools/index.js"
+import type { ToolDefinition } from "./tools/registry.js"
+
+const LIST_TOOL_CATEGORIES_TOOL_NAME = "list_tool_categories"
+const SEARCH_TOOLS_TOOL_NAME = "search_tools"
+const GET_TOOL_SCHEMA_TOOL_NAME = "get_tool_schema"
+export const INVOKE_TOOL_TOOL_NAME = "invoke_tool"
+
+export const PROXY_TOOL_NAMES: ReadonlyArray<string> = [
+  LIST_TOOL_CATEGORIES_TOOL_NAME,
+  SEARCH_TOOLS_TOOL_NAME,
+  GET_TOOL_SCHEMA_TOOL_NAME,
+  INVOKE_TOOL_TOOL_NAME
+]
+
+const SEARCH_DEFAULT_LIMIT = 10
+const SEARCH_MAX_LIMIT = 50
+
+const EmptyProxyParamsSchema = Schema.Record({ key: Schema.String, value: Schema.Never })
+const NonEmptyToolString = Schema.NonEmptyTrimmedString
+const SearchToolsParamsSchema = Schema.Struct({
+  query: NonEmptyToolString,
+  limit: Schema.optionalWith(
+    Schema.Number.pipe(Schema.int(), Schema.positive(), Schema.lessThanOrEqualTo(SEARCH_MAX_LIMIT)),
+    { exact: true }
+  )
+})
+const ToolNameParamsSchema = Schema.Struct({
+  toolName: NonEmptyToolString
+})
+const InvokeToolParamsSchema = Schema.Struct({
+  toolName: NonEmptyToolString,
+  arguments: Schema.optionalWith(Schema.Unknown, { exact: true })
+})
+
+const ProxyToolCategorySchema = Schema.Struct({
+  name: NonEmptyToolString,
+  description: NonEmptyToolString,
+  toolCount: Count
+})
+const ListToolCategoriesResultSchema = Schema.Struct({
+  categories: Schema.Array(ProxyToolCategorySchema)
+})
+const ToolSearchMatchSchema = Schema.Struct({
+  name: NonEmptyToolString,
+  category: NonEmptyToolString,
+  description: NonEmptyToolString,
+  requiredParams: Schema.Array(NonEmptyToolString),
+  optionalParams: Schema.Array(NonEmptyToolString)
+})
+const SearchToolsResultSchema = Schema.Struct({
+  matches: Schema.Array(ToolSearchMatchSchema)
+})
+const ToolAnnotationsSchema = Schema.Struct({
+  title: Schema.optionalWith(NonEmptyToolString, { exact: true }),
+  readOnlyHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
+  destructiveHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
+  idempotentHint: Schema.optionalWith(Schema.Boolean, { exact: true }),
+  openWorldHint: Schema.optionalWith(Schema.Boolean, { exact: true })
+})
+const GetToolSchemaResultSchema = Schema.Struct({
+  name: NonEmptyToolString,
+  category: NonEmptyToolString,
+  description: NonEmptyToolString,
+  inputSchema: Schema.Unknown,
+  outputSchema: Schema.Unknown,
+  annotations: ToolAnnotationsSchema
+})
+const InvokeToolResultSchema = Schema.Struct({
+  toolName: NonEmptyToolString,
+  result: Schema.Unknown,
+  warnings: Schema.optionalWith(Schema.Array(Schema.Unknown), { exact: true })
+})
+
+const emptyInputSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false
+} satisfies ToolDefinition["inputSchema"]
+
+const searchToolsInputSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      minLength: 1,
+      description: "Search text matched against Huly tool names, categories, descriptions, and parameter names."
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: SEARCH_MAX_LIMIT,
+      description: "Maximum number of matches to return. Defaults to 10 and cannot exceed 50."
+    }
+  },
+  required: ["query"],
+  additionalProperties: false
+} satisfies ToolDefinition["inputSchema"]
+
+const toolNameInputSchema = {
+  type: "object",
+  properties: {
+    toolName: {
+      type: "string",
+      minLength: 1,
+      description: "Exact Huly tool name from search_tools or list_tool_categories results."
+    }
+  },
+  required: ["toolName"],
+  additionalProperties: false
+} satisfies ToolDefinition["inputSchema"]
+
+const invokeToolInputSchema = {
+  type: "object",
+  properties: {
+    toolName: {
+      type: "string",
+      minLength: 1,
+      description: "Exact Huly tool name to invoke through the proxy."
+    },
+    arguments: {
+      description: "Arguments object for the target Huly tool. Use {} when the target tool accepts no parameters."
+    }
+  },
+  required: ["toolName"],
+  additionalProperties: false
+} satisfies ToolDefinition["inputSchema"]
+
+const readOnlyProxyAnnotations = (title: string): ToolAnnotations => ({
+  title,
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false
+})
+
+export const proxyToolDefinitions: ReadonlyArray<ToolDefinition> = [
+  {
+    name: LIST_TOOL_CATEGORIES_TOOL_NAME,
+    description:
+      "Lists Huly tool categories available through this proxy. Use this first when you need a broad map of capabilities before searching for a specific Huly tool.",
+    inputSchema: emptyInputSchema,
+    outputSchema: createToolOutputSchema(ListToolCategoriesResultSchema),
+    category: "proxy",
+    annotations: readOnlyProxyAnnotations("List Tool Categories")
+  },
+  {
+    name: SEARCH_TOOLS_TOOL_NAME,
+    description:
+      "Searches the current proxy-visible Huly tool catalog by tool name, category, description, and parameter names. Returns exact tool names plus required and optional parameter names for single-call follow-up with get_tool_schema or invoke_tool.",
+    inputSchema: searchToolsInputSchema,
+    outputSchema: createToolOutputSchema(SearchToolsResultSchema),
+    category: "proxy",
+    annotations: readOnlyProxyAnnotations("Search Tools")
+  },
+  {
+    name: GET_TOOL_SCHEMA_TOOL_NAME,
+    description:
+      "Returns the exact input and output schema for one proxy-visible Huly tool. Use this before invoke_tool when you are not certain about required argument names or result shape.",
+    inputSchema: toolNameInputSchema,
+    outputSchema: createToolOutputSchema(GetToolSchemaResultSchema),
+    category: "proxy",
+    annotations: readOnlyProxyAnnotations("Get Tool Schema")
+  },
+  {
+    name: INVOKE_TOOL_TOOL_NAME,
+    description:
+      "Invokes one proxy-visible Huly tool by exact name with its arguments. This tool can call read or write Huly operations; check get_tool_schema and the target tool annotations when safety matters.",
+    inputSchema: invokeToolInputSchema,
+    outputSchema: createToolOutputSchema(InvokeToolResultSchema),
+    category: "proxy",
+    annotations: {
+      title: "Invoke Tool",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false
+    }
+  }
+]
+
+export const isProxyToolName = (name: string): boolean => PROXY_TOOL_NAMES.includes(name)
+
+const decodeOrError = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  input: unknown,
+  toolName: string
+): A | McpToolResponse => {
+  const decoded = Schema.decodeUnknownEither(schema)(input ?? {})
+  if (Either.isRight(decoded)) return decoded.right
+  return mapParseErrorToMcp(decoded.left, toolName)
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isMcpToolResponse = (value: unknown): value is McpToolResponse => isRecord(value) && Array.isArray(value.content)
+
+const stringArray = (value: unknown): ReadonlyArray<string> =>
+  Array.isArray(value) && value.every((item) => typeof item === "string") ? value : []
+
+const schemaProperties = (schema: object): ReadonlyArray<string> => {
+  const properties = isRecord(schema) ? schema.properties : undefined
+  return isRecord(properties) ? Object.keys(properties) : []
+}
+
+const schemaRequired = (schema: unknown): ReadonlyArray<string> => isRecord(schema) ? stringArray(schema.required) : []
+
+const toolParamSummary = (
+  tool: ToolDefinition
+): { readonly requiredParams: ReadonlyArray<string>; readonly optionalParams: ReadonlyArray<string> } => {
+  const required = new Set(schemaRequired(tool.inputSchema))
+  const properties = schemaProperties(tool.inputSchema)
+  return {
+    requiredParams: properties.filter((name) => required.has(name)),
+    optionalParams: properties.filter((name) => !required.has(name))
+  }
+}
+
+const categoryDescription = (category: string): string => `Huly ${category} tools.`
+
+const listCategories = (registry: ToolRegistry): McpToolResponse => {
+  const counts = new Map<string, number>()
+  for (const tool of registry.definitions) {
+    counts.set(tool.category, (counts.get(tool.category) ?? 0) + 1)
+  }
+  return createSuccessResponse({
+    categories: [...counts.entries()].map(([name, toolCount]) => ({
+      name,
+      description: categoryDescription(name),
+      toolCount: Count.make(toolCount)
+    }))
+  })
+}
+
+const queryTokens = (query: string): ReadonlyArray<string> =>
+  query.toLowerCase().split(/[^a-z0-9]+/u).filter((token) => token !== "")
+
+const tokenHitCount = (tokens: ReadonlyArray<string>, text: string): number => {
+  const lower = text.toLowerCase()
+  return tokens.filter((token) => lower.includes(token)).length
+}
+
+const toolScore = (tool: ToolDefinition, tokens: ReadonlyArray<string>, normalizedQuery: string): number => {
+  const params = toolParamSummary(tool)
+  const paramText = [...params.requiredParams, ...params.optionalParams].join(" ")
+  const exactScore = tool.name.toLowerCase() === normalizedQuery ? 10_000 : 0
+  return exactScore
+    + tokenHitCount(tokens, tool.name) * 1_000
+    + tokenHitCount(tokens, tool.category) * 100
+    + tokenHitCount(tokens, tool.description) * 10
+    + tokenHitCount(tokens, paramText)
+}
+
+export const searchToolDefinitions = (
+  registry: ToolRegistry,
+  query: string,
+  limit: number = SEARCH_DEFAULT_LIMIT
+): ReadonlyArray<ToolDefinition> => {
+  const normalizedQuery = query.trim().toLowerCase()
+  const tokens = queryTokens(normalizedQuery)
+  if (tokens.length === 0) return []
+
+  return registry.definitions
+    .map((tool, index) => ({ index, score: toolScore(tool, tokens, normalizedQuery), tool }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, limit)
+    .map((match) => match.tool)
+}
+
+const searchTools = (registry: ToolRegistry, args: unknown): McpToolResponse => {
+  const params = decodeOrError(SearchToolsParamsSchema, args, SEARCH_TOOLS_TOOL_NAME)
+  if (isMcpToolResponse(params)) return params
+  const limit = Math.min(params.limit ?? SEARCH_DEFAULT_LIMIT, SEARCH_MAX_LIMIT)
+  const matches = searchToolDefinitions(registry, params.query, limit).map((tool) => {
+    const paramSummary = toolParamSummary(tool)
+    return {
+      name: tool.name,
+      category: tool.category,
+      description: tool.description,
+      requiredParams: paramSummary.requiredParams,
+      optionalParams: paramSummary.optionalParams
+    }
+  })
+  return createSuccessResponse({ matches })
+}
+
+const getToolSchema = (registry: ToolRegistry, args: unknown): McpToolResponse => {
+  const params = decodeOrError(ToolNameParamsSchema, args, GET_TOOL_SCHEMA_TOOL_NAME)
+  if (isMcpToolResponse(params)) return params
+
+  const tool = registry.tools.get(params.toolName)
+  if (tool === undefined) return createUnknownToolError(params.toolName)
+  return createSuccessResponse({
+    name: tool.name,
+    category: tool.category,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    outputSchema: tool.outputSchema,
+    annotations: resolveAnnotations(tool)
+  })
+}
+
+interface InvokeToolClients {
+  readonly hulyClient: Parameters<ToolRegistry["handleToolCall"]>[2]
+  readonly storageClient: HulyStorageClient["Type"]
+  readonly workspaceClient?: WorkspaceClientOperations
+}
+
+const invokeTool = async (
+  registry: ToolRegistry,
+  args: unknown,
+  clients: InvokeToolClients
+): Promise<McpToolResponse> => {
+  const params = decodeOrError(InvokeToolParamsSchema, args, INVOKE_TOOL_TOOL_NAME)
+  if (isMcpToolResponse(params)) return params
+
+  if (!registry.tools.has(params.toolName)) return createUnknownToolError(params.toolName)
+
+  const response = await registry.handleToolCall(
+    params.toolName,
+    params.arguments,
+    clients.hulyClient,
+    clients.storageClient,
+    clients.workspaceClient
+  )
+  if (response === null) return createUnknownToolError(params.toolName)
+  if (response.isError === true) return response
+
+  const warnings = response.structuredContent?.warnings ?? []
+  return createSuccessResponse(
+    {
+      toolName: params.toolName,
+      result: response.structuredContent?.result ?? response.content,
+      ...(warnings.length === 0 ? {} : { warnings })
+    },
+    warnings
+  )
+}
+
+interface ProxyToolCallInput {
+  readonly toolName: string
+  readonly args: unknown
+  readonly proxyCandidateRegistry: ToolRegistry
+  readonly clients?: InvokeToolClients
+}
+
+export const handleProxyToolCall = async (input: ProxyToolCallInput): Promise<McpToolResponse> => {
+  switch (input.toolName) {
+    case LIST_TOOL_CATEGORIES_TOOL_NAME: {
+      const params = decodeOrError(EmptyProxyParamsSchema, input.args, LIST_TOOL_CATEGORIES_TOOL_NAME)
+      if (isMcpToolResponse(params)) return params
+      return listCategories(input.proxyCandidateRegistry)
+    }
+    case SEARCH_TOOLS_TOOL_NAME:
+      return searchTools(input.proxyCandidateRegistry, input.args)
+    case GET_TOOL_SCHEMA_TOOL_NAME:
+      return getToolSchema(input.proxyCandidateRegistry, input.args)
+    case INVOKE_TOOL_TOOL_NAME:
+      if (input.clients === undefined) {
+        return createInvalidParamsError("invoke_tool requires initialized Huly clients.", "ProxyClientsMissing")
+      }
+      return invokeTool(input.proxyCandidateRegistry, input.args, input.clients)
+    default:
+      return createUnknownToolError(input.toolName)
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,7 +18,12 @@ import type { ProtocolExposureOptions } from "./protocol-tool-exposure.js"
 import { type SanitizedHulyRuntimeConfigContext, sanitizeHulyRuntimeConfigFromEnv } from "../config/config.js"
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import { TelemetryService } from "../telemetry/telemetry.js"
-import { type McpClientInfoLike, parseToolExposureConfig, type ToolExposureConfig } from "./tool-mode.js"
+import {
+  type McpClientInfoLike,
+  parseMcpClientInfo,
+  parseToolExposureConfig,
+  type ToolExposureConfig
+} from "./tool-mode.js"
 import { resolveToolScope } from "./tool-scope.js"
 import { createScopedRegistry, toolRegistry } from "./tools/index.js"
 
@@ -71,20 +76,17 @@ const parseToolExposureConfigEffect = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
-const clientInfoFromRecord = (value: unknown): McpClientInfoLike | undefined =>
-  isRecord(value) && typeof value.name === "string" ? { name: value.name } : undefined
-
 const clientInfoFromMcp2026Request = (req: Request): McpClientInfoLike | undefined => {
   const body = req.body
   if (!isRecord(body) || !isRecord(body.params) || !isRecord(body.params._meta)) return undefined
   const clientInfo = body.params._meta["io.modelcontextprotocol/clientInfo"]
-  return clientInfoFromRecord(clientInfo)
+  return parseMcpClientInfo(clientInfo)
 }
 
 const clientInfoFromLegacyHttpRequest = (req: Request): McpClientInfoLike | undefined => {
   const body = req.body
   if (!isRecord(body) || !isRecord(body.params)) return undefined
-  return clientInfoFromRecord(body.params.clientInfo) ?? clientInfoFromMcp2026Request(req)
+  return parseMcpClientInfo(body.params.clientInfo) ?? clientInfoFromMcp2026Request(req)
 }
 
 interface McpServerOperations {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,13 +11,14 @@ import type { Request } from "express"
 import { type ClientBundle, createMcpServer } from "./create-mcp-server.js"
 import type { HttpServerFactoryService, HttpTransportDependencies, HttpTransportError } from "./http-transport.js"
 import { DEFAULT_HTTP_PORT, startHttpTransport } from "./http-transport.js"
-import { buildHulyContext, parseToolsets } from "./huly-context-tool.js"
+import { buildHulyContext } from "./huly-context-tool.js"
 import { createMcpProtocolHandlers } from "./protocol-handlers.js"
 
 import { type SanitizedHulyRuntimeConfigContext, sanitizeHulyRuntimeConfigFromEnv } from "../config/config.js"
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import { TelemetryService } from "../telemetry/telemetry.js"
-import { createFilteredRegistry, toolRegistry } from "./tools/index.js"
+import { resolveToolScope } from "./tool-scope.js"
+import { createScopedRegistry, toolRegistry } from "./tools/index.js"
 
 export type { ClientBundle } from "./create-mcp-server.js"
 
@@ -75,18 +76,28 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
         const telemetry = yield* TelemetryService
         const writeError = config.writeError ?? defaultWriteError
 
-        const toolsetsRaw = yield* Effect.orElseSucceed(Config.string("TOOLSETS"), () => "")
-        const toolsetSummary = parseToolsets(toolsetsRaw || undefined, writeError)
-        const enabledCategories = toolsetSummary.enabledCategories
-
-        const toolsets = enabledCategories ? [...enabledCategories] : null
-        const registry = enabledCategories
-          ? createFilteredRegistry(enabledCategories)
-          : toolRegistry
+        const hulyToolsetsRaw = yield* Effect.orElseSucceed(Config.string("HULY_TOOLSETS"), () => "")
+        const hulyToolsRaw = yield* Effect.orElseSucceed(Config.string("HULY_TOOLS"), () => "")
+        const legacyToolsetsRaw = yield* Effect.orElseSucceed(Config.string("TOOLSETS"), () => "")
+        const toolScope = resolveToolScope(
+          {
+            hulyToolsets: hulyToolsetsRaw,
+            hulyTools: hulyToolsRaw,
+            legacyToolsets: legacyToolsetsRaw
+          },
+          toolRegistry.definitions,
+          writeError
+        )
+        const toolsets = toolScope.filteringActive ? toolScope.enabledToolsets : null
+        const registry = createScopedRegistry({
+          filteringActive: toolScope.filteringActive,
+          categories: toolScope.enabledCategories,
+          toolNames: toolScope.enabledToolNames
+        })
         const getRuntimeConfigContext = config.getRuntimeConfigContext
           ?? (() => sanitizeHulyRuntimeConfigFromEnv(process.env))
         const getHulyContext = (runtimeConfig: SanitizedHulyRuntimeConfigContext): GetHulyContextResult =>
-          buildHulyContext(config, registry, toolsetSummary, runtimeConfig)
+          buildHulyContext(config, registry, toolScope, runtimeConfig)
 
         telemetry.sessionStart({
           transport: config.transport,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -76,14 +76,12 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
         const telemetry = yield* TelemetryService
         const writeError = config.writeError ?? defaultWriteError
 
-        const hulyToolsetsRaw = yield* Effect.orElseSucceed(Config.string("HULY_TOOLSETS"), () => "")
-        const hulyToolsRaw = yield* Effect.orElseSucceed(Config.string("HULY_TOOLS"), () => "")
-        const legacyToolsetsRaw = yield* Effect.orElseSucceed(Config.string("TOOLSETS"), () => "")
+        const toolsetsRaw = yield* Effect.orElseSucceed(Config.string("TOOLSETS"), () => "")
+        const toolsRaw = yield* Effect.orElseSucceed(Config.string("TOOLS"), () => "")
         const toolScope = resolveToolScope(
           {
-            hulyToolsets: hulyToolsetsRaw,
-            hulyTools: hulyToolsRaw,
-            legacyToolsets: legacyToolsetsRaw
+            toolsets: toolsetsRaw,
+            tools: toolsRaw
           },
           toolRegistry.definitions,
           writeError

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,12 +11,14 @@ import type { Request } from "express"
 import { type ClientBundle, createMcpServer } from "./create-mcp-server.js"
 import type { HttpServerFactoryService, HttpTransportDependencies, HttpTransportError } from "./http-transport.js"
 import { DEFAULT_HTTP_PORT, startHttpTransport } from "./http-transport.js"
-import { buildHulyContext } from "./huly-context-tool.js"
+import { buildHulyContext, type ToolExposureContext } from "./huly-context-tool.js"
 import { createMcpProtocolHandlers } from "./protocol-handlers.js"
+import type { ProtocolExposureOptions } from "./protocol-tool-exposure.js"
 
 import { type SanitizedHulyRuntimeConfigContext, sanitizeHulyRuntimeConfigFromEnv } from "../config/config.js"
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
 import { TelemetryService } from "../telemetry/telemetry.js"
+import { type McpClientInfoLike, parseToolExposureConfig, type ToolExposureConfig } from "./tool-mode.js"
 import { resolveToolScope } from "./tool-scope.js"
 import { createScopedRegistry, toolRegistry } from "./tools/index.js"
 
@@ -58,6 +60,33 @@ const defaultWriteError = (message: string): void => {
   console.error(message)
 }
 
+const parseToolExposureConfigEffect = (
+  env: Parameters<typeof parseToolExposureConfig>[0]
+): Effect.Effect<ToolExposureConfig, McpServerError> => {
+  const parsed = parseToolExposureConfig(env)
+  if (parsed._tag === "Success") return Effect.succeed(parsed.value)
+  return Effect.fail(new McpServerError({ message: parsed.message }))
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const clientInfoFromRecord = (value: unknown): McpClientInfoLike | undefined =>
+  isRecord(value) && typeof value.name === "string" ? { name: value.name } : undefined
+
+const clientInfoFromMcp2026Request = (req: Request): McpClientInfoLike | undefined => {
+  const body = req.body
+  if (!isRecord(body) || !isRecord(body.params) || !isRecord(body.params._meta)) return undefined
+  const clientInfo = body.params._meta["io.modelcontextprotocol/clientInfo"]
+  return clientInfoFromRecord(clientInfo)
+}
+
+const clientInfoFromLegacyHttpRequest = (req: Request): McpClientInfoLike | undefined => {
+  const body = req.body
+  if (!isRecord(body) || !isRecord(body.params)) return undefined
+  return clientInfoFromRecord(body.params.clientInfo) ?? clientInfoFromMcp2026Request(req)
+}
+
 interface McpServerOperations {
   readonly run: () => Effect.Effect<void, McpServerError, HttpServerFactoryService>
   readonly stop: () => Effect.Effect<void, McpServerError>
@@ -69,7 +98,7 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
 >() {
   static layer(
     config: McpServerConfig
-  ): Layer.Layer<McpServerService, never, TelemetryService> {
+  ): Layer.Layer<McpServerService, McpServerError, TelemetryService> {
     return Layer.effect(
       McpServerService,
       Effect.gen(function*() {
@@ -78,6 +107,18 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
 
         const toolsetsRaw = yield* Effect.orElseSucceed(Config.string("TOOLSETS"), () => "")
         const toolsRaw = yield* Effect.orElseSucceed(Config.string("TOOLS"), () => "")
+        const hulyToolModeRaw = yield* Effect.orElseSucceed(
+          Config.string("HULY_TOOL_MODE"),
+          (): string | undefined => undefined
+        )
+        const proxyOutputStrictRaw = yield* Effect.orElseSucceed(
+          Config.string("PROXY_OUTPUT_STRICT"),
+          (): string | undefined => undefined
+        )
+        const exposureConfig = yield* parseToolExposureConfigEffect({
+          ...(hulyToolModeRaw === undefined ? {} : { hulyToolMode: hulyToolModeRaw }),
+          ...(proxyOutputStrictRaw === undefined ? {} : { proxyOutputStrict: proxyOutputStrictRaw })
+        })
         const toolScope = resolveToolScope(
           {
             toolsets: toolsetsRaw,
@@ -87,20 +128,37 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
           writeError
         )
         const toolsets = toolScope.filteringActive ? toolScope.enabledToolsets : null
-        const registry = createScopedRegistry({
+        const scopedNativeRegistry = createScopedRegistry({
           filteringActive: toolScope.filteringActive,
           categories: toolScope.enabledCategories,
           toolNames: toolScope.enabledToolNames
         })
+        const registries = {
+          fullRegistry: toolRegistry,
+          scopedNativeRegistry
+        }
         const getRuntimeConfigContext = config.getRuntimeConfigContext
           ?? (() => sanitizeHulyRuntimeConfigFromEnv(process.env))
-        const getHulyContext = (runtimeConfig: SanitizedHulyRuntimeConfigContext): GetHulyContextResult =>
-          buildHulyContext(config, registry, toolScope, runtimeConfig)
+        const getHulyContext = (
+          runtimeConfig: SanitizedHulyRuntimeConfigContext,
+          toolExposure: ToolExposureContext
+        ): GetHulyContextResult =>
+          buildHulyContext(config, scopedNativeRegistry, toolScope, runtimeConfig, toolExposure)
+        const sdkExposureOptions: Partial<ProtocolExposureOptions> = {
+          exposureConfig,
+          toolScopeFilteringActive: toolScope.filteringActive
+        }
+        const requestExposureOptions = (
+          currentClientInfo: () => McpClientInfoLike | undefined
+        ): Partial<ProtocolExposureOptions> => ({
+          ...sdkExposureOptions,
+          currentClientInfo
+        })
 
         telemetry.sessionStart({
           transport: config.transport,
           authMethod: config.authMethod ?? "password",
-          toolCount: registry.definitions.length,
+          toolCount: scopedNativeRegistry.definitions.length,
           toolsets
         })
 
@@ -126,9 +184,10 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
                 const [stdioServer, drainInflight] = createMcpServer(
                   config.resolveClients,
                   telemetry,
-                  registry,
-                  () => getHulyContext(getRuntimeConfigContext()),
-                  config.createServer
+                  registries,
+                  (toolExposure) => getHulyContext(getRuntimeConfigContext(), toolExposure),
+                  config.createServer,
+                  sdkExposureOptions
                 )
                 yield* Ref.set(serverRef, stdioServer)
                 const transport = config.createStdioTransport?.() ?? new StdioServerTransport()
@@ -199,9 +258,10 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
                     return createMcpServer(
                       requestResolveClients,
                       telemetry,
-                      registry,
-                      () => getHulyContext(requestRuntimeConfig),
-                      config.createServer
+                      registries,
+                      (toolExposure) => getHulyContext(requestRuntimeConfig, toolExposure),
+                      config.createServer,
+                      requestExposureOptions(() => clientInfoFromLegacyHttpRequest(req))
                     )[0]
                   },
                   config.httpTransportDependencies,
@@ -210,8 +270,11 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<
                     return createMcpProtocolHandlers(
                       requestResolveClients,
                       telemetry,
-                      registry,
-                      () => getHulyContext(requestRuntimeConfig)
+                      registries,
+                      (toolExposure) => getHulyContext(requestRuntimeConfig, toolExposure),
+                      undefined,
+                      undefined,
+                      requestExposureOptions(() => clientInfoFromMcp2026Request(req))
                     )
                   }
                 ).pipe(

--- a/src/mcp/tool-mode.ts
+++ b/src/mcp/tool-mode.ts
@@ -1,58 +1,111 @@
 import { Either, Schema } from "effect"
 
-export type ToolExposureMode = "native" | "proxy"
-export type ToolModeConfig = "auto" | "native" | "proxy"
+const ToolExposureModeSchema = Schema.Literal("native", "proxy")
+export type ToolExposureMode = Schema.Schema.Type<typeof ToolExposureModeSchema>
 
 const ToolModeConfigSchema = Schema.Literal("auto", "native", "proxy")
+export type ToolModeConfig = Schema.Schema.Type<typeof ToolModeConfigSchema>
+
 const ProxyOutputStrictEnvSchema = Schema.Literal("true", "false")
+const decodeToolExposureMode = Schema.decodeUnknownSync(ToolExposureModeSchema)
+const NATIVE_TOOL_EXPOSURE_MODE = decodeToolExposureMode("native")
+const PROXY_TOOL_EXPOSURE_MODE = decodeToolExposureMode("proxy")
 
-export interface ToolExposureConfig {
-  readonly configuredMode: ToolModeConfig
-  readonly proxyOutputStrict: boolean
-}
+const ToolExposureConfigSchema = Schema.Struct({
+  configuredMode: ToolModeConfigSchema,
+  proxyOutputStrict: Schema.Boolean
+})
+export type ToolExposureConfig = Schema.Schema.Type<typeof ToolExposureConfigSchema>
 
-interface ToolExposureEnv {
-  readonly hulyToolMode?: string
-  readonly proxyOutputStrict?: string
-}
+const ToolExposureEnvSchema = Schema.Struct({
+  hulyToolMode: Schema.optionalWith(Schema.String, { exact: true }),
+  proxyOutputStrict: Schema.optionalWith(Schema.String, { exact: true })
+})
+
+type ToolExposureConfigField = "HULY_TOOL_MODE" | "PROXY_OUTPUT_STRICT"
 
 type ToolExposureConfigParseResult =
   | { readonly _tag: "Success"; readonly value: ToolExposureConfig }
-  | { readonly _tag: "Failure"; readonly message: string; readonly field: "HULY_TOOL_MODE" | "PROXY_OUTPUT_STRICT" }
+  | { readonly _tag: "Failure"; readonly message: string; readonly field: ToolExposureConfigField }
 
 type EnvValueParseResult<T> =
   | { readonly _tag: "Success"; readonly value: T }
-  | { readonly _tag: "Failure"; readonly message: string; readonly field: "HULY_TOOL_MODE" | "PROXY_OUTPUT_STRICT" }
+  | { readonly _tag: "Failure"; readonly message: string; readonly field: ToolExposureConfigField }
 
-const DEFAULT_TOOL_EXPOSURE_CONFIG: ToolExposureConfig = {
+const DEFAULT_TOOL_EXPOSURE_CONFIG: ToolExposureConfig = ToolExposureConfigSchema.make({
   configuredMode: "auto",
   proxyOutputStrict: false
+})
+
+const isUnknownRecord = (input: unknown): input is Readonly<Record<string, unknown>> =>
+  typeof input === "object" && input !== null && !Array.isArray(input)
+
+const envShapeFailure = (input: unknown): ToolExposureConfigParseResult => {
+  if (isUnknownRecord(input)) {
+    if (
+      "hulyToolMode" in input
+      && input.hulyToolMode !== undefined
+      && typeof input.hulyToolMode !== "string"
+    ) {
+      return {
+        _tag: "Failure",
+        field: "HULY_TOOL_MODE",
+        message: "Configuration error: HULY_TOOL_MODE must be a string when set."
+      }
+    }
+    if (
+      "proxyOutputStrict" in input
+      && input.proxyOutputStrict !== undefined
+      && typeof input.proxyOutputStrict !== "string"
+    ) {
+      return {
+        _tag: "Failure",
+        field: "PROXY_OUTPUT_STRICT",
+        message: "Configuration error: PROXY_OUTPUT_STRICT must be a string when set."
+      }
+    }
+  }
+
+  return {
+    _tag: "Failure",
+    field: "HULY_TOOL_MODE",
+    message: "Configuration error: HULY_TOOL_MODE and PROXY_OUTPUT_STRICT must be string environment values."
+  }
 }
 
-export type ClientKind =
-  | "claude-code"
-  | "claude-ai"
-  | "cursor"
-  | "windsurf"
-  | "github-copilot"
-  | "codex"
-  | "opencode"
-  | "unknown"
+const ClientKindSchema = Schema.Literal(
+  "claude-code",
+  "claude-ai",
+  "cursor",
+  "windsurf",
+  "github-copilot",
+  "codex",
+  "opencode",
+  "unknown"
+)
+export type ClientKind = Schema.Schema.Type<typeof ClientKindSchema>
 
 export const DEFAULT_MODE_BY_CLIENT_KIND = {
-  "claude-code": "native",
-  "claude-ai": "proxy",
-  cursor: "proxy",
-  windsurf: "proxy",
-  "github-copilot": "proxy",
-  codex: "proxy",
-  opencode: "proxy",
-  unknown: "proxy"
+  "claude-code": NATIVE_TOOL_EXPOSURE_MODE,
+  "claude-ai": PROXY_TOOL_EXPOSURE_MODE,
+  cursor: PROXY_TOOL_EXPOSURE_MODE,
+  windsurf: PROXY_TOOL_EXPOSURE_MODE,
+  "github-copilot": PROXY_TOOL_EXPOSURE_MODE,
+  codex: PROXY_TOOL_EXPOSURE_MODE,
+  opencode: PROXY_TOOL_EXPOSURE_MODE,
+  unknown: PROXY_TOOL_EXPOSURE_MODE
 } satisfies Record<ClientKind, ToolExposureMode>
 
-export interface McpClientInfoLike {
-  readonly name?: string
-}
+const McpClientName = Schema.Trim.pipe(Schema.nonEmptyString(), Schema.brand("McpClientName")).annotations({
+  identifier: "McpClientName",
+  title: "McpClientName",
+  description: "Trimmed MCP client name from initialize or request metadata."
+})
+
+const McpClientInfoLikeSchema = Schema.Struct({
+  name: Schema.optionalWith(McpClientName, { exact: true })
+})
+export type McpClientInfoLike = Schema.Schema.Type<typeof McpClientInfoLikeSchema>
 
 export interface ResolveToolExposureModeInput {
   readonly configuredMode: ToolModeConfig
@@ -64,30 +117,40 @@ const trimmedLower = (value: string): string => value.trim().toLowerCase()
 const parseConfiguredMode = (
   raw: string | undefined
 ): EnvValueParseResult<ToolModeConfig> => {
-  const normalized = raw === undefined ? DEFAULT_TOOL_EXPOSURE_CONFIG.configuredMode : trimmedLower(raw)
+  if (raw === undefined) {
+    return { _tag: "Success", value: DEFAULT_TOOL_EXPOSURE_CONFIG.configuredMode }
+  }
+
+  const normalized = trimmedLower(raw)
   const decoded = Schema.decodeUnknownEither(ToolModeConfigSchema)(normalized)
   if (Either.isRight(decoded)) return { _tag: "Success", value: decoded.right }
   return {
     _tag: "Failure",
     field: "HULY_TOOL_MODE",
-    message: `Configuration error: HULY_TOOL_MODE must be one of auto, native, or proxy; received "${raw ?? ""}".`
+    message: `Configuration error: HULY_TOOL_MODE must be one of auto, native, or proxy; received "${raw}".`
   }
 }
 
 const parseProxyOutputStrict = (
   raw: string | undefined
 ): EnvValueParseResult<boolean> => {
-  const normalized = raw === undefined ? "false" : trimmedLower(raw)
+  if (raw === undefined) return { _tag: "Success", value: false }
+
+  const normalized = trimmedLower(raw)
   const decoded = Schema.decodeUnknownEither(ProxyOutputStrictEnvSchema)(normalized)
   if (Either.isRight(decoded)) return { _tag: "Success", value: decoded.right === "true" }
   return {
     _tag: "Failure",
     field: "PROXY_OUTPUT_STRICT",
-    message: `Configuration error: PROXY_OUTPUT_STRICT must be true or false; received "${raw ?? ""}".`
+    message: `Configuration error: PROXY_OUTPUT_STRICT must be true or false; received "${raw}".`
   }
 }
 
-export const parseToolExposureConfig = (env: ToolExposureEnv): ToolExposureConfigParseResult => {
+export const parseToolExposureConfig = (input: unknown): ToolExposureConfigParseResult => {
+  const decodedEnv = Schema.decodeUnknownEither(ToolExposureEnvSchema)(input)
+  if (Either.isLeft(decodedEnv)) return envShapeFailure(input)
+
+  const env = decodedEnv.right
   const configuredMode = parseConfiguredMode(env.hulyToolMode)
   if (configuredMode._tag === "Failure") return configuredMode
 
@@ -96,42 +159,48 @@ export const parseToolExposureConfig = (env: ToolExposureEnv): ToolExposureConfi
 
   return {
     _tag: "Success",
-    value: {
+    value: ToolExposureConfigSchema.make({
       configuredMode: configuredMode.value,
       proxyOutputStrict: proxyOutputStrict.value
-    }
+    })
   }
 }
 
+export const parseMcpClientInfo = (input: unknown): McpClientInfoLike | undefined => {
+  const decoded = Schema.decodeUnknownEither(McpClientInfoLikeSchema)(input)
+  return Either.isRight(decoded) ? decoded.right : undefined
+}
+
 const rawClientName = (clientInfo: McpClientInfoLike | undefined): string => {
-  const name = clientInfo?.name?.trim().toLowerCase()
+  const name = clientInfo?.name?.toLowerCase()
   if (name === undefined || name === "") return ""
 
   return name
 }
 
 const withoutRemoteSuffix = (name: string): string => name.replace(/\s*\([^)]*\)\s*$/, "").trim()
+const makeClientKind = Schema.decodeUnknownSync(ClientKindSchema)
 
 export const classifyMcpClient = (
   clientInfo: McpClientInfoLike | undefined
 ): ClientKind => {
   const rawName = rawClientName(clientInfo)
 
-  if (rawName === "claude-code") return "claude-code"
+  if (rawName === "claude-code") return makeClientKind("claude-code")
 
   const name = withoutRemoteSuffix(rawName)
 
-  if (name === "claude-code") return "unknown"
-  if (name === "claude-ai") return "claude-ai"
-  if (name === "cursor-vscode" || name.startsWith("cursor")) return "cursor"
-  if (name.startsWith("windsurf") || name.startsWith("cascade")) return "windsurf"
+  if (name === "claude-code") return makeClientKind("unknown")
+  if (name === "claude-ai") return makeClientKind("claude-ai")
+  if (name === "cursor-vscode" || name.startsWith("cursor")) return makeClientKind("cursor")
+  if (name.startsWith("windsurf") || name.startsWith("cascade")) return makeClientKind("windsurf")
   if (name.startsWith("github-copilot") || name.startsWith("copilot") || name.startsWith("vscode")) {
-    return "github-copilot"
+    return makeClientKind("github-copilot")
   }
-  if (name.startsWith("codex") || name.startsWith("openai-codex")) return "codex"
-  if (name.startsWith("opencode")) return "opencode"
+  if (name.startsWith("codex") || name.startsWith("openai-codex")) return makeClientKind("codex")
+  if (name.startsWith("opencode")) return makeClientKind("opencode")
 
-  return "unknown"
+  return makeClientKind("unknown")
 }
 
 export const resolveToolExposureMode = (

--- a/src/mcp/tool-mode.ts
+++ b/src/mcp/tool-mode.ts
@@ -1,0 +1,71 @@
+export type ToolExposureMode = "native" | "proxy"
+export type ToolModeConfig = "auto" | "native" | "proxy"
+
+export type ClientKind =
+  | "claude-code"
+  | "claude-ai"
+  | "cursor"
+  | "windsurf"
+  | "github-copilot"
+  | "codex"
+  | "opencode"
+  | "unknown"
+
+export const DEFAULT_MODE_BY_CLIENT_KIND = {
+  "claude-code": "native",
+  "claude-ai": "proxy",
+  cursor: "proxy",
+  windsurf: "proxy",
+  "github-copilot": "proxy",
+  codex: "proxy",
+  opencode: "proxy",
+  unknown: "proxy"
+} satisfies Record<ClientKind, ToolExposureMode>
+
+export interface McpClientInfoLike {
+  readonly name?: string
+}
+
+export interface ResolveToolExposureModeInput {
+  readonly configuredMode: ToolModeConfig
+  readonly clientInfo?: McpClientInfoLike
+}
+
+const rawClientName = (clientInfo: McpClientInfoLike | undefined): string => {
+  const name = clientInfo?.name?.trim().toLowerCase()
+  if (name === undefined || name === "") return ""
+
+  return name
+}
+
+const withoutRemoteSuffix = (name: string): string => name.replace(/\s*\([^)]*\)\s*$/, "").trim()
+
+export const classifyMcpClient = (
+  clientInfo: McpClientInfoLike | undefined
+): ClientKind => {
+  const rawName = rawClientName(clientInfo)
+
+  if (rawName === "claude-code") return "claude-code"
+
+  const name = withoutRemoteSuffix(rawName)
+
+  if (name === "claude-code") return "unknown"
+  if (name === "claude-ai") return "claude-ai"
+  if (name === "cursor-vscode" || name.startsWith("cursor")) return "cursor"
+  if (name.startsWith("windsurf") || name.startsWith("cascade")) return "windsurf"
+  if (name.startsWith("github-copilot") || name.startsWith("copilot") || name.startsWith("vscode")) {
+    return "github-copilot"
+  }
+  if (name.startsWith("codex") || name.startsWith("openai-codex")) return "codex"
+  if (name.startsWith("opencode")) return "opencode"
+
+  return "unknown"
+}
+
+export const resolveToolExposureMode = (
+  input: ResolveToolExposureModeInput
+): ToolExposureMode => {
+  if (input.configuredMode !== "auto") return input.configuredMode
+
+  return DEFAULT_MODE_BY_CLIENT_KIND[classifyMcpClient(input.clientInfo)]
+}

--- a/src/mcp/tool-mode.ts
+++ b/src/mcp/tool-mode.ts
@@ -194,7 +194,12 @@ export const classifyMcpClient = (
   if (name === "claude-ai") return makeClientKind("claude-ai")
   if (name === "cursor-vscode" || name.startsWith("cursor")) return makeClientKind("cursor")
   if (name.startsWith("windsurf") || name.startsWith("cascade")) return makeClientKind("windsurf")
-  if (name.startsWith("github-copilot") || name.startsWith("copilot") || name.startsWith("vscode")) {
+  if (
+    name.startsWith("github-copilot")
+    || name.startsWith("copilot")
+    || name.startsWith("visual studio code")
+    || name.startsWith("visual-studio-code")
+  ) {
     return makeClientKind("github-copilot")
   }
   if (name.startsWith("codex") || name.startsWith("openai-codex")) return makeClientKind("codex")

--- a/src/mcp/tool-mode.ts
+++ b/src/mcp/tool-mode.ts
@@ -1,5 +1,33 @@
+import { Either, Schema } from "effect"
+
 export type ToolExposureMode = "native" | "proxy"
 export type ToolModeConfig = "auto" | "native" | "proxy"
+
+const ToolModeConfigSchema = Schema.Literal("auto", "native", "proxy")
+const ProxyOutputStrictEnvSchema = Schema.Literal("true", "false")
+
+export interface ToolExposureConfig {
+  readonly configuredMode: ToolModeConfig
+  readonly proxyOutputStrict: boolean
+}
+
+interface ToolExposureEnv {
+  readonly hulyToolMode?: string
+  readonly proxyOutputStrict?: string
+}
+
+type ToolExposureConfigParseResult =
+  | { readonly _tag: "Success"; readonly value: ToolExposureConfig }
+  | { readonly _tag: "Failure"; readonly message: string; readonly field: "HULY_TOOL_MODE" | "PROXY_OUTPUT_STRICT" }
+
+type EnvValueParseResult<T> =
+  | { readonly _tag: "Success"; readonly value: T }
+  | { readonly _tag: "Failure"; readonly message: string; readonly field: "HULY_TOOL_MODE" | "PROXY_OUTPUT_STRICT" }
+
+const DEFAULT_TOOL_EXPOSURE_CONFIG: ToolExposureConfig = {
+  configuredMode: "auto",
+  proxyOutputStrict: false
+}
 
 export type ClientKind =
   | "claude-code"
@@ -29,6 +57,50 @@ export interface McpClientInfoLike {
 export interface ResolveToolExposureModeInput {
   readonly configuredMode: ToolModeConfig
   readonly clientInfo?: McpClientInfoLike
+}
+
+const trimmedLower = (value: string): string => value.trim().toLowerCase()
+
+const parseConfiguredMode = (
+  raw: string | undefined
+): EnvValueParseResult<ToolModeConfig> => {
+  const normalized = raw === undefined ? DEFAULT_TOOL_EXPOSURE_CONFIG.configuredMode : trimmedLower(raw)
+  const decoded = Schema.decodeUnknownEither(ToolModeConfigSchema)(normalized)
+  if (Either.isRight(decoded)) return { _tag: "Success", value: decoded.right }
+  return {
+    _tag: "Failure",
+    field: "HULY_TOOL_MODE",
+    message: `Configuration error: HULY_TOOL_MODE must be one of auto, native, or proxy; received "${raw ?? ""}".`
+  }
+}
+
+const parseProxyOutputStrict = (
+  raw: string | undefined
+): EnvValueParseResult<boolean> => {
+  const normalized = raw === undefined ? "false" : trimmedLower(raw)
+  const decoded = Schema.decodeUnknownEither(ProxyOutputStrictEnvSchema)(normalized)
+  if (Either.isRight(decoded)) return { _tag: "Success", value: decoded.right === "true" }
+  return {
+    _tag: "Failure",
+    field: "PROXY_OUTPUT_STRICT",
+    message: `Configuration error: PROXY_OUTPUT_STRICT must be true or false; received "${raw ?? ""}".`
+  }
+}
+
+export const parseToolExposureConfig = (env: ToolExposureEnv): ToolExposureConfigParseResult => {
+  const configuredMode = parseConfiguredMode(env.hulyToolMode)
+  if (configuredMode._tag === "Failure") return configuredMode
+
+  const proxyOutputStrict = parseProxyOutputStrict(env.proxyOutputStrict)
+  if (proxyOutputStrict._tag === "Failure") return proxyOutputStrict
+
+  return {
+    _tag: "Success",
+    value: {
+      configuredMode: configuredMode.value,
+      proxyOutputStrict: proxyOutputStrict.value
+    }
+  }
 }
 
 const rawClientName = (clientInfo: McpClientInfoLike | undefined): string => {

--- a/src/mcp/tool-scope.ts
+++ b/src/mcp/tool-scope.ts
@@ -1,9 +1,12 @@
+import type { ToolCategory, ToolName } from "./tools/registry.js"
+
 interface ToolScopeToolDefinition {
-  readonly name: string
-  readonly category: string
+  readonly name: ToolName
+  readonly category: ToolCategory
 }
 
 interface ToolScopeRawEnv {
+  // Raw environment values before CSV parsing and known-value resolution.
   readonly toolsets: string
   readonly tools: string
 }
@@ -11,14 +14,14 @@ interface ToolScopeRawEnv {
 export interface ToolScopeSummary {
   readonly filteringActive: boolean
   readonly requestedToolsets: ReadonlyArray<string>
-  readonly enabledToolsets: ReadonlyArray<string>
+  readonly enabledToolsets: ReadonlyArray<ToolCategory>
   readonly ignoredToolsets: ReadonlyArray<string>
   readonly requestedTools: ReadonlyArray<string>
-  readonly enabledTools: ReadonlyArray<string>
+  readonly enabledTools: ReadonlyArray<ToolName>
   readonly ignoredTools: ReadonlyArray<string>
-  readonly enabledCategories: ReadonlySet<string>
-  readonly enabledToolNames: ReadonlySet<string>
-  readonly availableCategories: ReadonlyArray<string>
+  readonly enabledCategories: ReadonlySet<ToolCategory>
+  readonly enabledToolNames: ReadonlySet<ToolName>
+  readonly availableCategories: ReadonlyArray<ToolCategory>
   readonly visibleRegisteredToolCount: number
   readonly totalRegisteredToolCount: number
 }
@@ -30,25 +33,29 @@ const normalizeCsv = (raw: string): ReadonlyArray<string> => {
 
 const orderedCategories = (
   definitions: ReadonlyArray<ToolScopeToolDefinition>
-): ReadonlyArray<string> => [...new Set(definitions.map((definition) => definition.category))]
+): ReadonlyArray<ToolCategory> => [...new Set(definitions.map((definition) => definition.category))]
 
-const resolveRequested = (
+const knownValueMap = <T extends string>(values: ReadonlyArray<T>): ReadonlyMap<string, T> =>
+  new Map(values.map((value) => [value, value]))
+
+const resolveRequested = <T extends string>(
   requested: ReadonlyArray<string>,
-  known: ReadonlySet<string>,
+  known: ReadonlyMap<string, T>,
   unknownMessage: (name: string) => string,
   writeError: (message: string) => void
 ): {
-  readonly enabled: ReadonlyArray<string>
+  readonly enabled: ReadonlyArray<T>
   readonly ignored: ReadonlyArray<string>
 } =>
   requested.reduce<{
-    readonly enabled: ReadonlyArray<string>
+    readonly enabled: ReadonlyArray<T>
     readonly ignored: ReadonlyArray<string>
   }>((acc, name) => {
-    if (known.has(name)) {
+    const knownValue = known.get(name)
+    if (knownValue !== undefined) {
       return {
         ...acc,
-        enabled: [...acc.enabled, name]
+        enabled: [...acc.enabled, knownValue]
       }
     }
 
@@ -70,8 +77,8 @@ export const resolveToolScope = (
   const requestedToolsets = normalizeCsv(rawEnv.toolsets)
   const requestedTools = normalizeCsv(rawEnv.tools)
   const availableCategories = orderedCategories(definitions)
-  const knownCategories = new Set(availableCategories)
-  const knownToolNames = new Set(definitions.map((definition) => definition.name))
+  const knownCategories = knownValueMap(availableCategories)
+  const knownToolNames = knownValueMap(definitions.map((definition) => definition.name))
 
   const toolsets = resolveRequested(
     requestedToolsets,

--- a/src/mcp/tool-scope.ts
+++ b/src/mcp/tool-scope.ts
@@ -1,0 +1,136 @@
+interface ToolScopeToolDefinition {
+  readonly name: string
+  readonly category: string
+}
+
+interface ToolScopeRawEnv {
+  readonly hulyToolsets: string
+  readonly hulyTools: string
+  readonly legacyToolsets: string
+}
+
+interface LegacyToolsetsAliasUsage {
+  readonly provided: boolean
+  readonly used: boolean
+  readonly ignored: boolean
+}
+
+export interface ToolScopeSummary {
+  readonly filteringActive: boolean
+  readonly requestedToolsets: ReadonlyArray<string>
+  readonly enabledToolsets: ReadonlyArray<string>
+  readonly ignoredToolsets: ReadonlyArray<string>
+  readonly requestedTools: ReadonlyArray<string>
+  readonly enabledTools: ReadonlyArray<string>
+  readonly ignoredTools: ReadonlyArray<string>
+  readonly legacyToolsets: LegacyToolsetsAliasUsage
+  readonly enabledCategories: ReadonlySet<string>
+  readonly enabledToolNames: ReadonlySet<string>
+  readonly availableCategories: ReadonlyArray<string>
+  readonly visibleRegisteredToolCount: number
+  readonly totalRegisteredToolCount: number
+}
+
+const normalizeCsv = (raw: string): ReadonlyArray<string> => {
+  const normalized = raw.split(",").map((part) => part.trim().toLowerCase()).filter((part) => part !== "")
+  return [...new Set(normalized)]
+}
+
+const orderedCategories = (
+  definitions: ReadonlyArray<ToolScopeToolDefinition>
+): ReadonlyArray<string> => [...new Set(definitions.map((definition) => definition.category))]
+
+const resolveRequested = (
+  requested: ReadonlyArray<string>,
+  known: ReadonlySet<string>,
+  unknownMessage: (name: string) => string,
+  writeError: (message: string) => void
+): {
+  readonly enabled: ReadonlyArray<string>
+  readonly ignored: ReadonlyArray<string>
+} =>
+  requested.reduce<{
+    readonly enabled: ReadonlyArray<string>
+    readonly ignored: ReadonlyArray<string>
+  }>((acc, name) => {
+    if (known.has(name)) {
+      return {
+        ...acc,
+        enabled: [...acc.enabled, name]
+      }
+    }
+
+    writeError(unknownMessage(name))
+    return {
+      ...acc,
+      ignored: [...acc.ignored, name]
+    }
+  }, {
+    enabled: [],
+    ignored: []
+  })
+
+export const resolveToolScope = (
+  rawEnv: ToolScopeRawEnv,
+  definitions: ReadonlyArray<ToolScopeToolDefinition>,
+  writeError: (message: string) => void
+): ToolScopeSummary => {
+  const hulyToolsets = normalizeCsv(rawEnv.hulyToolsets)
+  const hulyTools = normalizeCsv(rawEnv.hulyTools)
+  const legacyToolsets = normalizeCsv(rawEnv.legacyToolsets)
+  const availableCategories = orderedCategories(definitions)
+  const knownCategories = new Set(availableCategories)
+  const knownToolNames = new Set(definitions.map((definition) => definition.name))
+  const legacyProvided = legacyToolsets.length > 0
+  const legacyIgnored = legacyProvided && hulyToolsets.length > 0
+  const legacyUsed = legacyProvided && hulyToolsets.length === 0
+  const requestedToolsets = hulyToolsets.length > 0 ? hulyToolsets : legacyToolsets
+
+  if (legacyIgnored) {
+    writeError("Warning: TOOLSETS is deprecated and ignored because HULY_TOOLSETS is set.")
+  } else if (legacyUsed) {
+    writeError("Warning: TOOLSETS is deprecated; use HULY_TOOLSETS instead.")
+  }
+
+  const toolsets = resolveRequested(
+    requestedToolsets,
+    knownCategories,
+    (category) =>
+      `Warning: unknown toolset category "${category}", ignoring. Valid categories: ${availableCategories.join(", ")}`,
+    writeError
+  )
+  const tools = resolveRequested(
+    hulyTools,
+    knownToolNames,
+    (tool) => `Warning: unknown tool name "${tool}", ignoring.`,
+    writeError
+  )
+  const filteringActive = requestedToolsets.length > 0 || hulyTools.length > 0
+  const enabledCategories = new Set(toolsets.enabled)
+  const enabledToolNames = new Set(tools.enabled)
+  const visibleRegisteredToolCount = filteringActive
+    ? definitions.filter((definition) =>
+      enabledCategories.has(definition.category) || enabledToolNames.has(definition.name)
+    ).length
+    : definitions.length
+
+  return {
+    filteringActive,
+    requestedToolsets,
+    enabledToolsets: toolsets.enabled,
+    ignoredToolsets: toolsets.ignored,
+    requestedTools: hulyTools,
+    enabledTools: tools.enabled,
+    ignoredTools: tools.ignored,
+    legacyToolsets: {
+      provided: legacyProvided,
+      used: legacyUsed,
+      ignored: legacyIgnored
+    },
+    enabledCategories,
+    enabledToolNames,
+    availableCategories,
+    visibleRegisteredToolCount,
+    totalRegisteredToolCount: definitions.length
+  }
+}

--- a/src/mcp/tool-scope.ts
+++ b/src/mcp/tool-scope.ts
@@ -4,15 +4,8 @@ interface ToolScopeToolDefinition {
 }
 
 interface ToolScopeRawEnv {
-  readonly hulyToolsets: string
-  readonly hulyTools: string
-  readonly legacyToolsets: string
-}
-
-interface LegacyToolsetsAliasUsage {
-  readonly provided: boolean
-  readonly used: boolean
-  readonly ignored: boolean
+  readonly toolsets: string
+  readonly tools: string
 }
 
 export interface ToolScopeSummary {
@@ -23,7 +16,6 @@ export interface ToolScopeSummary {
   readonly requestedTools: ReadonlyArray<string>
   readonly enabledTools: ReadonlyArray<string>
   readonly ignoredTools: ReadonlyArray<string>
-  readonly legacyToolsets: LegacyToolsetsAliasUsage
   readonly enabledCategories: ReadonlySet<string>
   readonly enabledToolNames: ReadonlySet<string>
   readonly availableCategories: ReadonlyArray<string>
@@ -75,22 +67,11 @@ export const resolveToolScope = (
   definitions: ReadonlyArray<ToolScopeToolDefinition>,
   writeError: (message: string) => void
 ): ToolScopeSummary => {
-  const hulyToolsets = normalizeCsv(rawEnv.hulyToolsets)
-  const hulyTools = normalizeCsv(rawEnv.hulyTools)
-  const legacyToolsets = normalizeCsv(rawEnv.legacyToolsets)
+  const requestedToolsets = normalizeCsv(rawEnv.toolsets)
+  const requestedTools = normalizeCsv(rawEnv.tools)
   const availableCategories = orderedCategories(definitions)
   const knownCategories = new Set(availableCategories)
   const knownToolNames = new Set(definitions.map((definition) => definition.name))
-  const legacyProvided = legacyToolsets.length > 0
-  const legacyIgnored = legacyProvided && hulyToolsets.length > 0
-  const legacyUsed = legacyProvided && hulyToolsets.length === 0
-  const requestedToolsets = hulyToolsets.length > 0 ? hulyToolsets : legacyToolsets
-
-  if (legacyIgnored) {
-    writeError("Warning: TOOLSETS is deprecated and ignored because HULY_TOOLSETS is set.")
-  } else if (legacyUsed) {
-    writeError("Warning: TOOLSETS is deprecated; use HULY_TOOLSETS instead.")
-  }
 
   const toolsets = resolveRequested(
     requestedToolsets,
@@ -100,12 +81,12 @@ export const resolveToolScope = (
     writeError
   )
   const tools = resolveRequested(
-    hulyTools,
+    requestedTools,
     knownToolNames,
     (tool) => `Warning: unknown tool name "${tool}", ignoring.`,
     writeError
   )
-  const filteringActive = requestedToolsets.length > 0 || hulyTools.length > 0
+  const filteringActive = requestedToolsets.length > 0 || requestedTools.length > 0
   const enabledCategories = new Set(toolsets.enabled)
   const enabledToolNames = new Set(tools.enabled)
   const visibleRegisteredToolCount = filteringActive
@@ -119,14 +100,9 @@ export const resolveToolScope = (
     requestedToolsets,
     enabledToolsets: toolsets.enabled,
     ignoredToolsets: toolsets.ignored,
-    requestedTools: hulyTools,
+    requestedTools,
     enabledTools: tools.enabled,
     ignoredTools: tools.ignored,
-    legacyToolsets: {
-      provided: legacyProvided,
-      used: legacyUsed,
-      ignored: legacyIgnored
-    },
     enabledCategories,
     enabledToolNames,
     availableCategories,

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -32,7 +32,7 @@ import { processTools } from "./processes.js"
 import { projectTargetPreferenceTools } from "./project-target-preferences.js"
 import { projectTools } from "./projects.js"
 import { recruitingTools } from "./recruiting.js"
-import type { RegisteredTool, ToolDefinition } from "./registry.js"
+import type { RegisteredTool, ToolCategory, ToolDefinition, ToolName } from "./registry.js"
 import {
   createMissingArgumentsError,
   createUnexpectedArgumentsError,
@@ -105,18 +105,18 @@ const allTools: ReadonlyArray<RegisteredTool> = [
   ...testManagementPlansTools
 ]
 
-export const CATEGORY_NAMES: ReadonlySet<string> = new Set(
+export const CATEGORY_NAMES: ReadonlySet<ToolCategory> = new Set(
   allTools.map((t) => t.category)
 )
 
 type ToolRegistryData = {
-  readonly tools: ReadonlyMap<string, RegisteredTool>
+  readonly tools: ReadonlyMap<ToolName, RegisteredTool>
   readonly definitions: ReadonlyArray<ToolDefinition>
 }
 
 type ToolRegistryMethods = {
   readonly handleToolCall: (
-    toolName: string,
+    toolName: ToolName,
     args: unknown,
     hulyClient: HulyClient["Type"],
     storageClient: HulyStorageClient["Type"],
@@ -128,12 +128,12 @@ export type ToolRegistry = ToolRegistryData & ToolRegistryMethods
 
 interface ToolRegistryScope {
   readonly filteringActive: boolean
-  readonly categories: ReadonlySet<string>
-  readonly toolNames: ReadonlySet<string>
+  readonly categories: ReadonlySet<ToolCategory>
+  readonly toolNames: ReadonlySet<ToolName>
 }
 
 const buildRegistry = (tools: ReadonlyArray<RegisteredTool>): ToolRegistry => {
-  const map = new Map<string, RegisteredTool>(
+  const map = new Map<ToolName, RegisteredTool>(
     tools.map((t) => [t.name, t])
   )
   return {
@@ -163,11 +163,11 @@ export const createScopedRegistry = (scope: ToolRegistryScope): ToolRegistry => 
   )
 }
 
-export const createFilteredRegistry = (categories: ReadonlySet<string>): ToolRegistry =>
+export const createFilteredRegistry = (categories: ReadonlySet<ToolCategory>): ToolRegistry =>
   createScopedRegistry({
     filteringActive: true,
     categories,
-    toolNames: new Set<string>()
+    toolNames: new Set<ToolName>()
   })
 
 export { resolveAnnotations }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -126,6 +126,12 @@ type ToolRegistryMethods = {
 
 export type ToolRegistry = ToolRegistryData & ToolRegistryMethods
 
+interface ToolRegistryScope {
+  readonly filteringActive: boolean
+  readonly categories: ReadonlySet<string>
+  readonly toolNames: ReadonlySet<string>
+}
+
 const buildRegistry = (tools: ReadonlyArray<RegisteredTool>): ToolRegistry => {
   const map = new Map<string, RegisteredTool>(
     tools.map((t) => [t.name, t])
@@ -147,10 +153,22 @@ const buildRegistry = (tools: ReadonlyArray<RegisteredTool>): ToolRegistry => {
   }
 }
 
-export const createFilteredRegistry = (categories: ReadonlySet<string>): ToolRegistry =>
-  buildRegistry(allTools.filter((t) => categories.has(t.category)))
-
 export const toolRegistry: ToolRegistry = buildRegistry(allTools)
+
+export const createScopedRegistry = (scope: ToolRegistryScope): ToolRegistry => {
+  if (!scope.filteringActive) return toolRegistry
+
+  return buildRegistry(
+    allTools.filter((t) => scope.categories.has(t.category) || scope.toolNames.has(t.name))
+  )
+}
+
+export const createFilteredRegistry = (categories: ReadonlySet<string>): ToolRegistry =>
+  createScopedRegistry({
+    filteringActive: true,
+    categories,
+    toolNames: new Set<string>()
+  })
 
 export { resolveAnnotations }
 

--- a/src/mcp/tools/registry.ts
+++ b/src/mcp/tools/registry.ts
@@ -18,7 +18,48 @@ import {
 } from "../error-mapping.js"
 import { createToolOutputSchema, type McpOutputSchema } from "../tool-output-schema.js"
 
+export const ToolName = Schema.NonEmptyTrimmedString.pipe(Schema.brand("ToolName")).annotations({
+  identifier: "ToolName",
+  title: "ToolName",
+  description: "Exact MCP tool name registered by this server."
+})
+export type ToolName = Schema.Schema.Type<typeof ToolName>
+
+export const ToolDescription = Schema.NonEmptyTrimmedString.pipe(Schema.brand("ToolDescription")).annotations({
+  identifier: "ToolDescription",
+  title: "ToolDescription",
+  description: "Human-readable MCP tool description."
+})
+export type ToolDescription = Schema.Schema.Type<typeof ToolDescription>
+
+export const ToolCategory = Schema.NonEmptyTrimmedString.pipe(Schema.brand("ToolCategory")).annotations({
+  identifier: "ToolCategory",
+  title: "ToolCategory",
+  description: "MCP tool category used for toolset filtering and proxy discovery."
+})
+export type ToolCategory = Schema.Schema.Type<typeof ToolCategory>
+
+export const makeToolName = (value: string): ToolName => ToolName.make(value)
+export const makeToolDescription = (value: string): ToolDescription => ToolDescription.make(value)
+export const makeToolCategory = (value: string): ToolCategory => ToolCategory.make(value)
+
+export const parseToolName = (input: unknown): ToolName | undefined => {
+  const decoded = Schema.decodeUnknownEither(ToolName)(input)
+  return Either.isRight(decoded) ? decoded.right : undefined
+}
+
 export interface ToolDefinition {
+  readonly name: ToolName
+  readonly description: ToolDescription
+  readonly inputSchema: object
+  readonly outputSchema: McpOutputSchema
+  readonly category: ToolCategory
+  readonly annotations?: ToolAnnotations
+}
+
+// Raw static declaration input. createToolDefinition parses these literals into
+// branded ToolDefinition metadata before any registry/listing/call path sees them.
+interface ToolDefinitionSpec {
   readonly name: string
   readonly description: string
   readonly inputSchema: object
@@ -27,7 +68,16 @@ export interface ToolDefinition {
   readonly annotations?: ToolAnnotations
 }
 
-const deriveTitle = (name: string): string =>
+export const createToolDefinition = (spec: ToolDefinitionSpec): ToolDefinition => ({
+  name: makeToolName(spec.name),
+  description: makeToolDescription(spec.description),
+  inputSchema: spec.inputSchema,
+  outputSchema: spec.outputSchema,
+  category: makeToolCategory(spec.category),
+  ...(spec.annotations === undefined ? {} : { annotations: spec.annotations })
+})
+
+const deriveTitle = (name: ToolName): string =>
   name.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ")
 
 const READ_PREFIXES = ["list_", "get_", "describe_", "search_", "fulltext_", "download_", "preview_"]
@@ -52,10 +102,10 @@ const UPDATE_PREFIXES = [
 ]
 const DELETE_PREFIXES = ["delete_"]
 
-const matchesPrefix = (name: string, prefixes: ReadonlyArray<string>): boolean =>
+const matchesPrefix = (name: ToolName, prefixes: ReadonlyArray<string>): boolean =>
   prefixes.some((p) => name.startsWith(p))
 
-const deriveAnnotations = (name: string): ToolAnnotations => {
+const deriveAnnotations = (name: ToolName): ToolAnnotations => {
   const title = deriveTitle(name)
 
   if (matchesPrefix(name, READ_PREFIXES)) {
@@ -87,13 +137,13 @@ export interface RegisteredTool extends ToolDefinition {
   ) => Promise<McpToolResponse>
 }
 
-export const createMissingArgumentsError = (toolName: string): McpToolResponse =>
+export const createMissingArgumentsError = (toolName: ToolName): McpToolResponse =>
   createInvalidParamsError(
     `Invalid parameters for ${toolName}: missing arguments object. Pass an arguments object; use {} when you want defaults for optional parameters.`,
     "MissingArguments"
   )
 
-export const createUnexpectedArgumentsError = (toolName: string): McpToolResponse =>
+export const createUnexpectedArgumentsError = (toolName: ToolName): McpToolResponse =>
   createInvalidParamsError(
     `Invalid parameters for ${toolName}: this tool does not accept arguments. Pass {} or omit arguments.`,
     "UnexpectedArguments"
@@ -177,6 +227,8 @@ type ResultSchema = Schema.Schema.AnyNoContext
 
 type SchemaResult<S extends ResultSchema> = Schema.Schema.Type<S>
 
+// Authoring shape for static tool declarations. The registry parses this into
+// branded ToolDefinition metadata once, before tools can be listed or invoked.
 interface ToolSpec<S extends ResultSchema> {
   readonly name: string
   readonly description: string
@@ -188,14 +240,15 @@ interface ToolSpec<S extends ResultSchema> {
 
 const stripResultSchema = <S extends ResultSchema>(
   spec: ToolSpec<S>
-): ToolDefinition => ({
-  name: spec.name,
-  description: spec.description,
-  inputSchema: spec.inputSchema,
-  outputSchema: createToolOutputSchema(spec.resultSchema),
-  category: spec.category,
-  ...(spec.annotations === undefined ? {} : { annotations: spec.annotations })
-})
+): ToolDefinition =>
+  createToolDefinition({
+    name: spec.name,
+    description: spec.description,
+    inputSchema: spec.inputSchema,
+    outputSchema: createToolOutputSchema(spec.resultSchema),
+    category: spec.category,
+    ...(spec.annotations === undefined ? {} : { annotations: spec.annotations })
+  })
 
 interface HandlerArgs {
   readonly hulyClient: HulyClient["Type"]

--- a/src/telemetry/posthog.ts
+++ b/src/telemetry/posthog.ts
@@ -17,15 +17,22 @@ type ToolCalledProperties = {
   readonly tool_name: string
   readonly status: "success" | "error"
   readonly duration_ms: number
+  readonly client_kind?: string
+  readonly resolved_mode?: string
   readonly error_tag?: string
   readonly input_bytes?: number
   readonly output_bytes?: number
   readonly edit_mode?: string
 }
 
+type FirstListToolsProperties = {
+  readonly client_kind?: string
+  readonly resolved_mode?: string
+}
+
 type TelemetryEvent =
   | { readonly event: "session_start"; readonly properties: SessionStartProperties }
-  | { readonly event: "first_list_tools"; readonly properties?: undefined }
+  | { readonly event: "first_list_tools"; readonly properties?: FirstListToolsProperties }
   | { readonly event: "tool_called"; readonly properties: ToolCalledProperties }
   | { readonly event: "session_end"; readonly properties?: undefined }
 
@@ -102,11 +109,21 @@ export const createPostHogTelemetry = (
       })
     },
 
-    firstListTools: () => {
+    firstListTools: (props) => {
       if (listToolsSent) return
       listToolsSent = true
-      debugLog("[telemetry] first_list_tools")
-      capture({ event: "first_list_tools" })
+      debugLog(`[telemetry] first_list_tools: ${JSON.stringify(props ?? {})}`)
+      capture(
+        props === undefined
+          ? { event: "first_list_tools" }
+          : {
+            event: "first_list_tools",
+            properties: {
+              client_kind: props.clientKind,
+              resolved_mode: props.resolvedMode
+            }
+          }
+      )
     },
 
     toolCalled: (props) => {
@@ -117,6 +134,8 @@ export const createPostHogTelemetry = (
           tool_name: props.toolName,
           status: props.status,
           duration_ms: props.durationMs,
+          ...(props.clientKind !== undefined && { client_kind: props.clientKind }),
+          ...(props.resolvedMode !== undefined && { resolved_mode: props.resolvedMode }),
           ...(props.errorTag !== undefined && { error_tag: props.errorTag }),
           ...(props.inputBytes !== undefined && { input_bytes: props.inputBytes }),
           ...(props.outputBytes !== undefined && { output_bytes: props.outputBytes }),

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,5 +1,6 @@
 import { Config, Context, Effect, Layer } from "effect"
 
+import type { ClientKind, ToolExposureMode } from "../mcp/tool-mode.js"
 import { createNoopTelemetry } from "./noop.js"
 import { createPostHogTelemetry } from "./posthog.js"
 
@@ -15,6 +16,8 @@ export type SessionStartProps = {
 export type ToolCalledProps = {
   readonly toolName: string
   readonly status: "success" | "error"
+  readonly clientKind?: ClientKind | undefined
+  readonly resolvedMode?: ToolExposureMode | undefined
   readonly errorTag?: string | undefined
   readonly durationMs: number
   readonly inputBytes?: number | undefined
@@ -22,9 +25,14 @@ export type ToolCalledProps = {
   readonly editMode?: string | undefined
 }
 
+export type FirstListToolsProps = {
+  readonly clientKind: ClientKind
+  readonly resolvedMode: ToolExposureMode
+}
+
 export interface TelemetryOperations {
   readonly sessionStart: (props: SessionStartProps) => void
-  readonly firstListTools: () => void
+  readonly firstListTools: (props?: FirstListToolsProps) => void
   readonly toolCalled: (props: ToolCalledProps) => void
   readonly shutdown: () => Promise<void>
 }

--- a/test/config/runtime-context-and-toolsets.property.test.ts
+++ b/test/config/runtime-context-and-toolsets.property.test.ts
@@ -4,8 +4,8 @@ import { expect, it } from "vitest"
 
 import { sanitizeHulyRuntimeConfigFromEnv, sanitizeHulyRuntimeConfigFromHeaders } from "../../src/config/config.js"
 import { DEFAULT_HULY_CONNECTION_TIMEOUT } from "../../src/config/huly-config-constants.js"
-import { parseToolsets } from "../../src/mcp/huly-context-tool.js"
-import { CATEGORY_NAMES } from "../../src/mcp/tools/index.js"
+import { resolveToolScope } from "../../src/mcp/tool-scope.js"
+import { CATEGORY_NAMES, toolRegistry } from "../../src/mcp/tools/index.js"
 import { propertyTestParameters } from "../helpers/property.js"
 
 const secretArbitrary = fc.uuid().map((value) => `secret-${value}`)
@@ -166,32 +166,92 @@ describe("sanitized runtime context properties", () => {
   })
 })
 
-describe("parseToolsets properties", () => {
-  it("normalizes known categories and reports unknown categories", () => {
+const knownCategories = [...CATEGORY_NAMES]
+const knownToolNames = toolRegistry.definitions.map((tool) => tool.name)
+const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
+const knownToolNameArbitrary = fc.constantFrom(...knownToolNames)
+const unknownCategoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{1,20}$/).filter(
+  (name) => !CATEGORY_NAMES.has(name)
+)
+const unknownToolNameArbitrary = fc.stringMatching(/^[a-z][a-z0-9_]{1,30}$/).filter(
+  (name) => !toolRegistry.tools.has(name)
+)
+
+const decoratedCsv = (values: ReadonlyArray<string>): string =>
+  values.map((value, index) => index % 2 === 0 ? value.toUpperCase() : ` ${value} `).join(",")
+
+const uniqueLower = (
+  values: ReadonlyArray<string>
+): ReadonlyArray<string> => [...new Set(values.map((value) => value.toLowerCase()))]
+
+describe("tool scope parser properties", () => {
+  it("normalizes and de-duplicates known and unknown toolsets and tools", () => {
     fc.assert(
       fc.property(
-        fc.array(fc.constantFrom(...CATEGORY_NAMES), { maxLength: 8 }),
-        fc.array(fc.stringMatching(/^[a-z][a-z0-9_-]{1,20}$/).filter((name) => !CATEGORY_NAMES.has(name)), {
-          maxLength: 8
-        }),
-        (knownCategories, unknownCategories) => {
-          const requested = [...knownCategories, ...unknownCategories]
-          const raw = requested.map((category, index) => index % 2 === 0 ? category.toUpperCase() : ` ${category} `)
-            .join(",")
+        fc.array(fc.oneof(knownCategoryArbitrary, unknownCategoryArbitrary), { maxLength: 12 }),
+        fc.array(fc.oneof(knownToolNameArbitrary, unknownToolNameArbitrary), { maxLength: 12 }),
+        (requestedCategories, requestedTools) => {
           const warnings: Array<string> = []
-          const result = parseToolsets(raw, (message) => {
-            warnings.push(message)
-          })
+          const result = resolveToolScope(
+            {
+              hulyToolsets: decoratedCsv(requestedCategories),
+              hulyTools: decoratedCsv(requestedTools),
+              legacyToolsets: ""
+            },
+            toolRegistry.definitions,
+            (message) => {
+              warnings.push(message)
+            }
+          )
+          const normalizedCategories = uniqueLower(requestedCategories)
+          const normalizedTools = uniqueLower(requestedTools)
+          const ignoredCategories = normalizedCategories.filter((category) => !CATEGORY_NAMES.has(category))
+          const ignoredTools = normalizedTools.filter((tool) => !toolRegistry.tools.has(tool))
 
-          expect(result.requestedCategories).toEqual(requested.map((category) => category.toLowerCase()))
-          expect(result.ignoredCategories).toEqual(unknownCategories)
-          expect(warnings).toHaveLength(unknownCategories.length)
+          expect(result.requestedToolsets).toEqual(normalizedCategories)
+          expect(result.requestedTools).toEqual(normalizedTools)
+          expect(result.ignoredToolsets).toEqual(ignoredCategories)
+          expect(result.ignoredTools).toEqual(ignoredTools)
+          expect(result.enabledToolsets.every((category) => CATEGORY_NAMES.has(category))).toBe(true)
+          expect(result.enabledTools.every((tool) => toolRegistry.tools.has(tool))).toBe(true)
+          expect(warnings).toHaveLength(ignoredCategories.length + ignoredTools.length)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
 
-          if (knownCategories.length === 0) {
-            expect(result.enabledCategories).toBeUndefined()
-          } else {
-            expect(result.enabledCategories).toEqual(new Set(knownCategories))
-          }
+  it("preserves inactive versus active-all-invalid semantics", () => {
+    fc.assert(
+      fc.property(
+        fc.array(unknownCategoryArbitrary, { minLength: 1, maxLength: 8 }),
+        fc.array(unknownToolNameArbitrary, { maxLength: 8 }),
+        (unknownCategories, unknownTools) => {
+          const inactive = resolveToolScope(
+            {
+              hulyToolsets: "",
+              hulyTools: "",
+              legacyToolsets: ""
+            },
+            toolRegistry.definitions,
+            () => {}
+          )
+          const activeInvalid = resolveToolScope(
+            {
+              hulyToolsets: decoratedCsv(unknownCategories),
+              hulyTools: decoratedCsv(unknownTools),
+              legacyToolsets: ""
+            },
+            toolRegistry.definitions,
+            () => {}
+          )
+
+          expect(inactive.filteringActive).toBe(false)
+          expect(inactive.visibleRegisteredToolCount).toBe(toolRegistry.definitions.length)
+          expect(activeInvalid.filteringActive).toBe(true)
+          expect(activeInvalid.enabledToolsets).toEqual([])
+          expect(activeInvalid.enabledTools).toEqual([])
+          expect(activeInvalid.visibleRegisteredToolCount).toBe(0)
         }
       ),
       propertyTestParameters

--- a/test/config/runtime-context-and-toolsets.property.test.ts
+++ b/test/config/runtime-context-and-toolsets.property.test.ts
@@ -194,9 +194,8 @@ describe("tool scope parser properties", () => {
           const warnings: Array<string> = []
           const result = resolveToolScope(
             {
-              hulyToolsets: decoratedCsv(requestedCategories),
-              hulyTools: decoratedCsv(requestedTools),
-              legacyToolsets: ""
+              toolsets: decoratedCsv(requestedCategories),
+              tools: decoratedCsv(requestedTools)
             },
             toolRegistry.definitions,
             (message) => {
@@ -229,18 +228,16 @@ describe("tool scope parser properties", () => {
         (unknownCategories, unknownTools) => {
           const inactive = resolveToolScope(
             {
-              hulyToolsets: "",
-              hulyTools: "",
-              legacyToolsets: ""
+              toolsets: "",
+              tools: ""
             },
             toolRegistry.definitions,
             () => {}
           )
           const activeInvalid = resolveToolScope(
             {
-              hulyToolsets: decoratedCsv(unknownCategories),
-              hulyTools: decoratedCsv(unknownTools),
-              legacyToolsets: ""
+              toolsets: decoratedCsv(unknownCategories),
+              tools: decoratedCsv(unknownTools)
             },
             toolRegistry.definitions,
             () => {}

--- a/test/domain/schemas.huly-context.test.ts
+++ b/test/domain/schemas.huly-context.test.ts
@@ -71,6 +71,24 @@ const validContext = {
     visibleRegisteredToolCount: 12,
     totalRegisteredToolCount: 120,
     builtinTools: ["get_version", "get_huly_context"]
+  },
+  toolScope: {
+    active: true,
+    requestedToolsets: ["issues"],
+    enabledToolsets: ["issues"],
+    ignoredToolsets: [],
+    requestedTools: ["list_documents"],
+    enabledTools: ["list_documents"],
+    ignoredTools: [],
+    legacyToolsets: {
+      provided: false,
+      used: false,
+      ignored: false
+    },
+    availableCategories: ["issues", "projects"],
+    visibleRegisteredToolCount: 13,
+    totalRegisteredToolCount: 120,
+    builtinTools: ["get_version", "get_huly_context"]
   }
 }
 
@@ -81,6 +99,7 @@ describe("GetHulyContextResultSchema", () => {
       expect(decoded.package.name).toBe("@firfi/huly-mcp")
       expect(decoded.transport.type).toBe("http")
       expect(decoded.toolsets.builtinTools).toEqual(["get_version", "get_huly_context"])
+      expect(decoded.toolScope.enabledTools).toEqual(["list_documents"])
     }))
 
   it.effect("rejects non-sanitized URL origin values", () =>
@@ -134,9 +153,9 @@ describe("GetHulyContextResultSchema", () => {
           },
           {
             ...validContext,
-            toolsets: {
-              ...validContext.toolsets,
-              requestedCategories: [""]
+            toolScope: {
+              ...validContext.toolScope,
+              requestedTools: [""]
             }
           }
         ]
@@ -155,7 +174,8 @@ describe("GetHulyContextResultSchema", () => {
           huly: expect.any(Object),
           auth: expect.any(Object),
           configSources: expect.any(Object),
-          toolsets: expect.any(Object)
+          toolsets: expect.any(Object),
+          toolScope: expect.any(Object)
         }
       })
     }))

--- a/test/domain/schemas.huly-context.test.ts
+++ b/test/domain/schemas.huly-context.test.ts
@@ -80,11 +80,6 @@ const validContext = {
     requestedTools: ["list_documents"],
     enabledTools: ["list_documents"],
     ignoredTools: [],
-    legacyToolsets: {
-      provided: false,
-      used: false,
-      ignored: false
-    },
     availableCategories: ["issues", "projects"],
     visibleRegisteredToolCount: 13,
     totalRegisteredToolCount: 120,

--- a/test/domain/schemas.huly-context.test.ts
+++ b/test/domain/schemas.huly-context.test.ts
@@ -84,6 +84,16 @@ const validContext = {
     visibleRegisteredToolCount: 13,
     totalRegisteredToolCount: 120,
     builtinTools: ["get_version", "get_huly_context"]
+  },
+  toolExposure: {
+    configuredMode: "auto",
+    resolvedMode: "proxy",
+    clientKind: "codex",
+    proxyOutputStrict: false,
+    visibleToolCount: 6,
+    nativeVisibleToolCount: 0,
+    proxyCandidateToolCount: 120,
+    proxyToolNames: ["list_tool_categories", "search_tools", "get_tool_schema", "invoke_tool"]
   }
 }
 
@@ -95,6 +105,7 @@ describe("GetHulyContextResultSchema", () => {
       expect(decoded.transport.type).toBe("http")
       expect(decoded.toolsets.builtinTools).toEqual(["get_version", "get_huly_context"])
       expect(decoded.toolScope.enabledTools).toEqual(["list_documents"])
+      expect(decoded.toolExposure.resolvedMode).toBe("proxy")
     }))
 
   it.effect("rejects non-sanitized URL origin values", () =>
@@ -170,7 +181,8 @@ describe("GetHulyContextResultSchema", () => {
           auth: expect.any(Object),
           configSources: expect.any(Object),
           toolsets: expect.any(Object),
-          toolScope: expect.any(Object)
+          toolScope: expect.any(Object),
+          toolExposure: expect.any(Object)
         }
       })
     }))

--- a/test/mcp/create-mcp-server.test.ts
+++ b/test/mcp/create-mcp-server.test.ts
@@ -85,11 +85,6 @@ describe("createMcpServer", () => {
             requestedTools: [],
             enabledTools: [],
             ignoredTools: [],
-            legacyToolsets: {
-              provided: false,
-              used: false,
-              ignored: false
-            },
             availableCategories: ["issues"],
             visibleRegisteredToolCount: 1,
             totalRegisteredToolCount: 1,

--- a/test/mcp/create-mcp-server.test.ts
+++ b/test/mcp/create-mcp-server.test.ts
@@ -76,6 +76,24 @@ describe("createMcpServer", () => {
             visibleRegisteredToolCount: 1,
             totalRegisteredToolCount: 1,
             builtinTools: ["get_version", "get_huly_context"]
+          },
+          toolScope: {
+            active: false,
+            requestedToolsets: [],
+            enabledToolsets: [],
+            ignoredToolsets: [],
+            requestedTools: [],
+            enabledTools: [],
+            ignoredTools: [],
+            legacyToolsets: {
+              provided: false,
+              used: false,
+              ignored: false
+            },
+            availableCategories: ["issues"],
+            visibleRegisteredToolCount: 1,
+            totalRegisteredToolCount: 1,
+            builtinTools: ["get_version", "get_huly_context"]
           }
         }) as never,
       () => createCapturingServer(handlers)

--- a/test/mcp/json-schema-refs.test.ts
+++ b/test/mcp/json-schema-refs.test.ts
@@ -1,0 +1,83 @@
+import { describe } from "@effect/vitest"
+import { expect, it } from "vitest"
+
+import {
+  stripCollidingSchemaIds,
+  stripCollidingSchemaIdsProperties,
+  stripCollidingSchemaIdsRecord
+} from "../../src/mcp/json-schema-refs.js"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const expectRecord = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) throw new Error("Expected record")
+  return value
+}
+
+describe("stripCollidingSchemaIds", () => {
+  it("removes inline $id values under /schemas/ while keeping siblings and content", () => {
+    const input = {
+      type: "object",
+      properties: {
+        tx: { $id: "/schemas/unknown", title: "unknown", description: "opaque" }
+      }
+    }
+    const out = expectRecord(stripCollidingSchemaIds(input))
+    const props = expectRecord(out.properties)
+    const tx = expectRecord(props.tx)
+    expect(tx.$id).toBeUndefined()
+    expect(tx.title).toBe("unknown")
+    expect(tx.description).toBe("opaque")
+  })
+
+  it("strips /schemas/{} and recurses through arrays and nested objects", () => {
+    const input = {
+      anyOf: [
+        { $id: "/schemas/%7B%7D", title: "{}" },
+        { additionalProperties: { $id: "/schemas/unknown", title: "unknown" } }
+      ]
+    }
+    const out = expectRecord(stripCollidingSchemaIds(input))
+    expect(JSON.stringify(out)).not.toContain("/schemas/")
+    expect(JSON.stringify(out)).toContain("\"title\":\"{}\"")
+  })
+
+  it("keeps $ref and non-/schemas $id untouched", () => {
+    const input = {
+      $id: "PositiveInteger",
+      properties: { ref: { $ref: "#/$defs/Foo" }, keep: { $id: "https://example.com/x" } }
+    }
+    const out = expectRecord(stripCollidingSchemaIds(input))
+    expect(out.$id).toBe("PositiveInteger")
+    const props = expectRecord(out.properties)
+    expect(expectRecord(props.ref).$ref).toBe("#/$defs/Foo")
+    expect(expectRecord(props.keep).$id).toBe("https://example.com/x")
+  })
+
+  it("returns primitives and null unchanged", () => {
+    expect(stripCollidingSchemaIds("x")).toBe("x")
+    expect(stripCollidingSchemaIds(7)).toBe(7)
+    expect(stripCollidingSchemaIds(null)).toBe(null)
+  })
+})
+
+describe("stripCollidingSchemaIdsRecord", () => {
+  it("strips a top-level colliding $id and returns a record", () => {
+    const out = stripCollidingSchemaIdsRecord({ $id: "/schemas/unknown", type: "object" })
+    expect(out.$id).toBeUndefined()
+    expect(out.type).toBe("object")
+  })
+})
+
+describe("stripCollidingSchemaIdsProperties", () => {
+  it("strips nested colliding ids while preserving each property as an object", () => {
+    const out = stripCollidingSchemaIdsProperties({
+      a: { $id: "/schemas/unknown", title: "unknown" },
+      b: { type: "string" }
+    })
+    expect(expectRecord(out.a).$id).toBeUndefined()
+    expect(expectRecord(out.a).title).toBe("unknown")
+    expect(expectRecord(out.b).type).toBe("string")
+  })
+})

--- a/test/mcp/message-templates.test.ts
+++ b/test/mcp/message-templates.test.ts
@@ -15,6 +15,7 @@ import { HulyStorageClient } from "../../src/huly/storage.js"
 import { McpErrorCode } from "../../src/mcp/error-mapping.js"
 import { createMcpProtocolHandlers } from "../../src/mcp/protocol-handlers.js"
 import { toolRegistry } from "../../src/mcp/tools/index.js"
+import { makeToolName } from "../../src/mcp/tools/registry.js"
 import { createNoopTelemetry } from "../../src/telemetry/noop.js"
 import type { TelemetryOperations } from "../../src/telemetry/telemetry.js"
 
@@ -136,7 +137,7 @@ describe("message template MCP tools", () => {
       const clients = yield* buildClients([category("cat-sales", "Sales")])
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "list_message_template_categories",
+          makeToolName("list_message_template_categories"),
           {},
           clients.hulyClient,
           clients.storageClient
@@ -168,7 +169,7 @@ describe("message template MCP tools", () => {
       ])
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "render_message_template",
+          makeToolName("render_message_template"),
           {
             template: "tmpl-sales-welcome",
             values: [
@@ -198,7 +199,7 @@ describe("message template MCP tools", () => {
       const clients = yield* buildClients([])
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_message_template",
+          makeToolName("get_message_template"),
           { template: "missing" },
           clients.hulyClient,
           clients.storageClient

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -43,15 +43,26 @@ import {
 } from "../../src/mcp/protocol-handlers.js"
 import { resolveProtocolExposure, toListedTool } from "../../src/mcp/protocol-tool-exposure.js"
 import { handleProxyToolCall } from "../../src/mcp/proxy-tools.js"
+import { parseMcpClientInfo } from "../../src/mcp/tool-mode.js"
 import { createToolOutputSchema } from "../../src/mcp/tool-output-schema.js"
 import { createFilteredRegistry, type ToolRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
-import { defineTool, isNoArgumentTool, requiresArgumentsObject } from "../../src/mcp/tools/registry.js"
+import {
+  createToolDefinition,
+  defineTool,
+  isNoArgumentTool,
+  makeToolCategory,
+  makeToolDescription,
+  makeToolName,
+  type RegisteredTool,
+  requiresArgumentsObject
+} from "../../src/mcp/tools/registry.js"
 import { createNoopTelemetry } from "../../src/telemetry/noop.js"
 import type { TelemetryOperations, ToolCalledProps } from "../../src/telemetry/telemetry.js"
 import { VERSION } from "../../src/version.js"
 
 // A real, empty tool registry (no category tools) — used for the builtin-only paths.
-const emptyRegistry = createFilteredRegistry(new Set<string>())
+const categorySet = (...categories: ReadonlyArray<string>) => new Set(categories.map(makeToolCategory))
+const emptyRegistry = createFilteredRegistry(categorySet())
 
 // Clients/context are never reached on the paths under test; throwing makes accidental
 // use loud instead of silently passing.
@@ -196,8 +207,8 @@ describe("createMcpProtocolHandlers", () => {
 
     it("omits optional output schema and annotations when converting a bare listed tool", () => {
       const listed = toListedTool({
-        name: "bare_tool",
-        description: "Tool used to exercise protocol schema conversion.",
+        name: makeToolName("bare_tool"),
+        description: makeToolDescription("Tool used to exercise protocol schema conversion."),
         inputSchema: {
           type: "object",
           properties: {
@@ -417,32 +428,22 @@ const makeContextFromEnv = (env: Record<string, string>): GetHulyContextResult =
   )
 
 const propertylessToolOutputSchema = createToolOutputSchema(Schema.Struct({ ok: Schema.String }))
+const propertylessTool: RegisteredTool = {
+  ...createToolDefinition({
+    name: "propertyless_tool",
+    description: "Tool with an object schema that does not declare properties.",
+    inputSchema: { type: "object" },
+    outputSchema: propertylessToolOutputSchema,
+    category: "test"
+  }),
+  handler: async () => ({
+    content: [{ type: "text", text: "ok" }]
+  })
+}
 
 const propertylessObjectRegistry: ToolRegistry = {
-  tools: new Map([
-    [
-      "propertyless_tool",
-      {
-        name: "propertyless_tool",
-        description: "Tool with an object schema that does not declare properties.",
-        inputSchema: { type: "object" },
-        outputSchema: propertylessToolOutputSchema,
-        category: "test",
-        handler: async () => ({
-          content: [{ type: "text", text: "ok" }]
-        })
-      }
-    ]
-  ]),
-  definitions: [
-    {
-      name: "propertyless_tool",
-      description: "Tool with an object schema that does not declare properties.",
-      inputSchema: { type: "object" },
-      outputSchema: propertylessToolOutputSchema,
-      category: "test"
-    }
-  ],
+  tools: new Map([[propertylessTool.name, propertylessTool]]),
+  definitions: [propertylessTool],
   handleToolCall: async () => null
 }
 
@@ -534,7 +535,8 @@ const proxyExposureOptions = (config?: {
     proxyOutputStrict: config?.proxyOutputStrict ?? false
   },
   toolScopeFilteringActive: config?.toolScopeFilteringActive ?? false,
-  currentClientInfo: () => (config?.clientName === undefined ? undefined : { name: config.clientName })
+  currentClientInfo: () =>
+    config?.clientName === undefined ? undefined : parseMcpClientInfo({ name: config.clientName })
 })
 
 // Narrow the MCP content union to the text variant (no cast).
@@ -892,7 +894,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     const clients = await buildStubClients()()
 
     const response = await exposure.visibleNativeRegistry.handleToolCall(
-      "list_projects",
+      makeToolName("list_projects"),
       {},
       clients.hulyClient,
       clients.storageClient
@@ -1233,13 +1235,13 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
   it("returns target proxy errors and null dispatches without wrapping them as successes", async () => {
     const clients = await buildStubClients()()
     const errorResponse = await handleProxyToolCall({
-      toolName: "invoke_tool",
+      toolName: makeToolName("invoke_tool"),
       args: { toolName: "diagnostic_probe", arguments: {} },
       proxyCandidateRegistry: errorProxyRegistry,
       clients
     })
     const nullResponse = await handleProxyToolCall({
-      toolName: "invoke_tool",
+      toolName: makeToolName("invoke_tool"),
       args: { toolName: "diagnostic_probe", arguments: {} },
       proxyCandidateRegistry: nullDispatchProxyRegistry,
       clients
@@ -1253,17 +1255,17 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
 
   it("reports missing proxy clients and unknown proxy meta-tool names", async () => {
     const invalidListCategories = await handleProxyToolCall({
-      toolName: "list_tool_categories",
+      toolName: makeToolName("list_tool_categories"),
       args: "not an object",
       proxyCandidateRegistry: diagnosticProbeRegistry
     })
     const missingClients = await handleProxyToolCall({
-      toolName: "invoke_tool",
+      toolName: makeToolName("invoke_tool"),
       args: { toolName: "diagnostic_probe", arguments: {} },
       proxyCandidateRegistry: diagnosticProbeRegistry
     })
     const unknown = await handleProxyToolCall({
-      toolName: "missing_proxy_meta_tool",
+      toolName: makeToolName("missing_proxy_meta_tool"),
       args: {},
       proxyCandidateRegistry: diagnosticProbeRegistry
     })
@@ -1276,7 +1278,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
   })
 
   it("lists scoped native pins in non-strict proxy mode while keeping full proxy discovery", async () => {
-    const scopedIssuesRegistry = createFilteredRegistry(new Set(["issues"]))
+    const scopedIssuesRegistry = createFilteredRegistry(categorySet("issues"))
     const handlers = createMcpProtocolHandlers(
       unusedResolveClients,
       createTelemetryProbe().telemetry,
@@ -1296,7 +1298,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
   })
 
   it("uses active scope as a hard allow-list when proxy output strict is true", async () => {
-    const scopedIssuesRegistry = createFilteredRegistry(new Set(["issues"]))
+    const scopedIssuesRegistry = createFilteredRegistry(categorySet("issues"))
     const handlers = createMcpProtocolHandlers(
       unusedResolveClients,
       createTelemetryProbe().telemetry,
@@ -1323,7 +1325,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     const handlers = createMcpProtocolHandlers(
       buildStubClients(),
       createTelemetryProbe().telemetry,
-      protocolRegistries(diagnosticProbeRegistry, createFilteredRegistry(new Set(["missing_category"]))),
+      protocolRegistries(diagnosticProbeRegistry, createFilteredRegistry(categorySet("missing_category"))),
       makeValidContext,
       liveNowClock,
       () => Promise.resolve("0.0.0"),

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -979,9 +979,9 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(searchResult.matches.some((match) => isJsonObject(match) && match.category === "channels")).toBe(true)
   })
 
-  it("rejects direct calls to hidden native tools but exposes them through proxy search and schema lookup", async () => {
+  it("dispatches direct hidden native calls through proxy candidates for compatibility", async () => {
     const handlers = createMcpProtocolHandlers(
-      unusedResolveClients,
+      buildStubClients(),
       createTelemetryProbe().telemetry,
       protocolRegistries(toolRegistry),
       makeValidContext,
@@ -996,8 +996,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
       params: { name: "get_tool_schema", arguments: { toolName: "list_projects" } }
     })
 
-    expect(direct.isError).toBe(true)
-    expect(firstText(direct.content)).toContain("Unknown tool")
+    expect(direct.isError).not.toBe(true)
     expect(firstText(search.content)).toContain("list_projects")
     expect(schema.isError).not.toBe(true)
     expect(firstText(schema.content)).toContain("\"name\":\"list_projects\"")
@@ -1280,7 +1279,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
   it("lists scoped native pins in non-strict proxy mode while keeping full proxy discovery", async () => {
     const scopedIssuesRegistry = createFilteredRegistry(categorySet("issues"))
     const handlers = createMcpProtocolHandlers(
-      unusedResolveClients,
+      buildStubClients(),
       createTelemetryProbe().telemetry,
       protocolRegistries(toolRegistry, scopedIssuesRegistry),
       makeValidContext,
@@ -1291,18 +1290,20 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
 
     const listed = await handlers.listTools()
     const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "documents" } } })
+    const directHidden = await handlers.callTool({ params: { name: "list_projects", arguments: {} } })
 
     expect(listed.tools.map((tool) => tool.name)).toContain("list_issues")
     expect(listed.tools.map((tool) => tool.name)).not.toContain("list_documents")
     expect(firstText(search.content)).toContain("list_documents")
+    expect(directHidden.isError).not.toBe(true)
   })
 
   it("uses active scope as a hard allow-list when proxy output strict is true", async () => {
-    const scopedIssuesRegistry = createFilteredRegistry(categorySet("issues"))
+    const scopedProjectsRegistry = createFilteredRegistry(categorySet("projects"))
     const handlers = createMcpProtocolHandlers(
-      unusedResolveClients,
+      buildStubClients(),
       createTelemetryProbe().telemetry,
-      protocolRegistries(toolRegistry, scopedIssuesRegistry),
+      protocolRegistries(toolRegistry, scopedProjectsRegistry),
       makeValidContext,
       liveNowClock,
       () => Promise.resolve("0.0.0"),
@@ -1310,15 +1311,19 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     )
 
     const listed = await handlers.listTools()
-    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "documents" } } })
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "projects" } } })
     const schema = await handlers.callTool({
       params: { name: "get_tool_schema", arguments: { toolName: "list_documents" } }
     })
+    const directScoped = await handlers.callTool({ params: { name: "list_projects", arguments: {} } })
+    const directHidden = await handlers.callTool({ params: { name: "list_documents", arguments: {} } })
 
-    expect(listed.tools.map((tool) => tool.name)).not.toContain("list_issues")
+    expect(listed.tools.map((tool) => tool.name)).not.toContain("list_projects")
     expect(firstText(search.content)).not.toContain("list_documents")
-    expect(firstText(search.content)).toContain("\"category\":\"issues\"")
+    expect(firstText(search.content)).toContain("\"category\":\"projects\"")
     expect(schema.isError).toBe(true)
+    expect(directScoped.isError).not.toBe(true)
+    expect(directHidden.isError).toBe(true)
   })
 
   it("blocks search, schema, and invocation candidates when strict active scope resolves to no tools", async () => {

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -501,11 +501,6 @@ const makeValidContext = (): GetHulyContextResult =>
       requestedTools: [],
       enabledTools: [],
       ignoredTools: [],
-      legacyToolsets: {
-        provided: false,
-        used: false,
-        ignored: false
-      },
       availableCategories: ["issues"],
       visibleRegisteredToolCount: 1,
       totalRegisteredToolCount: 1,

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -946,6 +946,37 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     })
   })
 
+  it("uses descriptive category metadata for category listing and search", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const categories = await handlers.callTool({ params: { name: "list_tool_categories", arguments: {} } })
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "messaging" } } })
+    const categoryResult = categories.structuredContent?.result
+    const searchResult = search.structuredContent?.result
+
+    if (!isJsonObject(categoryResult) || !Array.isArray(categoryResult.categories)) {
+      throw new Error("expected category result")
+    }
+    const channelsCategory = categoryResult.categories.find((category) =>
+      isJsonObject(category) && category.name === "channels"
+    )
+    if (!isJsonObject(channelsCategory)) throw new Error("expected channels category")
+    expect(channelsCategory.description).toContain("Messaging")
+
+    if (!isJsonObject(searchResult) || !Array.isArray(searchResult.matches)) {
+      throw new Error("expected search result")
+    }
+    expect(searchResult.matches.some((match) => isJsonObject(match) && match.category === "channels")).toBe(true)
+  })
+
   it("rejects direct calls to hidden native tools but exposes them through proxy search and schema lookup", async () => {
     const handlers = createMcpProtocolHandlers(
       unusedResolveClients,

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -492,6 +492,24 @@ const makeValidContext = (): GetHulyContextResult =>
       visibleRegisteredToolCount: 1,
       totalRegisteredToolCount: 1,
       builtinTools: ["get_version", "get_huly_context"]
+    },
+    toolScope: {
+      active: false,
+      requestedToolsets: [],
+      enabledToolsets: [],
+      ignoredToolsets: [],
+      requestedTools: [],
+      enabledTools: [],
+      ignoredTools: [],
+      legacyToolsets: {
+        provided: false,
+        used: false,
+        ignored: false
+      },
+      availableCategories: ["issues"],
+      visibleRegisteredToolCount: 1,
+      totalRegisteredToolCount: 1,
+      builtinTools: ["get_version", "get_huly_context"]
     }
   })
 

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -57,7 +57,7 @@ import {
   requiresArgumentsObject
 } from "../../src/mcp/tools/registry.js"
 import { createNoopTelemetry } from "../../src/telemetry/noop.js"
-import type { TelemetryOperations, ToolCalledProps } from "../../src/telemetry/telemetry.js"
+import type { FirstListToolsProps, TelemetryOperations, ToolCalledProps } from "../../src/telemetry/telemetry.js"
 import { VERSION } from "../../src/version.js"
 
 // A real, empty tool registry (no category tools) — used for the builtin-only paths.
@@ -75,14 +75,14 @@ const unusedGetHulyContext = (): GetHulyContextResult => {
 const createTelemetryProbe = (): {
   telemetry: TelemetryOperations
   toolCalled: Array<ToolCalledProps>
-  firstListTools: Array<true>
+  firstListTools: Array<FirstListToolsProps | undefined>
 } => {
   const toolCalled: Array<ToolCalledProps> = []
-  const firstListTools: Array<true> = []
+  const firstListTools: Array<FirstListToolsProps | undefined> = []
   const telemetry: TelemetryOperations = {
     ...createNoopTelemetry(),
-    firstListTools: () => {
-      firstListTools.push(true)
+    firstListTools: (props) => {
+      firstListTools.push(props)
     },
     toolCalled: (props) => {
       toolCalled.push(props)
@@ -188,6 +188,30 @@ describe("createMcpProtocolHandlers", () => {
       expect(contextTool?.outputSchema).toHaveProperty(["$defs", "NonEmptyTrimmedString"])
       expect(contextTool?.outputSchema?.properties?.result).not.toHaveProperty("$defs")
       expect(probe.firstListTools).toHaveLength(1)
+      expect(assertAt(probe.firstListTools, 0)).toMatchObject({
+        clientKind: "unknown",
+        resolvedMode: "native"
+      })
+    })
+
+    it("records resolved client classification on first listTools", async () => {
+      const probe = createTelemetryProbe()
+      const handlers = createMcpProtocolHandlers(
+        unusedResolveClients,
+        probe.telemetry,
+        emptyRegistry,
+        unusedGetHulyContext,
+        liveNowClock,
+        () => Promise.resolve("0.0.0"),
+        proxyExposureOptions({ clientName: "codex-cli" })
+      )
+
+      await handlers.listTools()
+
+      expect(assertAt(probe.firstListTools, 0)).toMatchObject({
+        clientKind: "codex",
+        resolvedMode: "proxy"
+      })
     })
 
     it("omits properties when a registered object schema does not declare them", async () => {
@@ -620,7 +644,8 @@ describe("createMcpProtocolHandlers — version tool", () => {
       emptyRegistry,
       unusedGetHulyContext,
       queuedClock([1000, 1100]),
-      () => Promise.resolve("9.9.9")
+      () => Promise.resolve("9.9.9"),
+      proxyExposureOptions({ clientName: "codex-cli" })
     )
 
     const response = await handlers.callTool({ params: { name: VERSION_TOOL_NAME, arguments: {} } })
@@ -631,6 +656,8 @@ describe("createMcpProtocolHandlers — version tool", () => {
     expect(assertAt(probe.toolCalled, 0)).toMatchObject({
       toolName: VERSION_TOOL_NAME,
       status: "success",
+      clientKind: "codex",
+      resolvedMode: "proxy",
       durationMs: 100
     })
   })
@@ -655,6 +682,54 @@ describe("createMcpProtocolHandlers — version tool", () => {
     expect(response.isError).toBe(true)
     expect(fetched).toBe(false)
     expect(probe.toolCalled[0]?.status).toBe("error")
+  })
+
+  it("rejects malformed tool names before native registry lookup", async () => {
+    const probe = createTelemetryProbe()
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      probe.telemetry,
+      emptyRegistry,
+      unusedGetHulyContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions({ clientName: "codex-cli" })
+    )
+
+    const response = await handlers.callTool({ params: { name: " ", arguments: {} } })
+
+    expect(response.isError).toBe(true)
+    expect(firstText(response.content)).toContain("Unknown tool")
+    expect(assertAt(probe.toolCalled, 0)).toMatchObject({
+      toolName: " ",
+      status: "error",
+      clientKind: "codex",
+      resolvedMode: "proxy"
+    })
+  })
+
+  it("maps an invalid fetched latest version to an error", async () => {
+    const probe = createTelemetryProbe()
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      probe.telemetry,
+      emptyRegistry,
+      unusedGetHulyContext,
+      queuedClock([1000, 1100]),
+      () => Promise.resolve(""),
+      proxyExposureOptions({ clientName: "codex-cli" })
+    )
+
+    const response = await handlers.callTool({ params: { name: VERSION_TOOL_NAME, arguments: {} } })
+
+    expect(response.isError).toBe(true)
+    expect(firstText(response.content)).toBe("Failed to build version result")
+    expect(assertAt(probe.toolCalled, 0)).toMatchObject({
+      toolName: VERSION_TOOL_NAME,
+      status: "error",
+      clientKind: "codex",
+      resolvedMode: "proxy"
+    })
   })
 })
 

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -25,6 +25,8 @@ import { Diagnostics } from "../../src/huly/diagnostics.js"
 import { HulyConnectionError } from "../../src/huly/errors.js"
 import { task, tracker } from "../../src/huly/huly-plugins.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
+import { WorkspaceClient } from "../../src/huly/workspace-client.js"
+import { createInvalidParamsError } from "../../src/mcp/error-mapping.js"
 import {
   buildHulyContext,
   GET_HULY_CONTEXT_TOOL_NAME,
@@ -39,6 +41,8 @@ import {
   liveNowClock,
   type NowClock
 } from "../../src/mcp/protocol-handlers.js"
+import { resolveProtocolExposure, toListedTool } from "../../src/mcp/protocol-tool-exposure.js"
+import { handleProxyToolCall } from "../../src/mcp/proxy-tools.js"
 import { createToolOutputSchema } from "../../src/mcp/tool-output-schema.js"
 import { createFilteredRegistry, type ToolRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
 import { defineTool, isNoArgumentTool, requiresArgumentsObject } from "../../src/mcp/tools/registry.js"
@@ -190,6 +194,26 @@ describe("createMcpProtocolHandlers", () => {
       expect(listed?.inputSchema).not.toHaveProperty("properties")
     })
 
+    it("omits optional output schema and annotations when converting a bare listed tool", () => {
+      const listed = toListedTool({
+        name: "bare_tool",
+        description: "Tool used to exercise protocol schema conversion.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            valid: { type: "string" },
+            ignored: "not an object"
+          },
+          required: ["valid"],
+          additionalProperties: false
+        }
+      })
+
+      expect(listed.outputSchema).toBeUndefined()
+      expect(listed.annotations).toBeUndefined()
+      expect(listed.inputSchema.properties).toEqual({ valid: { type: "string" } })
+    })
+
     it("lists every registered category tool after schema compatibility conversion", async () => {
       const handlers = createMcpProtocolHandlers(
         unusedResolveClients,
@@ -292,6 +316,20 @@ const buildStubClients = (hulyOps: Partial<HulyClientOperations> = {}): () => Pr
         Layer.merge(HulyClient.testLayer(hulyOps), HulyStorageClient.testLayer({}))
       ).pipe(Effect.scoped)
       return { hulyClient: Context.get(ctx, HulyClient), storageClient: Context.get(ctx, HulyStorageClient) }
+    })
+  )
+
+const buildStubClientsWithWorkspace = (): () => Promise<ClientBundle> => () =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      const ctx = yield* Layer.build(
+        Layer.mergeAll(HulyClient.testLayer({}), HulyStorageClient.testLayer({}), WorkspaceClient.testLayer({}))
+      ).pipe(Effect.scoped)
+      return {
+        hulyClient: Context.get(ctx, HulyClient),
+        storageClient: Context.get(ctx, HulyStorageClient),
+        workspaceClient: Context.get(ctx, WorkspaceClient)
+      }
     })
   )
 
@@ -437,6 +475,18 @@ const diagnosticProbeTool = defineTool(
     })
 )
 
+const arraySchemaProbeTool = defineTool(
+  {
+    name: "array_schema_probe",
+    description: "array schema probe tool",
+    inputSchema: [],
+    resultSchema: Schema.Struct({ ok: Schema.Boolean }),
+    category: "test"
+  },
+  Schema.decodeUnknown(Schema.Unknown),
+  () => Effect.succeed({ ok: true })
+)
+
 const diagnosticProbeRegistry: ToolRegistry = {
   tools: new Map([[diagnosticProbeTool.name, diagnosticProbeTool]]),
   definitions: [diagnosticProbeTool],
@@ -445,6 +495,47 @@ const diagnosticProbeRegistry: ToolRegistry = {
     return diagnosticProbeTool.handler(args ?? {}, hulyClient, storageClient, workspaceClient)
   }
 }
+
+const contentOnlyProxyRegistry: ToolRegistry = {
+  ...diagnosticProbeRegistry,
+  handleToolCall: async () => ({
+    content: [{ type: "text", text: "plain target output" }]
+  })
+}
+
+const errorProxyRegistry: ToolRegistry = {
+  ...diagnosticProbeRegistry,
+  handleToolCall: async () => createInvalidParamsError("target rejected arguments", "TargetRejected")
+}
+
+const nullDispatchProxyRegistry: ToolRegistry = {
+  ...diagnosticProbeRegistry,
+  handleToolCall: async () => null
+}
+
+const arraySchemaProbeRegistry: ToolRegistry = {
+  tools: new Map([[arraySchemaProbeTool.name, arraySchemaProbeTool]]),
+  definitions: [arraySchemaProbeTool],
+  handleToolCall: async () => null
+}
+
+const protocolRegistries = (fullRegistry: ToolRegistry, scopedNativeRegistry: ToolRegistry = fullRegistry) => ({
+  fullRegistry,
+  scopedNativeRegistry
+})
+
+const proxyExposureOptions = (config?: {
+  proxyOutputStrict?: boolean
+  toolScopeFilteringActive?: boolean
+  clientName?: string
+}) => ({
+  exposureConfig: {
+    configuredMode: "proxy" as const,
+    proxyOutputStrict: config?.proxyOutputStrict ?? false
+  },
+  toolScopeFilteringActive: config?.toolScopeFilteringActive ?? false,
+  currentClientInfo: () => (config?.clientName === undefined ? undefined : { name: config.clientName })
+})
 
 // Narrow the MCP content union to the text variant (no cast).
 const firstText = (content: ReadonlyArray<unknown>): string => {
@@ -505,6 +596,16 @@ const makeValidContext = (): GetHulyContextResult =>
       visibleRegisteredToolCount: 1,
       totalRegisteredToolCount: 1,
       builtinTools: ["get_version", "get_huly_context"]
+    },
+    toolExposure: {
+      configuredMode: "auto",
+      resolvedMode: "native",
+      clientKind: "unknown",
+      proxyOutputStrict: false,
+      visibleToolCount: 3,
+      nativeVisibleToolCount: 1,
+      proxyCandidateToolCount: 1,
+      proxyToolNames: []
     }
   })
 
@@ -600,6 +701,36 @@ describe("createMcpProtocolHandlers — get_huly_context tool", () => {
     const response = await handlers.callTool({ params: { name: GET_HULY_CONTEXT_TOOL_NAME, arguments: { x: 1 } } })
 
     expect(response.isError).toBe(true)
+  })
+
+  it("passes resolved proxy exposure into the context result", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      (toolExposure) =>
+        buildHulyContext(
+          { transport: "stdio" },
+          toolRegistry,
+          parseToolsets(undefined, () => {}),
+          sanitizeHulyRuntimeConfigFromEnv({}),
+          toolExposure
+        ),
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions({ clientName: "codex-cli" })
+    )
+
+    const response = await handlers.callTool({ params: { name: GET_HULY_CONTEXT_TOOL_NAME, arguments: {} } })
+
+    expect(response.structuredContent?.result).toMatchObject({
+      toolExposure: {
+        configuredMode: "proxy",
+        resolvedMode: "proxy",
+        clientKind: "codex",
+        proxyToolNames: ["list_tool_categories", "search_tools", "get_tool_schema", "invoke_tool"]
+      }
+    })
   })
 })
 
@@ -749,6 +880,436 @@ describe("createMcpProtocolHandlers — tool dispatch", () => {
     const response = await handlers.callTool({ params: { name: argsTool.name } })
 
     expect(response.isError).toBe(true)
+  })
+})
+
+describe("createMcpProtocolHandlers — proxy mode", () => {
+  it("uses an empty visible native registry for unscoped proxy mode", async () => {
+    const exposure = resolveProtocolExposure(
+      protocolRegistries(toolRegistry),
+      proxyExposureOptions()
+    )
+    const clients = await buildStubClients()()
+
+    const response = await exposure.visibleNativeRegistry.handleToolCall(
+      "list_projects",
+      {},
+      clients.hulyClient,
+      clients.storageClient
+    )
+
+    expect(exposure.visibleNativeRegistry.definitions).toEqual([])
+    expect(response).toBeNull()
+  })
+
+  it("lists builtins and proxy meta-tools while hiding native tools when unscoped", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const listed = await handlers.listTools()
+    const names = listed.tools.map((tool) => tool.name)
+
+    expect(names).toEqual([
+      "get_version",
+      "get_huly_context",
+      "list_tool_categories",
+      "search_tools",
+      "get_tool_schema",
+      "invoke_tool"
+    ])
+    expect(names).not.toContain("list_projects")
+  })
+
+  it("lists proxy categories from the active candidate registry", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(diagnosticProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({ params: { name: "list_tool_categories", arguments: {} } })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toEqual({
+      categories: [{ name: "test", description: "Huly test tools.", toolCount: 1 }]
+    })
+  })
+
+  it("rejects direct calls to hidden native tools but exposes them through proxy search and schema lookup", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const direct = await handlers.callTool({ params: { name: "list_projects", arguments: {} } })
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "list projects" } } })
+    const schema = await handlers.callTool({
+      params: { name: "get_tool_schema", arguments: { toolName: "list_projects" } }
+    })
+
+    expect(direct.isError).toBe(true)
+    expect(firstText(direct.content)).toContain("Unknown tool")
+    expect(firstText(search.content)).toContain("list_projects")
+    expect(schema.isError).not.toBe(true)
+    expect(firstText(schema.content)).toContain("\"name\":\"list_projects\"")
+  })
+
+  it("keeps search param summaries root-required only and returns exact schemas for proxy lookup", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "edit_document" } } })
+    const schema = await handlers.callTool({
+      params: { name: "get_tool_schema", arguments: { toolName: "edit_document" } }
+    })
+    const searchResult = search.structuredContent?.result
+    const schemaResult = schema.structuredContent?.result
+
+    if (!isJsonObject(searchResult) || !Array.isArray(searchResult.matches)) {
+      throw new Error("expected search result matches")
+    }
+    const editMatch = searchResult.matches.find((match) => isJsonObject(match) && match.name === "edit_document")
+    if (!isJsonObject(editMatch)) throw new Error("expected edit_document search match")
+    expect(editMatch.requiredParams).toEqual(["teamspace", "document"])
+    expect(editMatch.optionalParams).toEqual(
+      expect.arrayContaining(["title", "content", "old_text", "new_text"])
+    )
+
+    if (!isJsonObject(schemaResult) || !isJsonObject(schemaResult.inputSchema)) {
+      throw new Error("expected schema lookup result")
+    }
+    expect(schemaResult.inputSchema.anyOf).toEqual([
+      { required: ["title"] },
+      { required: ["content"] },
+      { required: ["old_text", "new_text"] }
+    ])
+    expect(schemaResult.inputSchema).toHaveProperty("allOf")
+  })
+
+  it("ranks exact tool-name matches first and handles non-record input schemas in summaries", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(arraySchemaProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({
+      params: { name: "search_tools", arguments: { query: "array_schema_probe" } }
+    })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toEqual({
+      matches: [{
+        name: "array_schema_probe",
+        category: "test",
+        description: "array schema probe tool",
+        requiredParams: [],
+        optionalParams: []
+      }]
+    })
+  })
+
+  it("rejects proxy meta-tools directly in native mode", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext
+    )
+
+    const response = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "projects" } } })
+
+    expect(response.isError).toBe(true)
+    expect(firstText(response.content)).toContain("Unknown tool")
+  })
+
+  it("validates proxy meta-tool arguments before returning catalog data", async () => {
+    const handlers = createMcpProtocolHandlers(
+      buildStubClients(),
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const search = await handlers.callTool({ params: { name: "search_tools" } })
+    const schema = await handlers.callTool({ params: { name: "get_tool_schema", arguments: { toolName: "   " } } })
+    const invoked = await handlers.callTool({ params: { name: "invoke_tool", arguments: { toolName: "   " } } })
+
+    expect(search.isError).toBe(true)
+    expect(schema.isError).toBe(true)
+    expect(invoked.isError).toBe(true)
+  })
+
+  it("invokes a proxy candidate and wraps the target result with warnings", async () => {
+    const handlers = createMcpProtocolHandlers(
+      buildStubClients(),
+      createTelemetryProbe().telemetry,
+      protocolRegistries(diagnosticProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({
+      params: {
+        name: "invoke_tool",
+        arguments: {
+          toolName: "diagnostic_probe",
+          arguments: { subject: "proxy invoke" }
+        }
+      }
+    })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toEqual({
+      toolName: "diagnostic_probe",
+      result: { subject: "proxy invoke", degraded: true },
+      warnings: [{
+        code: "status_metadata_unresolved",
+        message: "Status metadata was degraded for proxy invoke."
+      }]
+    })
+  })
+
+  it("passes workspace clients into proxy invocation when available", async () => {
+    const handlers = createMcpProtocolHandlers(
+      buildStubClientsWithWorkspace(),
+      createTelemetryProbe().telemetry,
+      protocolRegistries(diagnosticProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({
+      params: {
+        name: "invoke_tool",
+        arguments: {
+          toolName: "diagnostic_probe",
+          arguments: { subject: "with workspace" }
+        }
+      }
+    })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toMatchObject({
+      toolName: "diagnostic_probe",
+      result: { subject: "with workspace", degraded: true }
+    })
+  })
+
+  it("maps proxy invoke client-resolution failures to tool errors", async () => {
+    const probe = createTelemetryProbe()
+    const errorHandlers = createMcpProtocolHandlers(
+      rejectingResolveClients,
+      probe.telemetry,
+      protocolRegistries(diagnosticProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+    const nonErrorHandlers = createMcpProtocolHandlers(
+      rejectingResolveClientsWithString,
+      probe.telemetry,
+      protocolRegistries(diagnosticProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const errorResponse = await errorHandlers.callTool({
+      params: {
+        name: "invoke_tool",
+        arguments: {
+          toolName: "diagnostic_probe",
+          arguments: { subject: "client failure" }
+        }
+      }
+    })
+    const nonErrorResponse = await nonErrorHandlers.callTool({
+      params: {
+        name: "invoke_tool",
+        arguments: {
+          toolName: "diagnostic_probe",
+          arguments: { subject: "client failure" }
+        }
+      }
+    })
+
+    expect(errorResponse.isError).toBe(true)
+    expect(firstText(errorResponse.content)).toContain("client init boom")
+    expect(nonErrorResponse.isError).toBe(true)
+    expect(firstText(nonErrorResponse.content)).toContain("client init boom")
+    expect(probe.toolCalled.map(call => call.status)).toEqual(["error", "error"])
+  })
+
+  it("wraps content-only proxy target output without warnings", async () => {
+    const handlers = createMcpProtocolHandlers(
+      buildStubClients(),
+      createTelemetryProbe().telemetry,
+      protocolRegistries(contentOnlyProxyRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({
+      params: { name: "invoke_tool", arguments: { toolName: "diagnostic_probe", arguments: {} } }
+    })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toEqual({
+      toolName: "diagnostic_probe",
+      result: [{ type: "text", text: "plain target output" }]
+    })
+  })
+
+  it("returns target proxy errors and null dispatches without wrapping them as successes", async () => {
+    const clients = await buildStubClients()()
+    const errorResponse = await handleProxyToolCall({
+      toolName: "invoke_tool",
+      args: { toolName: "diagnostic_probe", arguments: {} },
+      proxyCandidateRegistry: errorProxyRegistry,
+      clients
+    })
+    const nullResponse = await handleProxyToolCall({
+      toolName: "invoke_tool",
+      args: { toolName: "diagnostic_probe", arguments: {} },
+      proxyCandidateRegistry: nullDispatchProxyRegistry,
+      clients
+    })
+
+    expect(errorResponse.isError).toBe(true)
+    expect(firstText(errorResponse.content)).toContain("target rejected arguments")
+    expect(nullResponse.isError).toBe(true)
+    expect(firstText(nullResponse.content)).toContain("Unknown tool")
+  })
+
+  it("reports missing proxy clients and unknown proxy meta-tool names", async () => {
+    const invalidListCategories = await handleProxyToolCall({
+      toolName: "list_tool_categories",
+      args: "not an object",
+      proxyCandidateRegistry: diagnosticProbeRegistry
+    })
+    const missingClients = await handleProxyToolCall({
+      toolName: "invoke_tool",
+      args: { toolName: "diagnostic_probe", arguments: {} },
+      proxyCandidateRegistry: diagnosticProbeRegistry
+    })
+    const unknown = await handleProxyToolCall({
+      toolName: "missing_proxy_meta_tool",
+      args: {},
+      proxyCandidateRegistry: diagnosticProbeRegistry
+    })
+
+    expect(invalidListCategories.isError).toBe(true)
+    expect(missingClients.isError).toBe(true)
+    expect(firstText(missingClients.content)).toContain("requires initialized Huly clients")
+    expect(unknown.isError).toBe(true)
+    expect(firstText(unknown.content)).toContain("Unknown tool")
+  })
+
+  it("lists scoped native pins in non-strict proxy mode while keeping full proxy discovery", async () => {
+    const scopedIssuesRegistry = createFilteredRegistry(new Set(["issues"]))
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry, scopedIssuesRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions({ toolScopeFilteringActive: true })
+    )
+
+    const listed = await handlers.listTools()
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "documents" } } })
+
+    expect(listed.tools.map((tool) => tool.name)).toContain("list_issues")
+    expect(listed.tools.map((tool) => tool.name)).not.toContain("list_documents")
+    expect(firstText(search.content)).toContain("list_documents")
+  })
+
+  it("uses active scope as a hard allow-list when proxy output strict is true", async () => {
+    const scopedIssuesRegistry = createFilteredRegistry(new Set(["issues"]))
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(toolRegistry, scopedIssuesRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions({ proxyOutputStrict: true, toolScopeFilteringActive: true })
+    )
+
+    const listed = await handlers.listTools()
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "documents" } } })
+    const schema = await handlers.callTool({
+      params: { name: "get_tool_schema", arguments: { toolName: "list_documents" } }
+    })
+
+    expect(listed.tools.map((tool) => tool.name)).not.toContain("list_issues")
+    expect(firstText(search.content)).not.toContain("list_documents")
+    expect(firstText(search.content)).toContain("\"category\":\"issues\"")
+    expect(schema.isError).toBe(true)
+  })
+
+  it("blocks search, schema, and invocation candidates when strict active scope resolves to no tools", async () => {
+    const handlers = createMcpProtocolHandlers(
+      buildStubClients(),
+      createTelemetryProbe().telemetry,
+      protocolRegistries(diagnosticProbeRegistry, createFilteredRegistry(new Set(["missing_category"]))),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions({ proxyOutputStrict: true, toolScopeFilteringActive: true })
+    )
+
+    const search = await handlers.callTool({ params: { name: "search_tools", arguments: { query: "diagnostic" } } })
+    const schema = await handlers.callTool({
+      params: { name: "get_tool_schema", arguments: { toolName: "diagnostic_probe" } }
+    })
+    const invoked = await handlers.callTool({
+      params: { name: "invoke_tool", arguments: { toolName: "diagnostic_probe", arguments: { subject: "x" } } }
+    })
+
+    expect(firstText(search.content)).toBe("{\"matches\":[]}")
+    expect(schema.isError).toBe(true)
+    expect(invoked.isError).toBe(true)
   })
 })
 

--- a/test/mcp/proxy-tools.property.test.ts
+++ b/test/mcp/proxy-tools.property.test.ts
@@ -4,30 +4,39 @@ import { describe, expect, it } from "vitest"
 
 import { createSuccessResponse } from "../../src/mcp/error-mapping.js"
 import { resolveProtocolExposure } from "../../src/mcp/protocol-tool-exposure.js"
-import { searchToolDefinitions } from "../../src/mcp/proxy-tools.js"
+import { makeSearchToolLimit, makeToolSearchQuery, searchToolDefinitions } from "../../src/mcp/proxy-tools.js"
+import { parseMcpClientInfo } from "../../src/mcp/tool-mode.js"
 import { createToolOutputSchema } from "../../src/mcp/tool-output-schema.js"
 import { CATEGORY_NAMES, createScopedRegistry, type ToolRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
-import type { RegisteredTool } from "../../src/mcp/tools/registry.js"
+import {
+  createToolDefinition,
+  makeToolCategory,
+  makeToolName,
+  type RegisteredTool
+} from "../../src/mcp/tools/registry.js"
 import { propertyTestParameters } from "../helpers/property.js"
 
 const knownCategories = [...CATEGORY_NAMES]
 const knownToolNames = toolRegistry.definitions.map((tool) => tool.name)
 const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
 const knownToolNameArbitrary = fc.constantFrom(...knownToolNames)
-const queryArbitrary = fc.string({ minLength: 1, maxLength: 40 })
+const queryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{0,39}$/).map(makeToolSearchQuery)
+const searchLimitArbitrary = fc.integer({ min: 1, max: 50 }).map(makeSearchToolLimit)
 
 const generatedOutputSchema = createToolOutputSchema(Schema.Struct({ ok: Schema.Boolean }))
 
 const generatedTool = (name: string): RegisteredTool => ({
-  name,
-  description: "alpha generated tool",
-  inputSchema: {
-    type: "object",
-    properties: { shared: { type: "string" } },
-    additionalProperties: false
-  },
-  outputSchema: generatedOutputSchema,
-  category: "generated",
+  ...createToolDefinition({
+    name,
+    description: "alpha generated tool",
+    inputSchema: {
+      type: "object",
+      properties: { shared: { type: "string" } },
+      additionalProperties: false
+    },
+    outputSchema: generatedOutputSchema,
+    category: "generated"
+  }),
   handler: async () => createSuccessResponse({ ok: true })
 })
 
@@ -40,11 +49,11 @@ const registryFromDefinitions = (definitions: ReadonlyArray<RegisteredTool>): To
 describe("proxy tool search properties", () => {
   it("returns only tools from the searched candidate registry", () => {
     fc.assert(
-      fc.property(queryArbitrary, fc.integer({ min: 1, max: 50 }), (query, limit) => {
+      fc.property(queryArbitrary, searchLimitArbitrary, (query, limit) => {
         const scoped = createScopedRegistry({
           filteringActive: true,
-          categories: new Set(["issues"]),
-          toolNames: new Set(["list_documents"])
+          categories: new Set([makeToolCategory("issues")]),
+          toolNames: new Set([makeToolName("list_documents")])
         })
         const resultNames = searchToolDefinitions(scoped, query, limit).map((tool) => tool.name)
 
@@ -73,7 +82,7 @@ describe("proxy tool search properties", () => {
             {
               exposureConfig: { configuredMode: "proxy", proxyOutputStrict: true },
               toolScopeFilteringActive: active,
-              currentClientInfo: () => ({ name: "codex" })
+              currentClientInfo: () => parseMcpClientInfo({ name: "codex" })
             }
           )
 
@@ -93,7 +102,7 @@ describe("proxy tool search properties", () => {
         (suffixes) => {
           const definitions = suffixes.map((suffix) => generatedTool(`alpha_${suffix}`))
           const registry = registryFromDefinitions(definitions)
-          const matches = searchToolDefinitions(registry, "alpha", 50)
+          const matches = searchToolDefinitions(registry, makeToolSearchQuery("alpha"), makeSearchToolLimit(50))
 
           expect(matches.map((tool) => tool.name)).toEqual(definitions.map((tool) => tool.name))
         }

--- a/test/mcp/proxy-tools.property.test.ts
+++ b/test/mcp/proxy-tools.property.test.ts
@@ -1,0 +1,104 @@
+import { Schema } from "effect"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import { createSuccessResponse } from "../../src/mcp/error-mapping.js"
+import { resolveProtocolExposure } from "../../src/mcp/protocol-tool-exposure.js"
+import { searchToolDefinitions } from "../../src/mcp/proxy-tools.js"
+import { createToolOutputSchema } from "../../src/mcp/tool-output-schema.js"
+import { CATEGORY_NAMES, createScopedRegistry, type ToolRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
+import type { RegisteredTool } from "../../src/mcp/tools/registry.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const knownCategories = [...CATEGORY_NAMES]
+const knownToolNames = toolRegistry.definitions.map((tool) => tool.name)
+const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
+const knownToolNameArbitrary = fc.constantFrom(...knownToolNames)
+const queryArbitrary = fc.string({ minLength: 1, maxLength: 40 })
+
+const generatedOutputSchema = createToolOutputSchema(Schema.Struct({ ok: Schema.Boolean }))
+
+const generatedTool = (name: string): RegisteredTool => ({
+  name,
+  description: "alpha generated tool",
+  inputSchema: {
+    type: "object",
+    properties: { shared: { type: "string" } },
+    additionalProperties: false
+  },
+  outputSchema: generatedOutputSchema,
+  category: "generated",
+  handler: async () => createSuccessResponse({ ok: true })
+})
+
+const registryFromDefinitions = (definitions: ReadonlyArray<RegisteredTool>): ToolRegistry => ({
+  tools: new Map(definitions.map((tool) => [tool.name, tool])),
+  definitions,
+  handleToolCall: async () => null
+})
+
+describe("proxy tool search properties", () => {
+  it("returns only tools from the searched candidate registry", () => {
+    fc.assert(
+      fc.property(queryArbitrary, fc.integer({ min: 1, max: 50 }), (query, limit) => {
+        const scoped = createScopedRegistry({
+          filteringActive: true,
+          categories: new Set(["issues"]),
+          toolNames: new Set(["list_documents"])
+        })
+        const resultNames = searchToolDefinitions(scoped, query, limit).map((tool) => tool.name)
+
+        for (const name of resultNames) {
+          expect(scoped.tools.has(name)).toBe(true)
+        }
+      }),
+      propertyTestParameters
+    )
+  })
+
+  it("strict proxy candidates are always a subset of the full registry", () => {
+    fc.assert(
+      fc.property(
+        fc.boolean(),
+        fc.array(knownCategoryArbitrary, { maxLength: 8 }),
+        fc.array(knownToolNameArbitrary, { maxLength: 8 }),
+        (active, categories, toolNames) => {
+          const scoped = createScopedRegistry({
+            filteringActive: true,
+            categories: new Set(categories),
+            toolNames: new Set(toolNames)
+          })
+          const exposure = resolveProtocolExposure(
+            { fullRegistry: toolRegistry, scopedNativeRegistry: scoped },
+            {
+              exposureConfig: { configuredMode: "proxy", proxyOutputStrict: true },
+              toolScopeFilteringActive: active,
+              currentClientInfo: () => ({ name: "codex" })
+            }
+          )
+
+          for (const tool of exposure.proxyCandidateRegistry.definitions) {
+            expect(toolRegistry.tools.get(tool.name)).toBe(tool)
+          }
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("preserves registry order when scores tie", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.stringMatching(/^[a-z][a-z0-9]{0,8}$/), { minLength: 1, maxLength: 20 }),
+        (suffixes) => {
+          const definitions = suffixes.map((suffix) => generatedTool(`alpha_${suffix}`))
+          const registry = registryFromDefinitions(definitions)
+          const matches = searchToolDefinitions(registry, "alpha", 50)
+
+          expect(matches.map((tool) => tool.name)).toEqual(definitions.map((tool) => tool.name))
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/mcp/registry.property.test.ts
+++ b/test/mcp/registry.property.test.ts
@@ -4,7 +4,12 @@ import * as fc from "fast-check"
 import { describe, expect, it } from "vitest"
 
 import { createToolOutputSchema } from "../../src/mcp/tool-output-schema.js"
-import { CATEGORY_NAMES, createFilteredRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
+import {
+  CATEGORY_NAMES,
+  createFilteredRegistry,
+  createScopedRegistry,
+  toolRegistry
+} from "../../src/mcp/tools/index.js"
 import {
   isNoArgumentTool,
   requiresArgumentsObject,
@@ -14,9 +19,14 @@ import {
 import { propertyTestParameters } from "../helpers/property.js"
 
 const knownCategories = [...CATEGORY_NAMES]
+const knownToolNames = toolRegistry.definitions.map((tool) => tool.name)
 const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
+const knownToolNameArbitrary = fc.constantFrom(...knownToolNames)
 const unknownCategoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{1,24}$/).filter(
   (category) => !CATEGORY_NAMES.has(category)
+)
+const unknownToolNameArbitrary = fc.stringMatching(/^[a-z][a-z0-9_]{1,32}$/).filter(
+  (name) => !toolRegistry.tools.has(name)
 )
 
 const wordArbitrary = fc.stringMatching(/^[a-z][a-z0-9]{0,10}$/)
@@ -118,6 +128,55 @@ describe("createFilteredRegistry properties", () => {
         expect(filtered.definitions).toEqual([])
         expect(filtered.tools.size).toBe(0)
       }),
+      propertyTestParameters
+    )
+  })
+})
+
+describe("createScopedRegistry properties", () => {
+  it("returns the full registry when filtering is inactive", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(knownCategoryArbitrary, unknownCategoryArbitrary), { maxLength: 12 }),
+        fc.array(fc.oneof(knownToolNameArbitrary, unknownToolNameArbitrary), { maxLength: 12 }),
+        (categories, toolNames) => {
+          const scoped = createScopedRegistry({
+            filteringActive: false,
+            categories: new Set(categories),
+            toolNames: new Set(toolNames)
+          })
+
+          expect(scoped).toBe(toolRegistry)
+        }
+      ),
+      propertyTestParameters
+    )
+  })
+
+  it("preserves registry order and always returns a subset when filtering is active", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(knownCategoryArbitrary, unknownCategoryArbitrary), { maxLength: 12 }),
+        fc.array(fc.oneof(knownToolNameArbitrary, unknownToolNameArbitrary), { maxLength: 12 }),
+        (categories, toolNames) => {
+          const requestedCategories = new Set(categories)
+          const requestedToolNames = new Set(toolNames)
+          const scoped = createScopedRegistry({
+            filteringActive: true,
+            categories: requestedCategories,
+            toolNames: requestedToolNames
+          })
+          const expected = toolRegistry.definitions.filter((tool) =>
+            requestedCategories.has(tool.category) || requestedToolNames.has(tool.name)
+          )
+
+          expect(scoped.definitions).toEqual(expected)
+          expect([...scoped.tools.keys()]).toEqual(expected.map((tool) => tool.name))
+          for (const tool of scoped.definitions) {
+            expect(toolRegistry.tools.get(tool.name)).toBe(tool)
+          }
+        }
+      ),
       propertyTestParameters
     )
   })

--- a/test/mcp/registry.property.test.ts
+++ b/test/mcp/registry.property.test.ts
@@ -11,7 +11,10 @@ import {
   toolRegistry
 } from "../../src/mcp/tools/index.js"
 import {
+  createToolDefinition,
   isNoArgumentTool,
+  makeToolCategory,
+  makeToolName,
   requiresArgumentsObject,
   resolveAnnotations,
   type ToolDefinition
@@ -22,10 +25,10 @@ const knownCategories = [...CATEGORY_NAMES]
 const knownToolNames = toolRegistry.definitions.map((tool) => tool.name)
 const knownCategoryArbitrary = fc.constantFrom(...knownCategories)
 const knownToolNameArbitrary = fc.constantFrom(...knownToolNames)
-const unknownCategoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{1,24}$/).filter(
+const unknownCategoryArbitrary = fc.stringMatching(/^[a-z][a-z0-9_-]{1,24}$/).map(makeToolCategory).filter(
   (category) => !CATEGORY_NAMES.has(category)
 )
-const unknownToolNameArbitrary = fc.stringMatching(/^[a-z][a-z0-9_]{1,32}$/).filter(
+const unknownToolNameArbitrary = fc.stringMatching(/^[a-z][a-z0-9_]{1,32}$/).map(makeToolName).filter(
   (name) => !toolRegistry.tools.has(name)
 )
 
@@ -90,11 +93,13 @@ const prefixCaseArbitrary = fc.constantFrom(
 )
 
 const toolDefinition = (name: string, inputSchema: object, annotations?: ToolAnnotations): ToolDefinition => ({
-  name,
-  description: "generated test tool",
-  inputSchema,
-  outputSchema: createToolOutputSchema(Schema.Struct({ generated: Schema.Boolean })),
-  category: "generated",
+  ...createToolDefinition({
+    name,
+    description: "generated test tool",
+    inputSchema,
+    outputSchema: createToolOutputSchema(Schema.Struct({ generated: Schema.Boolean })),
+    category: "generated"
+  }),
   ...(annotations !== undefined && { annotations })
 })
 
@@ -235,7 +240,7 @@ describe("tool argument schema properties", () => {
       propertyTestParameters
     )
 
-    const listProjectTypes = toolRegistry.tools.get("list_project_types")
+    const listProjectTypes = toolRegistry.tools.get(makeToolName("list_project_types"))
 
     expect(listProjectTypes).toBeDefined()
     if (listProjectTypes !== undefined) {

--- a/test/mcp/server-parseToolsets.test.ts
+++ b/test/mcp/server-parseToolsets.test.ts
@@ -6,6 +6,7 @@ import { HulyStorageClient } from "../../src/huly/storage.js"
 import { WorkspaceClient } from "../../src/huly/workspace-client.js"
 import { HttpServerFactoryService } from "../../src/mcp/http-transport.js"
 import { type ClientBundle, McpServerError, McpServerService } from "../../src/mcp/server.js"
+import { createScopedRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
 import { TelemetryService } from "../../src/telemetry/telemetry.js"
 import { mockFn } from "../helpers/mock-fn.js"
 
@@ -143,6 +144,41 @@ describe("McpServerService.layer with TOOLSETS env", () => {
       yield* Layer.build(serverLayer)
       delete process.env.TOOLSETS
     }))
+
+  it.scoped("builds scoped registry from HULY_TOOLSETS and HULY_TOOLS", () => {
+    let capturedToolCount = 0
+    let capturedToolsets: ReadonlyArray<string> | null = null
+    const expectedRegistry = createScopedRegistry({
+      filteringActive: true,
+      categories: new Set(["issues"]),
+      toolNames: new Set(["list_documents"])
+    })
+    return Effect.gen(function*() {
+      process.env.HULY_TOOLSETS = "issues"
+      process.env.HULY_TOOLS = "list_documents"
+      const telemetryLayer = TelemetryService.testLayer({
+        sessionStart: (props) => {
+          capturedToolCount = props.toolCount
+          capturedToolsets = props.toolsets
+        }
+      })
+      const layers = Layer.mergeAll(
+        HulyClient.testLayer({}),
+        HulyStorageClient.testLayer({}),
+        WorkspaceClient.testLayer({}),
+        telemetryLayer
+      )
+
+      const serverLayer = buildTestServerLayer({ transport: "stdio" }, layers)
+      yield* Layer.build(serverLayer)
+
+      expect(capturedToolsets).toEqual(["issues"])
+      expect(capturedToolCount).toBe(expectedRegistry.definitions.length)
+      expect(expectedRegistry.tools.get("list_documents")).toBe(toolRegistry.tools.get("list_documents"))
+      delete process.env.HULY_TOOLSETS
+      delete process.env.HULY_TOOLS
+    })
+  })
 
   it.scoped("ignores unknown toolset categories and still builds", () => {
     const writeError = mockFn()

--- a/test/mcp/server-parseToolsets.test.ts
+++ b/test/mcp/server-parseToolsets.test.ts
@@ -7,6 +7,7 @@ import { WorkspaceClient } from "../../src/huly/workspace-client.js"
 import { HttpServerFactoryService } from "../../src/mcp/http-transport.js"
 import { type ClientBundle, McpServerError, McpServerService } from "../../src/mcp/server.js"
 import { createScopedRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
+import { makeToolCategory, makeToolName } from "../../src/mcp/tools/registry.js"
 import { TelemetryService } from "../../src/telemetry/telemetry.js"
 import { mockFn } from "../helpers/mock-fn.js"
 
@@ -156,8 +157,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     let capturedToolsets: ReadonlyArray<string> | null = null
     const expectedRegistry = createScopedRegistry({
       filteringActive: true,
-      categories: new Set(["issues"]),
-      toolNames: new Set(["list_documents"])
+      categories: new Set([makeToolCategory("issues")]),
+      toolNames: new Set([makeToolName("list_documents")])
     })
     return Effect.gen(function*() {
       process.env.TOOLSETS = "issues"
@@ -182,7 +183,9 @@ describe("McpServerService.layer with TOOLSETS env", () => {
 
       expect(capturedToolsets).toEqual(["issues"])
       expect(capturedToolCount).toBe(expectedRegistry.definitions.length)
-      expect(expectedRegistry.tools.get("list_documents")).toBe(toolRegistry.tools.get("list_documents"))
+      expect(expectedRegistry.tools.get(makeToolName("list_documents"))).toBe(
+        toolRegistry.tools.get(makeToolName("list_documents"))
+      )
       delete process.env.TOOLSETS
       delete process.env.TOOLS
     })

--- a/test/mcp/server-parseToolsets.test.ts
+++ b/test/mcp/server-parseToolsets.test.ts
@@ -133,6 +133,7 @@ describe("McpServerService.layer with TOOLSETS env", () => {
   it.scoped("builds successfully with no TOOLSETS env", () =>
     Effect.gen(function*() {
       delete process.env.TOOLSETS
+      delete process.env.TOOLS
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
       yield* Layer.build(serverLayer)
     }))
@@ -140,12 +141,13 @@ describe("McpServerService.layer with TOOLSETS env", () => {
   it.scoped("builds successfully with valid TOOLSETS", () =>
     Effect.gen(function*() {
       process.env.TOOLSETS = "issues"
+      delete process.env.TOOLS
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
       yield* Layer.build(serverLayer)
       delete process.env.TOOLSETS
     }))
 
-  it.scoped("builds scoped registry from HULY_TOOLSETS and HULY_TOOLS", () => {
+  it.scoped("builds scoped registry from TOOLSETS and TOOLS", () => {
     let capturedToolCount = 0
     let capturedToolsets: ReadonlyArray<string> | null = null
     const expectedRegistry = createScopedRegistry({
@@ -154,8 +156,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
       toolNames: new Set(["list_documents"])
     })
     return Effect.gen(function*() {
-      process.env.HULY_TOOLSETS = "issues"
-      process.env.HULY_TOOLS = "list_documents"
+      process.env.TOOLSETS = "issues"
+      process.env.TOOLS = "list_documents"
       const telemetryLayer = TelemetryService.testLayer({
         sessionStart: (props) => {
           capturedToolCount = props.toolCount
@@ -175,8 +177,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
       expect(capturedToolsets).toEqual(["issues"])
       expect(capturedToolCount).toBe(expectedRegistry.definitions.length)
       expect(expectedRegistry.tools.get("list_documents")).toBe(toolRegistry.tools.get("list_documents"))
-      delete process.env.HULY_TOOLSETS
-      delete process.env.HULY_TOOLS
+      delete process.env.TOOLSETS
+      delete process.env.TOOLS
     })
   })
 
@@ -184,6 +186,7 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     const writeError = mockFn()
     return Effect.gen(function*() {
       process.env.TOOLSETS = "nonexistent_category"
+      delete process.env.TOOLS
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers, writeError)
       yield* Layer.build(serverLayer)
       expect(writeError.mock.calls).toContainEqual([
@@ -197,6 +200,7 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     let capturedProps: unknown = null
     return Effect.gen(function*() {
       delete process.env.TOOLSETS
+      delete process.env.TOOLS
       const telemetryLayer = TelemetryService.testLayer({
         sessionStart: (props) => {
           capturedProps = props

--- a/test/mcp/server-parseToolsets.test.ts
+++ b/test/mcp/server-parseToolsets.test.ts
@@ -134,6 +134,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     Effect.gen(function*() {
       delete process.env.TOOLSETS
       delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
       yield* Layer.build(serverLayer)
     }))
@@ -142,6 +144,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     Effect.gen(function*() {
       process.env.TOOLSETS = "issues"
       delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
       yield* Layer.build(serverLayer)
       delete process.env.TOOLSETS
@@ -158,6 +162,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     return Effect.gen(function*() {
       process.env.TOOLSETS = "issues"
       process.env.TOOLS = "list_documents"
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
       const telemetryLayer = TelemetryService.testLayer({
         sessionStart: (props) => {
           capturedToolCount = props.toolCount
@@ -187,6 +193,8 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     return Effect.gen(function*() {
       process.env.TOOLSETS = "nonexistent_category"
       delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
       const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers, writeError)
       yield* Layer.build(serverLayer)
       expect(writeError.mock.calls).toContainEqual([
@@ -196,11 +204,38 @@ describe("McpServerService.layer with TOOLSETS env", () => {
     })
   })
 
+  it.scoped("uses the default error writer for unknown toolset categories", () => {
+    const originalToolsets = process.env.TOOLSETS
+    const originalTools = process.env.TOOLS
+    return Effect.gen(function*() {
+      process.env.TOOLSETS = "nonexistent_category_default_writer"
+      delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
+      const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
+
+      yield* Layer.build(serverLayer)
+
+      if (originalToolsets === undefined) {
+        delete process.env.TOOLSETS
+      } else {
+        process.env.TOOLSETS = originalToolsets
+      }
+      if (originalTools === undefined) {
+        delete process.env.TOOLS
+      } else {
+        process.env.TOOLS = originalTools
+      }
+    })
+  })
+
   it.scoped("sessionStart is called with correct transport and authMethod", () => {
     let capturedProps: unknown = null
     return Effect.gen(function*() {
       delete process.env.TOOLSETS
       delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      delete process.env.PROXY_OUTPUT_STRICT
       const telemetryLayer = TelemetryService.testLayer({
         sessionStart: (props) => {
           capturedProps = props
@@ -223,4 +258,32 @@ describe("McpServerService.layer with TOOLSETS env", () => {
       })
     })
   })
+
+  it.scoped("fails startup when HULY_TOOL_MODE is invalid", () =>
+    Effect.gen(function*() {
+      delete process.env.TOOLSETS
+      delete process.env.TOOLS
+      process.env.HULY_TOOL_MODE = "dynamic"
+      delete process.env.PROXY_OUTPUT_STRICT
+
+      const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
+      const exit = yield* Effect.exit(Layer.build(serverLayer))
+
+      expect(exit._tag).toBe("Failure")
+      delete process.env.HULY_TOOL_MODE
+    }))
+
+  it.scoped("fails startup when PROXY_OUTPUT_STRICT is invalid", () =>
+    Effect.gen(function*() {
+      delete process.env.TOOLSETS
+      delete process.env.TOOLS
+      delete process.env.HULY_TOOL_MODE
+      process.env.PROXY_OUTPUT_STRICT = "yes"
+
+      const serverLayer = buildTestServerLayer({ transport: "stdio" }, baseLayers)
+      const exit = yield* Effect.exit(Layer.build(serverLayer))
+
+      expect(exit._tag).toBe("Failure")
+      delete process.env.PROXY_OUTPUT_STRICT
+    }))
 })

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -1805,7 +1805,9 @@ describe("McpServerService.layer operations", () => {
     it.scoped("sessionStart includes toolsets when TOOLSETS env is set", () => {
       let capturedProps: SessionStartProps | null = null
       return Effect.gen(function*() {
+        const originalTools = process.env.TOOLS
         process.env.TOOLSETS = "issues,documents"
+        delete process.env.TOOLS
         const telemetryLayer = TelemetryService.testLayer({
           sessionStart: (props) => {
             capturedProps = props
@@ -1824,13 +1826,20 @@ describe("McpServerService.layer operations", () => {
         expect(capturedProps).not.toBeNull()
         expect(capturedProps!.toolsets).toEqual(expect.arrayContaining(["issues", "documents"]))
         delete process.env.TOOLSETS
+        if (originalTools === undefined) {
+          delete process.env.TOOLS
+        } else {
+          process.env.TOOLS = originalTools
+        }
       })
     })
 
     it.scoped("sessionStart toolsets is null when no TOOLSETS env", () => {
       let capturedProps: SessionStartProps | null = null
       return Effect.gen(function*() {
+        const originalTools = process.env.TOOLS
         delete process.env.TOOLSETS
+        delete process.env.TOOLS
         const telemetryLayer = TelemetryService.testLayer({
           sessionStart: (props) => {
             capturedProps = props
@@ -1848,6 +1857,11 @@ describe("McpServerService.layer operations", () => {
         yield* Layer.build(serverLayer)
         expect(capturedProps).not.toBeNull()
         expect(capturedProps!.toolsets).toBeNull()
+        if (originalTools === undefined) {
+          delete process.env.TOOLS
+        } else {
+          process.env.TOOLS = originalTools
+        }
       })
     })
 
@@ -2060,7 +2074,9 @@ describe("McpServerService.layer operations", () => {
       Effect.gen(function*() {
         capturedHandlers.clear()
         const originalToolsets = process.env.TOOLSETS
+        const originalTools = process.env.TOOLS
         process.env.TOOLSETS = "issues"
+        delete process.env.TOOLS
         const fiber = yield* buildAndRunWithResolveClients(
           async () => {
             throw new Error("client resolution should be skipped")
@@ -2114,6 +2130,11 @@ describe("McpServerService.layer operations", () => {
           delete process.env.TOOLSETS
         } else {
           process.env.TOOLSETS = originalToolsets
+        }
+        if (originalTools === undefined) {
+          delete process.env.TOOLS
+        } else {
+          process.env.TOOLS = originalTools
         }
         yield* cleanup(fiber)
       }), { timeout: 5000 })

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -122,6 +122,9 @@ const createMockServer = () =>
     setRequestHandler(schema: unknown, handler: (...args: Array<unknown>) => unknown) {
       capturedHandlers.set(schema, handler)
     },
+    getClientVersion() {
+      return { name: "claude-code", version: "1.0.0" }
+    },
     async connect() {
       if (mockConnectBehavior) return mockConnectBehavior()
     },
@@ -821,6 +824,40 @@ describe("McpServerService.layer operations", () => {
         yield* Fiber.join(fiber)
       }), { timeout: 5000 })
 
+    it.scoped("uses the default stdio transport when no factory is provided", () =>
+      Effect.gen(function*() {
+        const layers = Layer.mergeAll(
+          HulyClient.testLayer({}),
+          HulyStorageClient.testLayer({}),
+          WorkspaceClient.testLayer({}),
+          TelemetryService.testLayer()
+        )
+        const serverLayer = McpServerService.layer({
+          transport: "stdio",
+          autoExit: true,
+          createServer: createMockServer,
+          resolveClients: resolveClientsFromLayer(layers)
+        }).pipe(Layer.provide(layers))
+        const ctx = yield* Layer.build(serverLayer)
+        const ops = yield* McpServerService.pipe(
+          Effect.provide(Layer.succeedContext(ctx))
+        )
+
+        const fiber = yield* Effect.fork(
+          ops.run().pipe(
+            Effect.provideService(
+              HttpServerFactoryService,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock stub
+              { createApp: () => ({}) as never, listen: () => Effect.void as never }
+            )
+          )
+        )
+
+        yield* Effect.promise(() => new Promise((r) => setTimeout(r, 50)))
+        process.stdin.emit("end")
+        yield* Fiber.join(fiber)
+      }), { timeout: 5000 })
+
     it.scoped("run fails with already-running error on second call", () =>
       Effect.gen(function*() {
         const serverLayer = buildStdioService({ autoExit: true })
@@ -1496,6 +1533,279 @@ describe("McpServerService.layer operations", () => {
         }),
       { timeout: 5000 }
     )
+
+    it.scoped(
+      "http 2026 requests resolve tool exposure from per-request clientInfo metadata",
+      () =>
+        Effect.gen(function*() {
+          const originalMode = process.env.HULY_TOOL_MODE
+          const originalStrict = process.env.PROXY_OUTPUT_STRICT
+          delete process.env.HULY_TOOL_MODE
+          delete process.env.PROXY_OUTPUT_STRICT
+
+          const layers = Layer.mergeAll(
+            HulyClient.testLayer({}),
+            HulyStorageClient.testLayer({}),
+            WorkspaceClient.testLayer({}),
+            TelemetryService.testLayer()
+          )
+          const serverLayer = buildTestServerLayer({
+            transport: "http",
+            httpPort: 19881,
+            httpHost: "127.0.0.1",
+            httpTransportDependencies: quietHttpTransportDependencies
+          }, layers)
+          const ctx = yield* Layer.build(serverLayer)
+          const ops = yield* McpServerService.pipe(
+            Effect.provide(Layer.succeedContext(ctx))
+          )
+
+          const postHandlers: Array<(req: unknown, res: unknown) => Promise<void>> = []
+          const mockHttpFactory: HttpServerFactoryService["Type"] = {
+            createApp: () =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fake implements the Express methods used by startHttpTransport
+              ({
+                post: (_path: string, handler: (req: unknown, res: unknown) => Promise<void>) => {
+                  postHandlers.push(handler)
+                },
+                get: () => {},
+                delete: () => {}
+              }) as never,
+            listen: () =>
+              Effect.succeed({
+                close: (cb: (err?: Error) => void) => cb()
+              } as never)
+          }
+
+          const fiber = yield* Effect.fork(
+            ops.run().pipe(
+              Effect.provideService(HttpServerFactoryService, mockHttpFactory)
+            )
+          )
+
+          yield* Effect.promise(() => new Promise((r) => setTimeout(r, 100)))
+          const handler = assertAt(postHandlers, 0)
+          const responses: Array<{ readonly code: number; readonly body: unknown }> = []
+          const makeResponse = () => ({
+            headersSent: false,
+            setHeader: () => undefined,
+            status: (code: number) => ({
+              json: (body: unknown) => {
+                responses.push({ code, body })
+                return body
+              }
+            }),
+            on: () => undefined
+          })
+          const makeRequest = (id: string, clientInfo: Record<string, unknown>) => ({
+            body: {
+              jsonrpc: "2.0",
+              method: "tools/list",
+              id,
+              params: {
+                _meta: {
+                  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                  "io.modelcontextprotocol/clientInfo": clientInfo,
+                  "io.modelcontextprotocol/clientCapabilities": {}
+                }
+              }
+            },
+            headers: {
+              accept: "application/json, text/event-stream",
+              "mcp-protocol-version": "2026-07-28",
+              "mcp-method": "tools/list"
+            },
+            on: () => undefined
+          })
+          const resultAt = (index: number): unknown => {
+            const body = assertAt(responses, index).body
+            if (!isRecord(body) || !("result" in body)) {
+              throw new Error("Expected JSON-RPC success response")
+            }
+            return body.result
+          }
+
+          yield* Effect.promise(() =>
+            handler(makeRequest("codex", { name: "codex-cli", version: "1.0.0" }), makeResponse())
+          )
+          yield* Effect.promise(() =>
+            handler(makeRequest("claude", { name: "claude-code", version: "1.0.0" }), makeResponse())
+          )
+          yield* Effect.promise(() => handler(makeRequest("missing-name", { version: "1.0.0" }), makeResponse()))
+
+          const codexToolNames = assertListToolsResponse(resultAt(0)).tools.map(tool => tool.name)
+          const claudeToolNames = assertListToolsResponse(resultAt(1)).tools.map(tool => tool.name)
+          const unknownToolNames = assertListToolsResponse(resultAt(2)).tools.map(tool => tool.name)
+          expect(responses.map(response => response.code)).toEqual([200, 200, 200])
+          expect(codexToolNames).toContain("search_tools")
+          expect(codexToolNames).not.toContain("list_projects")
+          expect(claudeToolNames).toContain("list_projects")
+          expect(claudeToolNames).not.toContain("search_tools")
+          expect(unknownToolNames).toContain("search_tools")
+          expect(unknownToolNames).not.toContain("list_projects")
+
+          if (originalMode === undefined) {
+            delete process.env.HULY_TOOL_MODE
+          } else {
+            process.env.HULY_TOOL_MODE = originalMode
+          }
+          if (originalStrict === undefined) {
+            delete process.env.PROXY_OUTPUT_STRICT
+          } else {
+            process.env.PROXY_OUTPUT_STRICT = originalStrict
+          }
+          yield* Fiber.interrupt(fiber)
+        }),
+      { timeout: 5000 }
+    )
+
+    it.scoped(
+      "legacy http requests prefer request clientInfo and fall back to SDK client version",
+      () =>
+        Effect.gen(function*() {
+          const originalMode = process.env.HULY_TOOL_MODE
+          delete process.env.HULY_TOOL_MODE
+          capturedHandlers.clear()
+
+          let sdkClientInfo: { readonly name: string; readonly version: string } | undefined = {
+            name: "claude-code",
+            version: "1.0.0"
+          }
+          const createServerWithClientVersion = () =>
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fake implements only methods used by McpServerService
+            ({
+              setRequestHandler(schema: unknown, handler: (...args: Array<unknown>) => unknown) {
+                capturedHandlers.set(schema, handler)
+              },
+              getClientVersion() {
+                return sdkClientInfo
+              },
+              async connect() {},
+              async close() {}
+            }) as never
+          const clientLayer = Layer.mergeAll(
+            HulyClient.testLayer({}),
+            HulyStorageClient.testLayer({}),
+            WorkspaceClient.testLayer({})
+          )
+          const responses: Array<{ readonly code: number; readonly body: unknown }> = []
+          const transportDependencies: Partial<HttpTransportDependencies> = {
+            createTransport: () =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fake invokes the captured list-tools handler directly
+              ({
+                async close() {},
+                async handleRequest(
+                  _req: unknown,
+                  res: { status: (code: number) => { json: (body: unknown) => unknown } },
+                  body: unknown
+                ) {
+                  const handler = capturedHandlers.get(ListToolsRequestSchema)
+                  if (handler === undefined) throw new Error("expected list tools handler")
+                  const result = await handler()
+                  const id = isRecord(body) && (typeof body.id === "string" || typeof body.id === "number")
+                    ? body.id
+                    : null
+                  res.status(200).json({ jsonrpc: "2.0", id, result })
+                }
+              }) as never,
+            writeError: () => {}
+          }
+          const serverLayer = McpServerService.layer({
+            transport: "http",
+            httpPort: 19882,
+            httpHost: "127.0.0.1",
+            createServer: createServerWithClientVersion,
+            resolveClients: resolveClientsFromLayer(clientLayer),
+            httpTransportDependencies: transportDependencies
+          }).pipe(Layer.provide(Layer.mergeAll(clientLayer, TelemetryService.testLayer())))
+          const ctx = yield* Layer.build(serverLayer)
+          const ops = yield* McpServerService.pipe(
+            Effect.provide(Layer.succeedContext(ctx))
+          )
+          const postHandlers: Array<(req: unknown, res: unknown) => Promise<void>> = []
+          const mockHttpFactory: HttpServerFactoryService["Type"] = {
+            createApp: () =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test fake implements Express routing used by startHttpTransport
+              ({
+                post: (_path: string, handler: (req: unknown, res: unknown) => Promise<void>) => {
+                  postHandlers.push(handler)
+                },
+                get: () => {},
+                delete: () => {}
+              }) as never,
+            listen: () =>
+              Effect.succeed({
+                close: (cb: (err?: Error) => void) => cb()
+              } as never)
+          }
+          const makeResponse = () => ({
+            headersSent: false,
+            setHeader: () => undefined,
+            status: (code: number) => ({
+              json: (body: unknown) => {
+                responses.push({ code, body })
+                return body
+              }
+            }),
+            on: () => undefined
+          })
+          const makeLegacyListRequest = (
+            id: string,
+            clientInfo?: { readonly name: string; readonly version: string }
+          ) => ({
+            body: {
+              jsonrpc: "2.0",
+              method: "tools/list",
+              id,
+              params: clientInfo === undefined ? {} : { clientInfo }
+            },
+            headers: { accept: "application/json, text/event-stream" },
+            on: () => undefined
+          })
+          const resultAt = (index: number): unknown => {
+            const body = assertAt(responses, index).body
+            if (!isRecord(body) || !("result" in body)) {
+              throw new Error("Expected JSON-RPC success response")
+            }
+            return body.result
+          }
+
+          const fiber = yield* Effect.fork(
+            ops.run().pipe(
+              Effect.provideService(HttpServerFactoryService, mockHttpFactory)
+            )
+          )
+
+          yield* Effect.promise(() => new Promise((r) => setTimeout(r, 100)))
+          const handler = assertAt(postHandlers, 0)
+          yield* Effect.promise(() => handler(makeLegacyListRequest("sdk-fallback"), makeResponse()))
+          yield* Effect.promise(() =>
+            handler(makeLegacyListRequest("request-client", { name: "codex-cli", version: "1.0.0" }), makeResponse())
+          )
+          sdkClientInfo = undefined
+          yield* Effect.promise(() => handler(makeLegacyListRequest("unknown"), makeResponse()))
+
+          const sdkFallbackNames = assertListToolsResponse(resultAt(0)).tools.map(tool => tool.name)
+          const requestClientNames = assertListToolsResponse(resultAt(1)).tools.map(tool => tool.name)
+          const unknownNames = assertListToolsResponse(resultAt(2)).tools.map(tool => tool.name)
+          expect(responses.map(response => response.code)).toEqual([200, 200, 200])
+          expect(sdkFallbackNames).toContain("list_projects")
+          expect(sdkFallbackNames).not.toContain("search_tools")
+          expect(requestClientNames).toContain("search_tools")
+          expect(requestClientNames).not.toContain("list_projects")
+          expect(unknownNames).toContain("search_tools")
+          expect(unknownNames).not.toContain("list_projects")
+
+          if (originalMode === undefined) {
+            delete process.env.HULY_TOOL_MODE
+          } else {
+            process.env.HULY_TOOL_MODE = originalMode
+          }
+          yield* Fiber.interrupt(fiber)
+        }),
+      { timeout: 5000 }
+    )
+
     it.scoped("http transport resolves request-scoped clients for resource reads", () =>
       Effect.gen(function*() {
         capturedHandlers.clear()

--- a/test/mcp/tool-mode.test.ts
+++ b/test/mcp/tool-mode.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  classifyMcpClient,
+  type ClientKind,
+  DEFAULT_MODE_BY_CLIENT_KIND,
+  type McpClientInfoLike,
+  resolveToolExposureMode,
+  type ResolveToolExposureModeInput,
+  type ToolExposureMode,
+  type ToolModeConfig
+} from "../../src/mcp/tool-mode.js"
+
+describe("classifyMcpClient", () => {
+  it("classifies known client names after trimming and case normalization", () => {
+    const cases: ReadonlyArray<{
+      readonly clientInfo: McpClientInfoLike
+      readonly expected: ClientKind
+    }> = [
+      { clientInfo: { name: " claude-code " }, expected: "claude-code" },
+      { clientInfo: { name: "Claude-AI" }, expected: "claude-ai" },
+      { clientInfo: { name: "cursor-vscode" }, expected: "cursor" },
+      { clientInfo: { name: "Cursor Desktop" }, expected: "cursor" },
+      { clientInfo: { name: "windsurf-ide" }, expected: "windsurf" },
+      { clientInfo: { name: "cascade" }, expected: "windsurf" },
+      { clientInfo: { name: "github-copilot-chat" }, expected: "github-copilot" },
+      { clientInfo: { name: "copilot" }, expected: "github-copilot" },
+      { clientInfo: { name: "vscode" }, expected: "github-copilot" },
+      { clientInfo: { name: "codex-cli" }, expected: "codex" },
+      { clientInfo: { name: "openai-codex" }, expected: "codex" },
+      { clientInfo: { name: "opencode" }, expected: "opencode" }
+    ]
+
+    for (const testCase of cases) {
+      expect(classifyMcpClient(testCase.clientInfo)).toBe(testCase.expected)
+    }
+  })
+
+  it("classifies remote-wrapper names by their base client", () => {
+    expect(classifyMcpClient({ name: "claude-ai (via mcp-remote)" })).toBe("claude-ai")
+    expect(classifyMcpClient({ name: " Cursor-vscode (via mcp-remote) " })).toBe("cursor")
+  })
+
+  it("keeps wrapped claude-code out of the exact native-only classification", () => {
+    expect(classifyMcpClient({ name: "claude-code (via mcp-remote)" })).toBe("unknown")
+    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: { name: "claude-code (via mcp-remote)" } }))
+      .toBe("proxy")
+  })
+
+  it("defaults missing and unknown client names to unknown", () => {
+    expect(classifyMcpClient(undefined)).toBe("unknown")
+    expect(classifyMcpClient({})).toBe("unknown")
+    expect(classifyMcpClient({ name: "  " })).toBe("unknown")
+    expect(classifyMcpClient({ name: "some-new-client" })).toBe("unknown")
+  })
+})
+
+describe("resolveToolExposureMode", () => {
+  it("uses explicit configured modes without client classification", () => {
+    const nativeMode: ToolModeConfig = "native"
+    const proxyMode: ToolModeConfig = "proxy"
+
+    expect(resolveToolExposureMode({ configuredMode: nativeMode })).toBe("native")
+    expect(resolveToolExposureMode({ configuredMode: proxyMode })).toBe("proxy")
+  })
+
+  it("maps auto mode through the default client-kind table", () => {
+    const defaults: Record<ClientKind, ToolExposureMode> = DEFAULT_MODE_BY_CLIENT_KIND
+    const input: ResolveToolExposureModeInput = {
+      configuredMode: "auto",
+      clientInfo: { name: "claude-code" }
+    }
+
+    expect(defaults["claude-code"]).toBe("native")
+    expect(defaults.unknown).toBe("proxy")
+    expect(resolveToolExposureMode(input)).toBe("native")
+    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: { name: "claude-ai" } })).toBe("proxy")
+    expect(resolveToolExposureMode({ configuredMode: "auto" })).toBe("proxy")
+  })
+})

--- a/test/mcp/tool-mode.test.ts
+++ b/test/mcp/tool-mode.test.ts
@@ -5,6 +5,7 @@ import {
   type ClientKind,
   DEFAULT_MODE_BY_CLIENT_KIND,
   type McpClientInfoLike,
+  parseMcpClientInfo,
   parseToolExposureConfig,
   resolveToolExposureMode,
   type ResolveToolExposureModeInput,
@@ -12,24 +13,30 @@ import {
   type ToolModeConfig
 } from "../../src/mcp/tool-mode.js"
 
+const clientInfo = (name: string): McpClientInfoLike => {
+  const parsed = parseMcpClientInfo({ name })
+  if (parsed === undefined) throw new Error(`expected valid client info for ${name}`)
+  return parsed
+}
+
 describe("classifyMcpClient", () => {
   it("classifies known client names after trimming and case normalization", () => {
     const cases: ReadonlyArray<{
       readonly clientInfo: McpClientInfoLike
       readonly expected: ClientKind
     }> = [
-      { clientInfo: { name: " claude-code " }, expected: "claude-code" },
-      { clientInfo: { name: "Claude-AI" }, expected: "claude-ai" },
-      { clientInfo: { name: "cursor-vscode" }, expected: "cursor" },
-      { clientInfo: { name: "Cursor Desktop" }, expected: "cursor" },
-      { clientInfo: { name: "windsurf-ide" }, expected: "windsurf" },
-      { clientInfo: { name: "cascade" }, expected: "windsurf" },
-      { clientInfo: { name: "github-copilot-chat" }, expected: "github-copilot" },
-      { clientInfo: { name: "copilot" }, expected: "github-copilot" },
-      { clientInfo: { name: "vscode" }, expected: "github-copilot" },
-      { clientInfo: { name: "codex-cli" }, expected: "codex" },
-      { clientInfo: { name: "openai-codex" }, expected: "codex" },
-      { clientInfo: { name: "opencode" }, expected: "opencode" }
+      { clientInfo: clientInfo(" claude-code "), expected: "claude-code" },
+      { clientInfo: clientInfo("Claude-AI"), expected: "claude-ai" },
+      { clientInfo: clientInfo("cursor-vscode"), expected: "cursor" },
+      { clientInfo: clientInfo("Cursor Desktop"), expected: "cursor" },
+      { clientInfo: clientInfo("windsurf-ide"), expected: "windsurf" },
+      { clientInfo: clientInfo("cascade"), expected: "windsurf" },
+      { clientInfo: clientInfo("github-copilot-chat"), expected: "github-copilot" },
+      { clientInfo: clientInfo("copilot"), expected: "github-copilot" },
+      { clientInfo: clientInfo("vscode"), expected: "github-copilot" },
+      { clientInfo: clientInfo("codex-cli"), expected: "codex" },
+      { clientInfo: clientInfo("openai-codex"), expected: "codex" },
+      { clientInfo: clientInfo("opencode"), expected: "opencode" }
     ]
 
     for (const testCase of cases) {
@@ -38,21 +45,21 @@ describe("classifyMcpClient", () => {
   })
 
   it("classifies remote-wrapper names by their base client", () => {
-    expect(classifyMcpClient({ name: "claude-ai (via mcp-remote)" })).toBe("claude-ai")
-    expect(classifyMcpClient({ name: " Cursor-vscode (via mcp-remote) " })).toBe("cursor")
+    expect(classifyMcpClient(clientInfo("claude-ai (via mcp-remote)"))).toBe("claude-ai")
+    expect(classifyMcpClient(clientInfo(" Cursor-vscode (via mcp-remote) "))).toBe("cursor")
   })
 
   it("keeps wrapped claude-code out of the exact native-only classification", () => {
-    expect(classifyMcpClient({ name: "claude-code (via mcp-remote)" })).toBe("unknown")
-    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: { name: "claude-code (via mcp-remote)" } }))
+    expect(classifyMcpClient(clientInfo("claude-code (via mcp-remote)"))).toBe("unknown")
+    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: clientInfo("claude-code (via mcp-remote)") }))
       .toBe("proxy")
   })
 
   it("defaults missing and unknown client names to unknown", () => {
     expect(classifyMcpClient(undefined)).toBe("unknown")
     expect(classifyMcpClient({})).toBe("unknown")
-    expect(classifyMcpClient({ name: "  " })).toBe("unknown")
-    expect(classifyMcpClient({ name: "some-new-client" })).toBe("unknown")
+    expect(classifyMcpClient(parseMcpClientInfo({ name: "  " }))).toBe("unknown")
+    expect(classifyMcpClient(clientInfo("some-new-client"))).toBe("unknown")
   })
 })
 
@@ -69,13 +76,13 @@ describe("resolveToolExposureMode", () => {
     const defaults: Record<ClientKind, ToolExposureMode> = DEFAULT_MODE_BY_CLIENT_KIND
     const input: ResolveToolExposureModeInput = {
       configuredMode: "auto",
-      clientInfo: { name: "claude-code" }
+      clientInfo: clientInfo("claude-code")
     }
 
     expect(defaults["claude-code"]).toBe("native")
     expect(defaults.unknown).toBe("proxy")
     expect(resolveToolExposureMode(input)).toBe("native")
-    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: { name: "claude-ai" } })).toBe("proxy")
+    expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: clientInfo("claude-ai") })).toBe("proxy")
     expect(resolveToolExposureMode({ configuredMode: "auto" })).toBe("proxy")
   })
 })
@@ -113,6 +120,34 @@ describe("parseToolExposureConfig", () => {
     expect(parseToolExposureConfig({ hulyToolMode: " " })).toMatchObject({
       _tag: "Failure",
       field: "HULY_TOOL_MODE"
+    })
+  })
+
+  it("rejects invalid exposure env shapes instead of defaulting", () => {
+    expect(parseToolExposureConfig({ hulyToolMode: 123 })).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE",
+      message: expect.stringContaining("must be a string")
+    })
+    expect(parseToolExposureConfig({ proxyOutputStrict: true })).toMatchObject({
+      _tag: "Failure",
+      field: "PROXY_OUTPUT_STRICT",
+      message: expect.stringContaining("must be a string")
+    })
+    expect(parseToolExposureConfig(null)).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE",
+      message: expect.stringContaining("string environment values")
+    })
+    expect(parseToolExposureConfig([])).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE",
+      message: expect.stringContaining("string environment values")
+    })
+    expect(parseToolExposureConfig({ hulyToolMode: "auto", proxyOutputStrict: undefined })).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE",
+      message: expect.stringContaining("string environment values")
     })
   })
 })

--- a/test/mcp/tool-mode.test.ts
+++ b/test/mcp/tool-mode.test.ts
@@ -33,7 +33,9 @@ describe("classifyMcpClient", () => {
       { clientInfo: clientInfo("cascade"), expected: "windsurf" },
       { clientInfo: clientInfo("github-copilot-chat"), expected: "github-copilot" },
       { clientInfo: clientInfo("copilot"), expected: "github-copilot" },
-      { clientInfo: clientInfo("vscode"), expected: "github-copilot" },
+      { clientInfo: clientInfo("github-copilot-developer"), expected: "github-copilot" },
+      { clientInfo: clientInfo("Visual Studio Code"), expected: "github-copilot" },
+      { clientInfo: clientInfo("Visual-Studio-Code"), expected: "github-copilot" },
       { clientInfo: clientInfo("codex-cli"), expected: "codex" },
       { clientInfo: clientInfo("openai-codex"), expected: "codex" },
       { clientInfo: clientInfo("opencode"), expected: "opencode" }

--- a/test/mcp/tool-mode.test.ts
+++ b/test/mcp/tool-mode.test.ts
@@ -5,6 +5,7 @@ import {
   type ClientKind,
   DEFAULT_MODE_BY_CLIENT_KIND,
   type McpClientInfoLike,
+  parseToolExposureConfig,
   resolveToolExposureMode,
   type ResolveToolExposureModeInput,
   type ToolExposureMode,
@@ -76,5 +77,42 @@ describe("resolveToolExposureMode", () => {
     expect(resolveToolExposureMode(input)).toBe("native")
     expect(resolveToolExposureMode({ configuredMode: "auto", clientInfo: { name: "claude-ai" } })).toBe("proxy")
     expect(resolveToolExposureMode({ configuredMode: "auto" })).toBe("proxy")
+  })
+})
+
+describe("parseToolExposureConfig", () => {
+  it("defaults to auto mode and non-strict proxy output", () => {
+    expect(parseToolExposureConfig({})).toEqual({
+      _tag: "Success",
+      value: { configuredMode: "auto", proxyOutputStrict: false }
+    })
+  })
+
+  it("parses supported mode and strict values after trimming and case normalization", () => {
+    expect(parseToolExposureConfig({ hulyToolMode: " PROXY ", proxyOutputStrict: " TRUE " })).toEqual({
+      _tag: "Success",
+      value: { configuredMode: "proxy", proxyOutputStrict: true }
+    })
+    expect(parseToolExposureConfig({ hulyToolMode: "native", proxyOutputStrict: "false" })).toEqual({
+      _tag: "Success",
+      value: { configuredMode: "native", proxyOutputStrict: false }
+    })
+  })
+
+  it("rejects invalid exposure env values with field-specific messages", () => {
+    expect(parseToolExposureConfig({ hulyToolMode: "dynamic" })).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE",
+      message: expect.stringContaining("auto, native, or proxy")
+    })
+    expect(parseToolExposureConfig({ proxyOutputStrict: "yes" })).toMatchObject({
+      _tag: "Failure",
+      field: "PROXY_OUTPUT_STRICT",
+      message: expect.stringContaining("true or false")
+    })
+    expect(parseToolExposureConfig({ hulyToolMode: " " })).toMatchObject({
+      _tag: "Failure",
+      field: "HULY_TOOL_MODE"
+    })
   })
 })

--- a/test/mcp/tool-scope.test.ts
+++ b/test/mcp/tool-scope.test.ts
@@ -10,18 +10,16 @@ import { createScopedRegistry, toolRegistry } from "../../src/mcp/tools/index.js
 import { createNoopTelemetry } from "../../src/telemetry/noop.js"
 
 interface PartialScopeEnv {
-  readonly hulyToolsets?: string
-  readonly hulyTools?: string
-  readonly legacyToolsets?: string
+  readonly toolsets?: string
+  readonly tools?: string
 }
 
 const resolveScoped = (env: PartialScopeEnv) => {
   const warnings: Array<string> = []
   const scope = resolveToolScope(
     {
-      hulyToolsets: env.hulyToolsets ?? "",
-      hulyTools: env.hulyTools ?? "",
-      legacyToolsets: env.legacyToolsets ?? ""
+      toolsets: env.toolsets ?? "",
+      tools: env.tools ?? ""
     },
     toolRegistry.definitions,
     (message) => {
@@ -47,8 +45,8 @@ describe("tool scope filtering", () => {
     expect(registry.tools.has("list_issues")).toBe(true)
   })
 
-  it("filters by HULY_TOOLSETS category", () => {
-    const { registry, scope } = resolveScoped({ hulyToolsets: "issues" })
+  it("filters by TOOLSETS category", () => {
+    const { registry, scope } = resolveScoped({ toolsets: "issues" })
 
     expect(scope.filteringActive).toBe(true)
     expect(scope.enabledToolsets).toEqual(["issues"])
@@ -57,17 +55,17 @@ describe("tool scope filtering", () => {
     expect(registry.tools.has("list_documents")).toBe(false)
   })
 
-  it("filters by exact HULY_TOOLS names", () => {
-    const { registry, scope } = resolveScoped({ hulyTools: "list_documents" })
+  it("filters by exact TOOLS names", () => {
+    const { registry, scope } = resolveScoped({ tools: "list_documents" })
 
     expect(scope.enabledTools).toEqual(["list_documents"])
     expect(registry.definitions.map((tool) => tool.name)).toEqual(["list_documents"])
   })
 
-  it("unions HULY_TOOLSETS and HULY_TOOLS while preserving registry order", () => {
+  it("unions TOOLSETS and TOOLS while preserving registry order", () => {
     const { registry } = resolveScoped({
-      hulyToolsets: "issues",
-      hulyTools: "list_documents"
+      toolsets: "issues",
+      tools: "list_documents"
     })
     const names = registry.definitions.map((tool) => tool.name)
     const expected = toolRegistry.definitions
@@ -81,8 +79,8 @@ describe("tool scope filtering", () => {
 
   it("keeps only built-in tools visible when an active scope is all invalid", async () => {
     const { registry, scope, warnings } = resolveScoped({
-      hulyToolsets: "missing_category",
-      hulyTools: "missing_tool"
+      toolsets: "missing_category",
+      tools: "missing_tool"
     })
     const handlers = createMcpProtocolHandlers(
       () => Promise.reject(new Error("clients must not resolve")),
@@ -104,33 +102,20 @@ describe("tool scope filtering", () => {
     ])
   })
 
-  it("prefers HULY_TOOLSETS over legacy TOOLSETS", () => {
-    const { registry, scope, warnings } = resolveScoped({
-      hulyToolsets: "documents",
-      legacyToolsets: "issues"
-    })
-
-    expect(scope.requestedToolsets).toEqual(["documents"])
-    expect(scope.legacyToolsets).toEqual({ provided: true, used: false, ignored: true })
-    expect(registry.definitions.every((tool) => tool.category === "documents")).toBe(true)
-    expect(warnings).toEqual([expect.stringContaining("TOOLSETS is deprecated and ignored")])
-  })
-
-  it("supports legacy TOOLSETS as a deprecated HULY_TOOLSETS alias", () => {
-    const { registry, scope, warnings } = resolveScoped({ legacyToolsets: "issues" })
+  it("uses TOOLSETS as the primary category scope without deprecation warnings", () => {
+    const { registry, scope, warnings } = resolveScoped({ toolsets: "issues" })
 
     expect(scope.requestedToolsets).toEqual(["issues"])
     expect(scope.enabledToolsets).toEqual(["issues"])
-    expect(scope.legacyToolsets).toEqual({ provided: true, used: true, ignored: false })
     expect(registry.tools.has("list_issues")).toBe(true)
     expect(registry.tools.has("list_documents")).toBe(false)
-    expect(warnings).toEqual([expect.stringContaining("TOOLSETS is deprecated")])
+    expect(warnings).toEqual([])
   })
 
   it("reports toolsets and tool-name scope in get_huly_context", () => {
     const { registry, scope } = resolveScoped({
-      hulyToolsets: "issues",
-      hulyTools: "list_documents,missing_tool"
+      toolsets: "issues",
+      tools: "list_documents,missing_tool"
     })
     const context = Schema.decodeUnknownSync(GetHulyContextResultSchema)(
       buildHulyContext({ transport: "stdio" }, registry, scope, sanitizeHulyRuntimeConfigFromEnv({}))
@@ -147,8 +132,7 @@ describe("tool scope filtering", () => {
       enabledToolsets: ["issues"],
       requestedTools: ["list_documents", "missing_tool"],
       enabledTools: ["list_documents"],
-      ignoredTools: ["missing_tool"],
-      legacyToolsets: { provided: false, used: false, ignored: false }
+      ignoredTools: ["missing_tool"]
     })
     expect(context.toolScope.visibleRegisteredToolCount).toBe(registry.definitions.length)
     expect(context.toolScope.totalRegisteredToolCount).toBe(toolRegistry.definitions.length)

--- a/test/mcp/tool-scope.test.ts
+++ b/test/mcp/tool-scope.test.ts
@@ -1,0 +1,156 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+
+import { sanitizeHulyRuntimeConfigFromEnv } from "../../src/config/config.js"
+import { GetHulyContextResultSchema } from "../../src/domain/schemas/index.js"
+import { buildHulyContext } from "../../src/mcp/huly-context-tool.js"
+import { createMcpProtocolHandlers } from "../../src/mcp/protocol-handlers.js"
+import { resolveToolScope } from "../../src/mcp/tool-scope.js"
+import { createScopedRegistry, toolRegistry } from "../../src/mcp/tools/index.js"
+import { createNoopTelemetry } from "../../src/telemetry/noop.js"
+
+interface PartialScopeEnv {
+  readonly hulyToolsets?: string
+  readonly hulyTools?: string
+  readonly legacyToolsets?: string
+}
+
+const resolveScoped = (env: PartialScopeEnv) => {
+  const warnings: Array<string> = []
+  const scope = resolveToolScope(
+    {
+      hulyToolsets: env.hulyToolsets ?? "",
+      hulyTools: env.hulyTools ?? "",
+      legacyToolsets: env.legacyToolsets ?? ""
+    },
+    toolRegistry.definitions,
+    (message) => {
+      warnings.push(message)
+    }
+  )
+  const registry = createScopedRegistry({
+    filteringActive: scope.filteringActive,
+    categories: scope.enabledCategories,
+    toolNames: scope.enabledToolNames
+  })
+
+  return { registry, scope, warnings }
+}
+
+describe("tool scope filtering", () => {
+  it("leaves the full registry visible when no scope env is set", () => {
+    const { registry, scope } = resolveScoped({})
+
+    expect(scope.filteringActive).toBe(false)
+    expect(registry).toBe(toolRegistry)
+    expect(registry.tools.has("list_documents")).toBe(true)
+    expect(registry.tools.has("list_issues")).toBe(true)
+  })
+
+  it("filters by HULY_TOOLSETS category", () => {
+    const { registry, scope } = resolveScoped({ hulyToolsets: "issues" })
+
+    expect(scope.filteringActive).toBe(true)
+    expect(scope.enabledToolsets).toEqual(["issues"])
+    expect(registry.definitions.every((tool) => tool.category === "issues")).toBe(true)
+    expect(registry.tools.has("list_issues")).toBe(true)
+    expect(registry.tools.has("list_documents")).toBe(false)
+  })
+
+  it("filters by exact HULY_TOOLS names", () => {
+    const { registry, scope } = resolveScoped({ hulyTools: "list_documents" })
+
+    expect(scope.enabledTools).toEqual(["list_documents"])
+    expect(registry.definitions.map((tool) => tool.name)).toEqual(["list_documents"])
+  })
+
+  it("unions HULY_TOOLSETS and HULY_TOOLS while preserving registry order", () => {
+    const { registry } = resolveScoped({
+      hulyToolsets: "issues",
+      hulyTools: "list_documents"
+    })
+    const names = registry.definitions.map((tool) => tool.name)
+    const expected = toolRegistry.definitions
+      .filter((tool) => tool.category === "issues" || tool.name === "list_documents")
+      .map((tool) => tool.name)
+
+    expect(names).toEqual(expected)
+    expect(names).toContain("list_issues")
+    expect(names).toContain("list_documents")
+  })
+
+  it("keeps only built-in tools visible when an active scope is all invalid", async () => {
+    const { registry, scope, warnings } = resolveScoped({
+      hulyToolsets: "missing_category",
+      hulyTools: "missing_tool"
+    })
+    const handlers = createMcpProtocolHandlers(
+      () => Promise.reject(new Error("clients must not resolve")),
+      createNoopTelemetry(),
+      registry,
+      () => buildHulyContext({ transport: "stdio" }, registry, scope, sanitizeHulyRuntimeConfigFromEnv({}))
+    )
+
+    const listed = await handlers.listTools()
+    const callResult = await handlers.callTool({ params: { name: "list_documents", arguments: {} } })
+
+    expect(scope.filteringActive).toBe(true)
+    expect(registry.definitions).toEqual([])
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["get_version", "get_huly_context"])
+    expect(callResult.isError).toBe(true)
+    expect(warnings).toEqual([
+      expect.stringContaining("unknown toolset category"),
+      expect.stringContaining("unknown tool name")
+    ])
+  })
+
+  it("prefers HULY_TOOLSETS over legacy TOOLSETS", () => {
+    const { registry, scope, warnings } = resolveScoped({
+      hulyToolsets: "documents",
+      legacyToolsets: "issues"
+    })
+
+    expect(scope.requestedToolsets).toEqual(["documents"])
+    expect(scope.legacyToolsets).toEqual({ provided: true, used: false, ignored: true })
+    expect(registry.definitions.every((tool) => tool.category === "documents")).toBe(true)
+    expect(warnings).toEqual([expect.stringContaining("TOOLSETS is deprecated and ignored")])
+  })
+
+  it("supports legacy TOOLSETS as a deprecated HULY_TOOLSETS alias", () => {
+    const { registry, scope, warnings } = resolveScoped({ legacyToolsets: "issues" })
+
+    expect(scope.requestedToolsets).toEqual(["issues"])
+    expect(scope.enabledToolsets).toEqual(["issues"])
+    expect(scope.legacyToolsets).toEqual({ provided: true, used: true, ignored: false })
+    expect(registry.tools.has("list_issues")).toBe(true)
+    expect(registry.tools.has("list_documents")).toBe(false)
+    expect(warnings).toEqual([expect.stringContaining("TOOLSETS is deprecated")])
+  })
+
+  it("reports toolsets and tool-name scope in get_huly_context", () => {
+    const { registry, scope } = resolveScoped({
+      hulyToolsets: "issues",
+      hulyTools: "list_documents,missing_tool"
+    })
+    const context = Schema.decodeUnknownSync(GetHulyContextResultSchema)(
+      buildHulyContext({ transport: "stdio" }, registry, scope, sanitizeHulyRuntimeConfigFromEnv({}))
+    )
+
+    expect(context.toolsets).toMatchObject({
+      filteringActive: true,
+      requestedCategories: ["issues"],
+      enabledCategories: ["issues"]
+    })
+    expect(context.toolScope).toMatchObject({
+      active: true,
+      requestedToolsets: ["issues"],
+      enabledToolsets: ["issues"],
+      requestedTools: ["list_documents", "missing_tool"],
+      enabledTools: ["list_documents"],
+      ignoredTools: ["missing_tool"],
+      legacyToolsets: { provided: false, used: false, ignored: false }
+    })
+    expect(context.toolScope.visibleRegisteredToolCount).toBe(registry.definitions.length)
+    expect(context.toolScope.totalRegisteredToolCount).toBe(toolRegistry.definitions.length)
+  })
+})

--- a/test/mcp/tools-index.test.ts
+++ b/test/mcp/tools-index.test.ts
@@ -9,9 +9,12 @@ import { testMarkupUrlConfig } from "../../src/huly/operations/markup.js"
 import type { HulyStorageOperations } from "../../src/huly/storage.js"
 import { testWorkbenchUrlConfig } from "../../src/huly/url-builders.js"
 import { CATEGORY_NAMES, createFilteredRegistry, TOOL_DEFINITIONS, toolRegistry } from "../../src/mcp/tools/index.js"
+import { makeToolCategory, makeToolName } from "../../src/mcp/tools/registry.js"
 import { assertExists } from "../../src/utils/assertions.js"
 
 const toolDefinition = (name: string) => assertExists(TOOL_DEFINITIONS[name], `Expected tool definition for ${name}`)
+const categorySet = (...categories: ReadonlyArray<string>) => new Set(categories.map(makeToolCategory))
+const toolName = makeToolName
 
 const noopHulyClient: HulyClientOperations = {
   getAccountUuid: () => "00000000-0000-4000-8000-000000000000" as AccountUuid,
@@ -41,19 +44,19 @@ const noopStorageClient: HulyStorageOperations = {
 describe("CATEGORY_NAMES", () => {
   it.effect("contains expected categories", () =>
     Effect.gen(function*() {
-      expect(CATEGORY_NAMES.has("projects")).toBe(true)
-      expect(CATEGORY_NAMES.has("issues")).toBe(true)
-      expect(CATEGORY_NAMES.has("documents")).toBe(true)
-      expect(CATEGORY_NAMES.has("comments")).toBe(true)
-      expect(CATEGORY_NAMES.has("task-management")).toBe(true)
-      expect(CATEGORY_NAMES.has("associations")).toBe(true)
-      expect(CATEGORY_NAMES.has("sdk-discovery")).toBe(true)
-      expect(CATEGORY_NAMES.has("user-statuses")).toBe(true)
-      expect(CATEGORY_NAMES.has("inventory")).toBe(true)
-      expect(CATEGORY_NAMES.has("recruiting")).toBe(true)
-      expect(CATEGORY_NAMES.has("views")).toBe(true)
-      expect(CATEGORY_NAMES.has("preferences")).toBe(true)
-      expect(CATEGORY_NAMES.has("approvals")).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("projects"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("issues"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("documents"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("comments"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("task-management"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("associations"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("sdk-discovery"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("user-statuses"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("inventory"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("recruiting"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("views"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("preferences"))).toBe(true)
+      expect(CATEGORY_NAMES.has(makeToolCategory("approvals"))).toBe(true)
       expect(CATEGORY_NAMES.size).toBeGreaterThan(5)
     }))
 
@@ -61,23 +64,23 @@ describe("CATEGORY_NAMES", () => {
     Effect.gen(function*() {
       const names = new Set(toolRegistry.definitions.map((tool) => tool.name))
 
-      expect(names.has("list_schedules")).toBe(true)
-      expect(names.has("get_schedule")).toBe(true)
-      expect(names.has("create_schedule")).toBe(true)
-      expect(names.has("update_schedule")).toBe(true)
-      expect(names.has("delete_schedule")).toBe(true)
-      expect(names.has("list_office_floors")).toBe(true)
-      expect(names.has("get_office_floor")).toBe(true)
-      expect(names.has("list_office_rooms")).toBe(true)
-      expect(names.has("get_office_room")).toBe(true)
-      expect(names.has("list_offices")).toBe(true)
-      expect(names.has("get_office")).toBe(true)
-      expect(names.has("list_active_room_info")).toBe(true)
-      expect(names.has("list_active_room_participants")).toBe(true)
-      expect(names.has("list_meeting_minutes")).toBe(true)
-      expect(names.has("get_meeting_minutes")).toBe(true)
-      expect(names.has("list_device_preferences")).toBe(true)
-      expect(names.has("list_office_defaults")).toBe(true)
+      expect(names.has(toolName("list_schedules"))).toBe(true)
+      expect(names.has(toolName("get_schedule"))).toBe(true)
+      expect(names.has(toolName("create_schedule"))).toBe(true)
+      expect(names.has(toolName("update_schedule"))).toBe(true)
+      expect(names.has(toolName("delete_schedule"))).toBe(true)
+      expect(names.has(toolName("list_office_floors"))).toBe(true)
+      expect(names.has(toolName("get_office_floor"))).toBe(true)
+      expect(names.has(toolName("list_office_rooms"))).toBe(true)
+      expect(names.has(toolName("get_office_room"))).toBe(true)
+      expect(names.has(toolName("list_offices"))).toBe(true)
+      expect(names.has(toolName("get_office"))).toBe(true)
+      expect(names.has(toolName("list_active_room_info"))).toBe(true)
+      expect(names.has(toolName("list_active_room_participants"))).toBe(true)
+      expect(names.has(toolName("list_meeting_minutes"))).toBe(true)
+      expect(names.has(toolName("get_meeting_minutes"))).toBe(true)
+      expect(names.has(toolName("list_device_preferences"))).toBe(true)
+      expect(names.has(toolName("list_office_defaults"))).toBe(true)
     }))
 
   it.effect("registers issue #102 closeout tools in their owning categories", () =>
@@ -128,7 +131,7 @@ describe("toolRegistry", () => {
 describe("createFilteredRegistry", () => {
   it.effect("filters to only requested categories", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["issues"]))
+      const filtered = createFilteredRegistry(categorySet("issues"))
 
       expect(filtered.definitions.length).toBeGreaterThan(0)
       expect(filtered.definitions.length).toBeLessThan(toolRegistry.definitions.length)
@@ -140,14 +143,14 @@ describe("createFilteredRegistry", () => {
 
   it.effect("returns empty registry for unknown category", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["nonexistent_category"]))
+      const filtered = createFilteredRegistry(categorySet("nonexistent_category"))
       expect(filtered.definitions.length).toBe(0)
       expect(filtered.tools.size).toBe(0)
     }))
 
   it.effect("combines multiple categories", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["issues", "projects"]))
+      const filtered = createFilteredRegistry(categorySet("issues", "projects"))
 
       const categories = new Set(filtered.definitions.map((t) => t.category))
       expect(categories.size).toBeLessThanOrEqual(2)
@@ -159,7 +162,7 @@ describe("createFilteredRegistry", () => {
 
   it.effect("filters to task-management tools", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["task-management"]))
+      const filtered = createFilteredRegistry(categorySet("task-management"))
       const toolNames = filtered.definitions.map((tool) => tool.name)
 
       expect(toolNames).toEqual([
@@ -176,7 +179,7 @@ describe("createFilteredRegistry", () => {
 
   it.effect("filters to association tools", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["associations"]))
+      const filtered = createFilteredRegistry(categorySet("associations"))
       const toolNames = filtered.definitions.map((tool) => tool.name)
 
       expect(toolNames).toEqual([
@@ -194,7 +197,7 @@ describe("createFilteredRegistry", () => {
 
   it.effect("filters to user status tools", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["user-statuses"]))
+      const filtered = createFilteredRegistry(categorySet("user-statuses"))
       const toolNames = filtered.definitions.map((tool) => tool.name)
 
       expect(toolNames).toEqual(["list_user_statuses"])
@@ -205,7 +208,7 @@ describe("createFilteredRegistry", () => {
 
   it.effect("filters to recruiting tools", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["recruiting"]))
+      const filtered = createFilteredRegistry(categorySet("recruiting"))
       const toolNames = filtered.definitions.map((tool) => tool.name)
 
       expect(toolNames).toEqual([
@@ -266,7 +269,7 @@ describe("handleToolCall", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "totally_nonexistent_tool_xyz",
+          toolName("totally_nonexistent_tool_xyz"),
           {},
           noopHulyClient,
           noopStorageClient
@@ -280,7 +283,7 @@ describe("handleToolCall", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "list_projects",
+          toolName("list_projects"),
           undefined,
           noopHulyClient,
           noopStorageClient
@@ -295,7 +298,7 @@ describe("handleToolCall", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_unread_notification_count",
+          toolName("get_unread_notification_count"),
           undefined,
           noopHulyClient,
           noopStorageClient
@@ -310,7 +313,7 @@ describe("handleToolCall", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_issue",
+          toolName("get_issue"),
           undefined,
           noopHulyClient,
           noopStorageClient
@@ -326,7 +329,7 @@ describe("handleToolCall", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_unread_notification_count",
+          toolName("get_unread_notification_count"),
           { junk: true },
           noopHulyClient,
           noopStorageClient
@@ -354,7 +357,7 @@ describe("TOOL_DEFINITIONS", () => {
     Effect.gen(function*() {
       for (const [name, tool] of Object.entries(TOOL_DEFINITIONS)) {
         expect(tool.name).toBe(name)
-        expect(toolRegistry.tools.has(name)).toBe(true)
+        expect(toolRegistry.tools.has(toolName(name))).toBe(true)
       }
     }))
 })

--- a/test/mcp/tools/boards.test.ts
+++ b/test/mcp/tools/boards.test.ts
@@ -19,8 +19,10 @@ import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
 import { McpErrorCode } from "../../../src/mcp/error-mapping.js"
 import { boardTools } from "../../../src/mcp/tools/boards.js"
 import { createFilteredRegistry, TOOL_DEFINITIONS } from "../../../src/mcp/tools/index.js"
+import { makeToolCategory, makeToolName } from "../../../src/mcp/tools/registry.js"
 
 const toolDefinition = (name: string) => assertExists(TOOL_DEFINITIONS[name], `Expected tool definition for ${name}`)
+const boardRegistry = () => createFilteredRegistry(new Set([makeToolCategory("boards")]))
 
 // Huly SDK refs, account UUIDs, intl strings, and component handles are erased string brands at runtime.
 const accountUuid = (value: string): AccountUuid => value as AccountUuid
@@ -103,7 +105,7 @@ const toTypedDocs = <T extends Doc>(docs: ReadonlyArray<Doc>): Array<T> => {
 describe("board MCP tools", () => {
   it.effect("registers board tools in order", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["boards"]))
+      const filtered = boardRegistry()
 
       expect(filtered.definitions.map((tool) => tool.name)).toEqual([
         "list_boards",
@@ -137,9 +139,9 @@ describe("board MCP tools", () => {
 
   it.effect("serializes successful board responses as structured content", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["boards"]))
+      const registry = boardRegistry()
       const result = yield* Effect.promise(() =>
-        registry.handleToolCall("list_boards", {}, makeClient({ boards: [boardDoc] }), storageClient)
+        registry.handleToolCall(makeToolName("list_boards"), {}, makeClient({ boards: [boardDoc] }), storageClient)
       )
 
       expect(result?.isError).toBeUndefined()
@@ -156,9 +158,14 @@ describe("board MCP tools", () => {
 
   it.effect("serializes successful board menu page responses as structured content", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["boards"]))
+      const registry = boardRegistry()
       const result = yield* Effect.promise(() =>
-        registry.handleToolCall("list_board_menu_pages", {}, makeClient({ menuPages: [menuPageDoc] }), storageClient)
+        registry.handleToolCall(
+          makeToolName("list_board_menu_pages"),
+          {},
+          makeClient({ menuPages: [menuPageDoc] }),
+          storageClient
+        )
       )
 
       expect(result?.isError).toBeUndefined()
@@ -175,9 +182,14 @@ describe("board MCP tools", () => {
 
   it.effect("maps board domain errors to invalid params", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["boards"]))
+      const registry = boardRegistry()
       const result = yield* Effect.promise(() =>
-        registry.handleToolCall("get_board", { board: "Missing" }, makeClient({ boards: [] }), storageClient)
+        registry.handleToolCall(
+          makeToolName("get_board"),
+          { board: "Missing" },
+          makeClient({ boards: [] }),
+          storageClient
+        )
       )
 
       expect(result?.isError).toBe(true)
@@ -187,9 +199,14 @@ describe("board MCP tools", () => {
 
   it.effect("maps board saved-view domain errors to invalid params", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["boards"]))
+      const registry = boardRegistry()
       const result = yield* Effect.promise(() =>
-        registry.handleToolCall("get_board_saved_view", { savedView: "Missing" }, makeClient({}), storageClient)
+        registry.handleToolCall(
+          makeToolName("get_board_saved_view"),
+          { savedView: "Missing" },
+          makeClient({}),
+          storageClient
+        )
       )
 
       expect(result?.isError).toBe(true)

--- a/test/mcp/tools/inventory.test.ts
+++ b/test/mcp/tools/inventory.test.ts
@@ -12,6 +12,7 @@ import type { HulyStorageOperations } from "../../../src/huly/storage.js"
 import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
 import { McpErrorCode } from "../../../src/mcp/error-mapping.js"
 import { toolRegistry } from "../../../src/mcp/tools/index.js"
+import { makeToolName } from "../../../src/mcp/tools/registry.js"
 import { corePersonId, docRef, spaceRef } from "../../helpers/huly-sdk.js"
 
 // AccountUuid is a branded SDK string; integration-test fixtures use literal strings at runtime.
@@ -162,7 +163,7 @@ describe("inventory MCP tools", () => {
   it.effect("returns encoded structured inventory list responses", () =>
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
-        toolRegistry.handleToolCall("list_inventory_categories", {}, hulyClient, storageClient)
+        toolRegistry.handleToolCall(makeToolName("list_inventory_categories"), {}, hulyClient, storageClient)
       )
 
       expect(result?.isError).toBeUndefined()
@@ -173,7 +174,7 @@ describe("inventory MCP tools", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "list_inventory_product_attachments",
+          makeToolName("list_inventory_product_attachments"),
           { product: "prod-camera" },
           hulyClientWithInventoryProduct,
           storageClient
@@ -190,7 +191,7 @@ describe("inventory MCP tools", () => {
     Effect.gen(function*() {
       const result = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_inventory_category",
+          makeToolName("get_inventory_category"),
           { category: "Missing" },
           hulyClient,
           storageClient
@@ -206,7 +207,7 @@ describe("inventory MCP tools", () => {
     Effect.gen(function*() {
       const attachmentResult = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "get_inventory_product_attachment",
+          makeToolName("get_inventory_product_attachment"),
           { product: "prod-camera", attachmentId: "missing-attachment" },
           hulyClientWithInventoryProduct,
           storageClient
@@ -214,7 +215,7 @@ describe("inventory MCP tools", () => {
       )
       const commentResult = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "update_inventory_product_comment",
+          makeToolName("update_inventory_product_comment"),
           { product: "prod-camera", commentId: "missing-comment", body: "Updated" },
           hulyClientWithInventoryProduct,
           storageClient
@@ -222,7 +223,7 @@ describe("inventory MCP tools", () => {
       )
       const ambiguousResult = yield* Effect.promise(() =>
         toolRegistry.handleToolCall(
-          "list_inventory_product_activity",
+          makeToolName("list_inventory_product_activity"),
           { product: "Camera" },
           hulyClientWithInventoryProduct,
           storageClient

--- a/test/mcp/tools/views.test.ts
+++ b/test/mcp/tools/views.test.ts
@@ -16,10 +16,12 @@ import type { HulyStorageOperations } from "../../../src/huly/storage.js"
 import { testWorkbenchUrlConfig } from "../../../src/huly/url-builders.js"
 import { McpErrorCode } from "../../../src/mcp/error-mapping.js"
 import { createFilteredRegistry, TOOL_DEFINITIONS } from "../../../src/mcp/tools/index.js"
+import { makeToolCategory, makeToolName } from "../../../src/mcp/tools/registry.js"
 import { viewTools } from "../../../src/mcp/tools/views.js"
 import { assertAt, assertExists } from "../../../src/utils/assertions.js"
 
 const toolDefinition = (name: string) => assertExists(TOOL_DEFINITIONS[name], `Expected tool definition for ${name}`)
+const viewRegistry = () => createFilteredRegistry(new Set([makeToolCategory("views")]))
 
 // Huly SDK brands, intl ids, and component handles are erased at runtime; these fixture casts restore
 // compile-time brands for stable literals that match the SDK shapes used by the fake client.
@@ -135,7 +137,7 @@ const toTypedDocs = <T extends Doc>(docs: ReadonlyArray<Doc>): Array<T> => {
 describe("view MCP tools", () => {
   it.effect("registers view tools in order", () =>
     Effect.gen(function*() {
-      const filtered = createFilteredRegistry(new Set(["views"]))
+      const filtered = viewRegistry()
 
       expect(filtered.definitions.map((tool) => tool.name)).toEqual([
         "list_filtered_views",
@@ -147,10 +149,10 @@ describe("view MCP tools", () => {
 
   it.effect("serializes filtered view responses as structured content", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["views"]))
+      const registry = viewRegistry()
       const result = yield* Effect.promise(() =>
         registry.handleToolCall(
-          "list_filtered_views",
+          makeToolName("list_filtered_views"),
           { attachedTo: String(board.app.Board) },
           makeClient({ filteredViews: [filteredViewDoc] }),
           storageClient
@@ -174,10 +176,10 @@ describe("view MCP tools", () => {
 
   it.effect("serializes viewlet responses with descriptors and preferences", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["views"]))
+      const registry = viewRegistry()
       const result = yield* Effect.promise(() =>
         registry.handleToolCall(
-          "list_viewlets",
+          makeToolName("list_viewlets"),
           { attachTo: String(board.class.Card) },
           makeClient({
             viewlets: [viewletDoc],
@@ -214,10 +216,10 @@ describe("view MCP tools", () => {
 
   it.effect("surfaces descriptor metadata warnings in the MCP envelope", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["views"]))
+      const registry = viewRegistry()
       const result = yield* Effect.promise(() =>
         registry.handleToolCall(
-          "list_viewlets",
+          makeToolName("list_viewlets"),
           { attachTo: String(board.class.Card) },
           makeClient({
             viewlets: [viewletDoc],
@@ -241,10 +243,10 @@ describe("view MCP tools", () => {
 
   it.effect("maps generic view domain errors to invalid params", () =>
     Effect.gen(function*() {
-      const registry = createFilteredRegistry(new Set(["views"]))
+      const registry = viewRegistry()
       const result = yield* Effect.promise(() =>
         registry.handleToolCall(
-          "get_filtered_view",
+          makeToolName("get_filtered_view"),
           { filteredView: "Missing" },
           makeClient({ filteredViews: [] }),
           storageClient

--- a/test/telemetry/posthog.property.test.ts
+++ b/test/telemetry/posthog.property.test.ts
@@ -29,11 +29,22 @@ const sessionStartArbitrary = fc.record({
 
 const toolCalledArbitrary = fc.record(
   {
+    clientKind: fc.constantFrom(
+      "claude-code",
+      "claude-ai",
+      "cursor",
+      "windsurf",
+      "github-copilot",
+      "codex",
+      "opencode",
+      "unknown"
+    ),
     durationMs: fc.integer({ min: 0, max: 3_600_000 }),
     editMode: fc.string({ maxLength: 24 }),
     errorTag: fc.string({ maxLength: 48 }),
     inputBytes: fc.integer({ min: 0, max: 10_000_000 }),
     outputBytes: fc.integer({ min: 0, max: 10_000_000 }),
+    resolvedMode: fc.constantFrom("native", "proxy"),
     status: fc.constantFrom("success", "error"),
     toolName: fc.stringMatching(/^[a-z][a-z0-9_]{0,40}$/)
   },
@@ -136,10 +147,12 @@ const expectedEventProperties = (
           duration_ms: operation.props.durationMs,
           status: operation.props.status,
           tool_name: operation.props.toolName,
+          ...(operation.props.clientKind === undefined ? {} : { client_kind: operation.props.clientKind }),
           ...(operation.props.editMode === undefined ? {} : { edit_mode: operation.props.editMode }),
           ...(operation.props.errorTag === undefined ? {} : { error_tag: operation.props.errorTag }),
           ...(operation.props.inputBytes === undefined ? {} : { input_bytes: operation.props.inputBytes }),
-          ...(operation.props.outputBytes === undefined ? {} : { output_bytes: operation.props.outputBytes })
+          ...(operation.props.outputBytes === undefined ? {} : { output_bytes: operation.props.outputBytes }),
+          ...(operation.props.resolvedMode === undefined ? {} : { resolved_mode: operation.props.resolvedMode })
         })
         break
     }

--- a/test/telemetry/posthog.test.ts
+++ b/test/telemetry/posthog.test.ts
@@ -95,6 +95,18 @@ describe("createPostHogTelemetry", () => {
       expect(call.properties.session_id).toBeTypeOf("string")
       expect(call.properties.version).toBeTypeOf("string")
     })
+
+    it("captures client classification when provided", () => {
+      const telemetry = createTelemetry(false)
+      telemetry.firstListTools({ clientKind: "codex", resolvedMode: "proxy" })
+
+      const call = assertAt(mockCapture.mock.calls, 0)[0]
+      expect(call.event).toBe("first_list_tools")
+      expect(call.properties).toMatchObject({
+        client_kind: "codex",
+        resolved_mode: "proxy"
+      })
+    })
   })
 
   describe("toolCalled", () => {
@@ -113,6 +125,24 @@ describe("createPostHogTelemetry", () => {
         tool_name: "list_issues",
         status: "success",
         duration_ms: 42
+      })
+    })
+
+    it("captures client classification when provided", () => {
+      const telemetry = createTelemetry(false)
+      telemetry.toolCalled({
+        toolName: "list_issues",
+        status: "success",
+        durationMs: 42,
+        clientKind: "codex",
+        resolvedMode: "proxy"
+      })
+
+      const call = assertAt(mockCapture.mock.calls, 0)[0]
+      expect(call.event).toBe("tool_called")
+      expect(call.properties).toMatchObject({
+        client_kind: "codex",
+        resolved_mode: "proxy"
       })
     })
 
@@ -251,7 +281,7 @@ describe("createPostHogTelemetry", () => {
 
       telemetry.firstListTools()
 
-      expect(debugMessages).toContain("[telemetry] first_list_tools")
+      expect(debugMessages).toContainEqual(expect.stringContaining("[telemetry] first_list_tools"))
     })
 
     it("logs toolCalled to console.error", () => {


### PR DESCRIPTION
gpt 55

## Summary
- Add native Huly tool scope filtering with `TOOLSETS` category selection and `TOOLS` exact tool-name selection; no scope env keeps the current full native tool surface.
- Enforce the scoped registry for both `tools/list` and direct `tools/call`, while keeping built-ins visible and reporting unknown scope entries through warnings and `get_huly_context.toolScope`.
- Add client exposure-mode mapping prep without activating proxy behavior or changing runtime tool exposure for proxy mode yet.
- Add a dedicated tool-scope integration matrix covering defaults, category-only, exact-tool-only, union, all-invalid scope, and representative client names.

## Verification
- `pnpm vitest run test/mcp/tool-scope.test.ts test/mcp/tool-mode.test.ts test/mcp/server-parseToolsets.test.ts test/config/runtime-context-and-toolsets.property.test.ts test/mcp/registry.property.test.ts test/domain/schemas.huly-context.test.ts test/mcp/create-mcp-server.test.ts test/mcp/protocol-handlers.test.ts test/mcp/server.test.ts` — 165 passed.
- `pnpm check-all` — passed; 202 files, 3435 tests, coverage above 99%.
- `HULY_URL="${HULY_URL/localhost/host.docker.internal}" pnpm integration:tool-scope` — passed local-Huly scope matrix.
- `HULY_URL="${HULY_URL/localhost/host.docker.internal}" bash scripts/integration_test_full.sh` — passed; 791 passed, 0 failed, 28 skipped.
- Subagent review loop run after implementation; final finding was stale local-only PRD text plus the untracked integration script, both handled for the PR branch.

## Notes
- Proxy meta-tools are still not implemented in this slice.
- Existing unrelated dirty local files were not included in the commit: `docs/02_LAZY_TOOL_PRD.md`, `_apalache-out/`, and untracked `plans/*`.
