### PR TITLE
remove isRecord helpers

### DIFF
--- a/src/domain/schemas/chat-message-attachments.ts
+++ b/src/domain/schemas/chat-message-attachments.ts
@@ -1,8 +1,8 @@
-import { JSONSchema, Predicate, Schema } from "effect"
+import { JSONSchema, Schema } from "effect"
 
 import { UPDATE_ATTACHMENT_FIELDS } from "./attachments.js"
 import { AttachmentDescription, AttachmentFileName, Base64FileData, LocalFilePath } from "./domain-values.js"
-import { withExactlyOneRequired, withJsonSchemaPropertyDescriptions } from "./json-schema.js"
+import { parseJsonSchemaRecord, withExactlyOneRequired, withJsonSchemaPropertyDescriptions } from "./json-schema.js"
 import {
   assertUpdateFields,
   atLeastOneUpdateFieldMessage,
@@ -176,7 +176,15 @@ export type DeleteChatMessageAttachmentParams = Schema.Schema.Type<
   typeof DeleteChatMessageAttachmentParamsSchema
 >
 
-const CHAT_MESSAGE_ATTACHMENT_FIELD_DESCRIPTIONS: Readonly<Partial<Record<string, string>>> = {
+type PropertyKeyOfUnion<T> = T extends T ? keyof T : never
+
+type ChatMessageAttachmentDescriptionField =
+  | keyof AddChatMessageAttachmentParams
+  | keyof GetChatMessageAttachmentParams
+  | keyof ListChatMessageAttachmentsParams
+  | keyof UpdateChatMessageAttachmentParams
+
+const CHAT_MESSAGE_ATTACHMENT_FIELD_DESCRIPTIONS = {
   target:
     "Chat attachment target. Use channel_message for a channel message, dm_message for a direct-message message, or thread_reply for a thread reply.",
   limit: `Maximum number of matching attachments to return (default: ${DEFAULT_LIMIT}).`,
@@ -188,14 +196,23 @@ const CHAT_MESSAGE_ATTACHMENT_FIELD_DESCRIPTIONS: Readonly<Partial<Record<string
   data: "Base64-encoded file data. Mutually exclusive with filePath and fileUrl.",
   description: "Optional attachment description. Use null on update to clear it.",
   pinned: "Whether the attachment should be pinned."
-}
+} satisfies Readonly<Record<ChatMessageAttachmentDescriptionField, string>>
 
-const CHAT_MESSAGE_ATTACHMENT_TARGET_FIELD_DESCRIPTIONS: Readonly<Partial<Record<string, string>>> = {
+type ChatMessageAttachmentTargetDescriptionField = PropertyKeyOfUnion<ChatMessageAttachmentTarget>
+
+const CHAT_MESSAGE_ATTACHMENT_TARGET_FIELD_DESCRIPTIONS = {
   kind: "Target kind: channel_message, dm_message, or thread_reply.",
   channel: "Channel name or ID. Required for channel_message and thread_reply targets.",
   dm: "Direct-message conversation ID or one-to-one participant display name.",
   messageId: "Existing message ID. For thread_reply, this is the parent channel message ID.",
   replyId: "Existing thread reply ID."
+} satisfies Readonly<Record<ChatMessageAttachmentTargetDescriptionField, string>>
+
+const JsonSchemaArraySchema = Schema.Array(Schema.Unknown)
+
+const parseJsonSchemaArray = (value: unknown): ReadonlyArray<unknown> | undefined => {
+  const decoded = Schema.decodeUnknownEither(JsonSchemaArraySchema)(value)
+  return decoded._tag === "Right" ? decoded.right : undefined
 }
 
 const withRootSchemaMetadata = (schema: object, title: string, description: string): object => ({
@@ -204,32 +221,32 @@ const withRootSchemaMetadata = (schema: object, title: string, description: stri
   description
 })
 
-export const withChatMessageAttachmentTargetVariantDescriptions = (schema: object): object => {
-  const properties = Predicate.isRecord(schema) ? schema.properties : undefined
-  if (!Predicate.isRecord(properties)) return schema
-  const target = properties.target
-  if (!Predicate.isRecord(target) || !Array.isArray(target.anyOf)) return schema
+const chatMessageAttachmentJsonSchema = <A, I, R>(schema: Schema.Schema<A, I, R>): object => {
+  const jsonSchema = withJsonSchemaPropertyDescriptions(
+    JSONSchema.make(schema),
+    CHAT_MESSAGE_ATTACHMENT_FIELD_DESCRIPTIONS
+  )
+  const properties = parseJsonSchemaRecord(parseJsonSchemaRecord(jsonSchema)?.properties)
+  const target = parseJsonSchemaRecord(properties?.target)
+  const anyOf = parseJsonSchemaArray(target?.anyOf)
+  if (properties === undefined || target === undefined || anyOf === undefined) return jsonSchema
 
   return {
-    ...schema,
+    ...jsonSchema,
     properties: {
       ...properties,
       target: {
         ...target,
-        anyOf: target.anyOf.map((variant) =>
-          Predicate.isRecord(variant)
-            ? withJsonSchemaPropertyDescriptions(variant, CHAT_MESSAGE_ATTACHMENT_TARGET_FIELD_DESCRIPTIONS)
-            : variant
-        )
+        anyOf: anyOf.map((variant) => {
+          const variantRecord = parseJsonSchemaRecord(variant)
+          return variantRecord === undefined
+            ? variant
+            : withJsonSchemaPropertyDescriptions(variantRecord, CHAT_MESSAGE_ATTACHMENT_TARGET_FIELD_DESCRIPTIONS)
+        })
       }
     }
   }
 }
-
-const chatMessageAttachmentJsonSchema = <A, I, R>(schema: Schema.Schema<A, I, R>): object =>
-  withChatMessageAttachmentTargetVariantDescriptions(
-    withJsonSchemaPropertyDescriptions(JSONSchema.make(schema), CHAT_MESSAGE_ATTACHMENT_FIELD_DESCRIPTIONS)
-  )
 
 const withExactlyOneChatMessageAttachmentFileSource = (schema: object): object =>
   withExactlyOneRequired(schema, CHAT_MESSAGE_ATTACHMENT_FILE_SOURCE_FIELDS)

--- a/src/domain/schemas/inventory-media-json-schema.test.ts
+++ b/src/domain/schemas/inventory-media-json-schema.test.ts
@@ -1,16 +1,16 @@
-import { Predicate, Schema } from "effect"
+import { Schema } from "effect"
 import { describe, expect, it } from "vitest"
 
 import { inventoryMediaJsonSchema, withExactlyOneInventoryMediaFileSource } from "./inventory-media-json-schema.js"
+import { parseJsonSchemaRecord } from "./json-schema.js"
 
 const getProperty = (schema: unknown, property: string): unknown => {
-  if (!Predicate.isRecord(schema) || !Predicate.isRecord(schema.properties)) return undefined
-  return schema.properties[property]
+  return parseJsonSchemaRecord(parseJsonSchemaRecord(schema)?.properties)?.[property]
 }
 
 const getDescription = (schema: unknown, property: string): unknown => {
   const field = getProperty(schema, property)
-  return Predicate.isRecord(field) ? field.description : undefined
+  return parseJsonSchemaRecord(field)?.description
 }
 
 describe("Inventory media JSON schema helpers", () => {
@@ -27,7 +27,7 @@ describe("Inventory media JSON schema helpers", () => {
   it("adds oneOf requirements for exactly one media file source", () => {
     const jsonSchema = withExactlyOneInventoryMediaFileSource({ type: "object" })
 
-    expect(Predicate.isRecord(jsonSchema) ? jsonSchema.oneOf : undefined).toEqual([
+    expect(parseJsonSchemaRecord(jsonSchema)?.oneOf).toEqual([
       { required: ["filePath"] },
       { required: ["fileUrl"] },
       { required: ["data"] }

--- a/src/domain/schemas/json-schema.test.ts
+++ b/src/domain/schemas/json-schema.test.ts
@@ -1,13 +1,13 @@
-import { Predicate } from "effect"
 import { describe, expect, it } from "vitest"
 
-import { withExactlyOneRequired, withJsonSchemaPropertyDescriptions } from "./json-schema.js"
+import { parseJsonSchemaRecord, withExactlyOneRequired, withJsonSchemaPropertyDescriptions } from "./json-schema.js"
 
 const expectRecord = (value: unknown): { readonly [x: string | symbol]: unknown } => {
-  if (!Predicate.isRecord(value)) {
+  const record = parseJsonSchemaRecord(value)
+  if (record === undefined) {
     throw new Error("Expected record")
   }
-  return value
+  return record
 }
 
 const getProperty = (schema: unknown, property: string): unknown => {
@@ -18,7 +18,7 @@ const getProperty = (schema: unknown, property: string): unknown => {
 
 const getDescription = (schema: unknown, property: string): unknown => {
   const field = getProperty(schema, property)
-  return Predicate.isRecord(field) ? field.description : undefined
+  return parseJsonSchemaRecord(field)?.description
 }
 
 describe("JSON schema helpers", () => {

--- a/src/domain/schemas/json-schema.ts
+++ b/src/domain/schemas/json-schema.ts
@@ -1,21 +1,34 @@
-import { Predicate } from "effect"
+import { Schema } from "effect"
 
 type JsonSchemaPropertyDescriptions = Readonly<Partial<Record<string, string>>>
+
+const JsonSchemaRecordSchema = Schema.Record({ key: Schema.String, value: Schema.Unknown })
+
+type JsonSchemaRecord = Schema.Schema.Type<typeof JsonSchemaRecordSchema>
+
+export const parseJsonSchemaRecord = (value: unknown): JsonSchemaRecord | undefined => {
+  try {
+    return Schema.decodeUnknownSync(JsonSchemaRecordSchema)(value)
+  } catch {
+    return undefined
+  }
+}
 
 export const withJsonSchemaPropertyDescriptions = (
   schema: object,
   descriptions: JsonSchemaPropertyDescriptions
 ): object => {
-  const properties = Predicate.isRecord(schema) ? schema.properties : undefined
-  if (!Predicate.isRecord(properties)) return schema
+  const properties = parseJsonSchemaRecord(parseJsonSchemaRecord(schema)?.properties)
+  if (properties === undefined) return schema
   return {
     ...schema,
     properties: Object.fromEntries(
       Object.entries(properties).map(([key, value]) => {
         const description = descriptions[key]
+        const property = parseJsonSchemaRecord(value)
         return [
           key,
-          description === undefined || !Predicate.isRecord(value) ? value : { ...value, description }
+          description === undefined || property === undefined ? value : { ...property, description }
         ]
       })
     )

--- a/src/huly/operations/spaces-shared.ts
+++ b/src/huly/operations/spaces-shared.ts
@@ -89,6 +89,7 @@ export const optionalObjectClassName = (value: string | undefined): ObjectClassN
   value === undefined || value === "" ? undefined : ObjectClassName.make(value)
 
 const RoleAssignmentStorageSchema = Schema.Record({ key: Schema.String, value: Schema.Array(AccountUuid) })
+const RoleAssignmentStorageObjectSchema = Schema.Record({ key: Schema.String, value: Schema.Unknown })
 
 type SpaceRoleAssignmentEntry = readonly [Ref<Role>, ReadonlyArray<HulyAccountUuid>]
 
@@ -102,8 +103,10 @@ interface SpaceRoleAssignmentReadResult {
   readonly degradationReasons: ReadonlyArray<string>
 }
 
-const isRecordObject = (value: unknown): value is Readonly<Record<string, unknown>> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
+const parseRoleAssignmentStorageObject = (value: unknown): Readonly<Record<string, unknown>> | undefined => {
+  const decoded = Schema.decodeUnknownEither(RoleAssignmentStorageObjectSchema)(value)
+  return decoded._tag === "Right" ? decoded.right : undefined
+}
 
 const validStoredAccountUuid = (value: unknown): HulyAccountUuid | undefined => {
   const decoded = Schema.decodeUnknownEither(AccountUuid)(value)
@@ -149,14 +152,15 @@ export const readSpaceRoleAssignmentEntries = (
 ): SpaceRoleAssignmentReadResult => {
   const source = spaceRoleAssignmentSource(space, spaceType)
   if (!source.present) return { entries: [], degradationReasons: [] }
-  if (!isRecordObject(source.value)) {
+  const storedAssignments = parseRoleAssignmentStorageObject(source.value)
+  if (storedAssignments === undefined) {
     return {
       entries: [],
       degradationReasons: [`role assignment mixin ${spaceType.targetClass} is not an object`]
     }
   }
 
-  const parsed = Object.entries(source.value).flatMap(([roleId, members]) => {
+  const parsed = Object.entries(storedAssignments).flatMap(([roleId, members]) => {
     if (!validRoleIds.has(toRef<Role>(roleId))) {
       return [{
         _tag: "dropped" as const,

--- a/src/mcp/http-2026-boundary.ts
+++ b/src/mcp/http-2026-boundary.ts
@@ -1,0 +1,358 @@
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js"
+import { Schema } from "effect"
+import type { Request } from "express"
+
+const MCP_2026_PROTOCOL_VERSION = "2026-07-28"
+
+// JSON-RPC error codes specific to the MCP 2026-07-28 stateless transport. Standard
+// JSON-RPC codes come from the SDK's ErrorCode enum (ErrorCode.InvalidRequest etc.).
+// HEADER_MISMATCH (-32001) intentionally reuses the numeric value the SDK assigns to
+// ErrorCode.RequestTimeout, but carries a distinct 2026 meaning (header/body/_meta
+// mismatch), so it stays a named local rather than ErrorCode.RequestTimeout.
+const HEADER_MISMATCH = -32001
+const UNSUPPORTED_PROTOCOL_VERSION = -32004
+const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion"
+const CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo"
+const CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities"
+const PARAMETER_SEPARATOR_NOT_FOUND = -1
+
+interface JsonRpcRequest {
+  readonly jsonrpc: "2.0"
+  readonly id?: string | number | null
+  readonly method: string
+  readonly params?: unknown
+}
+
+export interface JsonRpcErrorObject {
+  readonly code: number
+  readonly message: string
+  readonly data?: unknown
+}
+
+export interface JsonRpcErrorResponse {
+  readonly jsonrpc: "2.0"
+  readonly id: string | number | null
+  readonly error: JsonRpcErrorObject
+}
+
+interface HeaderValidationBase {
+  readonly request: JsonRpcRequest
+  readonly id: string | number | null
+}
+
+const AnyRecordSchema = Schema.Record({ key: Schema.String, value: Schema.Unknown })
+const JsonRpcRequestEnvelopeSchema = Schema.Struct({
+  jsonrpc: Schema.optional(Schema.Unknown),
+  id: Schema.optional(Schema.Unknown),
+  method: Schema.optional(Schema.Unknown),
+  params: Schema.optional(Schema.Unknown)
+})
+type JsonRpcRequestEnvelope = Schema.Schema.Type<typeof JsonRpcRequestEnvelopeSchema>
+
+const Mcp2026RequestMetadataSchema = AnyRecordSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      [PROTOCOL_VERSION_META_KEY]: Schema.Literal(MCP_2026_PROTOCOL_VERSION),
+      [CLIENT_INFO_META_KEY]: AnyRecordSchema,
+      [CLIENT_CAPABILITIES_META_KEY]: AnyRecordSchema
+    })
+  )
+)
+
+const Mcp2026RequestParamsSchema = AnyRecordSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      _meta: Mcp2026RequestMetadataSchema
+    })
+  )
+)
+type Mcp2026RequestParams = Schema.Schema.Type<typeof Mcp2026RequestParamsSchema>
+
+const NonEmptyProtocolStringSchema = Schema.String.pipe(Schema.nonEmptyString())
+const ToolCallParamsSchema = Mcp2026RequestParamsSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      name: NonEmptyProtocolStringSchema
+    })
+  )
+)
+const ResourceReadParamsSchema = Mcp2026RequestParamsSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      uri: NonEmptyProtocolStringSchema
+    })
+  )
+)
+type ToolCallParams = Schema.Schema.Type<typeof ToolCallParamsSchema>
+type ResourceReadParams = Schema.Schema.Type<typeof ResourceReadParamsSchema>
+
+type HeaderValidation =
+  | (HeaderValidationBase & {
+    readonly kind: "other"
+    readonly params: Mcp2026RequestParams
+  })
+  | (HeaderValidationBase & {
+    readonly kind: "tools/call"
+    readonly request: JsonRpcRequest & { readonly method: "tools/call" }
+    readonly params: ToolCallParams
+  })
+  | (HeaderValidationBase & {
+    readonly kind: "resources/read"
+    readonly request: JsonRpcRequest & { readonly method: "resources/read" }
+    readonly params: ResourceReadParams
+  })
+
+type Mcp2026RequestParamsParseResult =
+  | { readonly _tag: "success"; readonly params: Mcp2026RequestParams }
+  | { readonly _tag: "error"; readonly error: JsonRpcErrorObject }
+
+const Mcp2026RequestParamsWithMetaSchema = AnyRecordSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      _meta: AnyRecordSchema
+    })
+  )
+)
+const Mcp2026ProtocolMetadataSchema = Schema.Struct({
+  [PROTOCOL_VERSION_META_KEY]: Schema.Literal(MCP_2026_PROTOCOL_VERSION)
+})
+const Mcp2026ClientInfoMetadataSchema = Schema.Struct({
+  [CLIENT_INFO_META_KEY]: AnyRecordSchema
+})
+
+const requestMethodSchema = Schema.Struct({ method: Schema.optional(Schema.Unknown) })
+
+const lightweightMetaProtocolSchema = Schema.Struct({
+  params: Schema.Struct({
+    _meta: Schema.Struct({
+      [PROTOCOL_VERSION_META_KEY]: Schema.String
+    })
+  })
+})
+
+const firstHeader = (value: string | ReadonlyArray<string> | undefined): string | undefined => {
+  if (typeof value === "string") return value
+  return value?.[0]
+}
+
+const parseJsonRpcRequestEnvelope = (body: object): JsonRpcRequestEnvelope =>
+  Schema.decodeUnknownSync(JsonRpcRequestEnvelopeSchema)(body)
+
+const parseMcp2026RequestParams = (params: unknown): Mcp2026RequestParamsParseResult => {
+  const decoded = Schema.decodeUnknownEither(Mcp2026RequestParamsSchema)(params)
+  if (decoded._tag === "Right") return { _tag: "success", params: decoded.right }
+
+  const paramsWithMeta = Schema.decodeUnknownEither(Mcp2026RequestParamsWithMetaSchema)(params)
+  if (paramsWithMeta._tag === "Left") {
+    return { _tag: "error", error: { code: HEADER_MISMATCH, message: "Header mismatch: params._meta is required" } }
+  }
+  if (Schema.decodeUnknownEither(Mcp2026ProtocolMetadataSchema)(paramsWithMeta.right._meta)._tag === "Left") {
+    return {
+      _tag: "error",
+      error: { code: HEADER_MISMATCH, message: "Header mismatch: params._meta protocol version must be 2026-07-28" }
+    }
+  }
+  if (Schema.decodeUnknownEither(Mcp2026ClientInfoMetadataSchema)(paramsWithMeta.right._meta)._tag === "Left") {
+    return {
+      _tag: "error",
+      error: { code: HEADER_MISMATCH, message: "Header mismatch: clientInfo metadata is required" }
+    }
+  }
+  return {
+    _tag: "error",
+    error: { code: HEADER_MISMATCH, message: "Header mismatch: clientCapabilities metadata is required" }
+  }
+}
+
+const parseRequestId = (id: unknown): string | number | null | undefined =>
+  typeof id === "string" || typeof id === "number" || id === null ? id : undefined
+
+const parseJsonRpcRequestId = (body: unknown): string | number | null => {
+  if (Array.isArray(body) || body === null || typeof body !== "object") return null
+  return parseRequestId(parseJsonRpcRequestEnvelope(body).id) ?? null
+}
+
+const metaProtocolVersion = (body: unknown): string | undefined => {
+  try {
+    return Schema.decodeUnknownSync(lightweightMetaProtocolSchema)(body)
+      .params._meta[PROTOCOL_VERSION_META_KEY]
+  } catch {
+    return undefined
+  }
+}
+
+const bodyMethod = (body: unknown): string | undefined => {
+  if (Array.isArray(body) || body === null || body === undefined || typeof body !== "object") return undefined
+  const requestMethod = Schema.decodeUnknownSync(requestMethodSchema)(body).method
+  return typeof requestMethod === "string" ? requestMethod : undefined
+}
+
+// A request is handled by the 2026 stateless dispatcher when it carries a signal the
+// legacy SDK Streamable HTTP transport never emits: the Mcp-Method routing header
+// (mandatory in the 2026 transport), a 2026 protocol version inside params._meta, or
+// the server/discover bootstrap call. We deliberately do NOT trigger on
+// MCP-Protocol-Version alone because the SDK client sends that header with its own
+// negotiated version, so routing on it would hijack legacy clients once the SDK
+// advertises 2026-07-28. The header is still required once dispatched.
+export const shouldDispatchMcp2026Request = (req: Request): boolean =>
+  firstHeader(req.headers["mcp-method"]) !== undefined
+  || metaProtocolVersion(req.body) === MCP_2026_PROTOCOL_VERSION
+  || bodyMethod(req.body) === "server/discover"
+
+const jsonRpcError = (
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown
+): JsonRpcErrorResponse => {
+  if (data === undefined) {
+    return { jsonrpc: "2.0", id, error: { code, message } }
+  }
+  return { jsonrpc: "2.0", id, error: { code, message, data } }
+}
+
+const acceptsModernResponseTypes = (req: Request): boolean => {
+  const accept = firstHeader(req.headers.accept)
+  if (accept === undefined) return false
+  const parts = accept.split(",").map((part) => {
+    const parameterIndex = part.indexOf(";")
+    const mediaType = parameterIndex === PARAMETER_SEPARATOR_NOT_FOUND ? part : part.slice(0, parameterIndex)
+    return mediaType.trim().toLowerCase()
+  })
+  return parts.includes("application/json") && parts.includes("text/event-stream")
+}
+
+const parseJsonRpcRequest = (body: unknown): JsonRpcRequest | JsonRpcErrorObject => {
+  if (Array.isArray(body)) {
+    return { code: ErrorCode.InvalidRequest, message: "Batch JSON-RPC requests are not supported" }
+  }
+  if (body === null || typeof body !== "object") {
+    return { code: ErrorCode.InvalidRequest, message: "Request body must be a single JSON-RPC object" }
+  }
+
+  const request = parseJsonRpcRequestEnvelope(body)
+  if (request.jsonrpc !== "2.0") {
+    return { code: ErrorCode.InvalidRequest, message: "Request body must include jsonrpc: \"2.0\"" }
+  }
+  if (typeof request.method !== "string" || request.method === "") {
+    return { code: ErrorCode.InvalidRequest, message: "Request body must include a non-empty method" }
+  }
+  const requestId = parseRequestId(request.id)
+  return {
+    jsonrpc: "2.0",
+    ...(requestId === undefined ? {} : { id: requestId }),
+    method: request.method,
+    params: request.params
+  }
+}
+
+const requiredStringHeader = (req: Request, name: string): string | JsonRpcErrorObject => {
+  const header = firstHeader(req.headers[name.toLowerCase()])
+  if (header === undefined || header.trim() === "") {
+    return { code: HEADER_MISMATCH, message: `Header mismatch: required ${name} header is missing` }
+  }
+  return header
+}
+
+export const parseHeaderValidatedRequest = (req: Request): HeaderValidation | JsonRpcErrorResponse => {
+  const parsed = parseJsonRpcRequest(req.body)
+  if ("code" in parsed) return jsonRpcError(parseJsonRpcRequestId(req.body), parsed.code, parsed.message, parsed.data)
+  const requestId = parsed.id ?? null
+
+  if (!acceptsModernResponseTypes(req)) {
+    return jsonRpcError(
+      requestId,
+      HEADER_MISMATCH,
+      "Header mismatch: Accept header must include application/json and text/event-stream"
+    )
+  }
+
+  const protocolHeader = requiredStringHeader(req, "MCP-Protocol-Version")
+  if (typeof protocolHeader !== "string") {
+    return jsonRpcError(requestId, protocolHeader.code, protocolHeader.message, protocolHeader.data)
+  }
+  if (protocolHeader !== MCP_2026_PROTOCOL_VERSION) {
+    return jsonRpcError(
+      requestId,
+      UNSUPPORTED_PROTOCOL_VERSION,
+      "Unsupported protocol version",
+      { supported: [MCP_2026_PROTOCOL_VERSION], requested: protocolHeader }
+    )
+  }
+
+  const methodHeader = requiredStringHeader(req, "Mcp-Method")
+  if (typeof methodHeader !== "string") {
+    return jsonRpcError(requestId, methodHeader.code, methodHeader.message, methodHeader.data)
+  }
+  if (methodHeader !== parsed.method) {
+    return jsonRpcError(
+      requestId,
+      HEADER_MISMATCH,
+      `Header mismatch: Mcp-Method header value '${methodHeader}' does not match body value '${parsed.method}'`
+    )
+  }
+
+  const params = parseMcp2026RequestParams(parsed.params)
+  if (params._tag === "error") {
+    return jsonRpcError(requestId, params.error.code, params.error.message, params.error.data)
+  }
+
+  const nameValidation = parseNamedRequest(req, parsed, params.params)
+  if ("code" in nameValidation) {
+    return jsonRpcError(requestId, nameValidation.code, nameValidation.message, nameValidation.data)
+  }
+
+  return { ...nameValidation, id: requestId }
+}
+
+const parseNamedRequest = (
+  req: Request,
+  request: JsonRpcRequest,
+  params: Mcp2026RequestParams
+): HeaderValidation | JsonRpcErrorObject => {
+  const method = request.method
+  if (method !== "tools/call" && method !== "resources/read") {
+    return { kind: "other", request, params, id: request.id ?? null }
+  }
+
+  const nameHeader = requiredStringHeader(req, "Mcp-Name")
+  if (typeof nameHeader !== "string") return nameHeader
+
+  if (method === "tools/call") {
+    const toolCallParams = Schema.decodeUnknownEither(ToolCallParamsSchema)(params)
+    if (toolCallParams._tag === "Left") {
+      return { code: ErrorCode.InvalidParams, message: "Invalid params: tools/call requires params.name" }
+    }
+    if (nameHeader !== toolCallParams.right.name) {
+      return {
+        code: HEADER_MISMATCH,
+        message:
+          `Header mismatch: Mcp-Name header value '${nameHeader}' does not match body value '${toolCallParams.right.name}'`
+      }
+    }
+    return {
+      kind: "tools/call",
+      request: { ...request, method },
+      params: toolCallParams.right,
+      id: request.id ?? null
+    }
+  }
+
+  const resourceReadParams = Schema.decodeUnknownEither(ResourceReadParamsSchema)(params)
+  if (resourceReadParams._tag === "Left") {
+    return { code: ErrorCode.InvalidParams, message: "Invalid params: resources/read requires params.uri" }
+  }
+  if (nameHeader !== resourceReadParams.right.uri) {
+    return {
+      code: HEADER_MISMATCH,
+      message:
+        `Header mismatch: Mcp-Name header value '${nameHeader}' does not match body value '${resourceReadParams.right.uri}'`
+    }
+  }
+  return {
+    kind: "resources/read",
+    request: { ...request, method },
+    params: resourceReadParams.right,
+    id: request.id ?? null
+  }
+}

--- a/src/mcp/http-2026-dispatcher.ts
+++ b/src/mcp/http-2026-dispatcher.ts
@@ -2,18 +2,14 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import type { Request, Response } from "express"
 
 import { McpErrorCode } from "./error-mapping.js"
+import {
+  type JsonRpcErrorObject,
+  type JsonRpcErrorResponse,
+  parseHeaderValidatedRequest
+} from "./http-2026-boundary.js"
 import type { McpProtocolHandlers } from "./protocol-handlers.js"
 
-const MCP_2026_PROTOCOL_VERSION = "2026-07-28"
-
-// JSON-RPC error codes specific to the MCP 2026-07-28 stateless transport. Standard
-// JSON-RPC codes come from the SDK's ErrorCode enum (ErrorCode.InvalidRequest etc.), and
-// the shared resource-not-found code from McpErrorCode (src/mcp/error-mapping.ts).
-// HEADER_MISMATCH (-32001) intentionally reuses the numeric value the SDK assigns to
-// ErrorCode.RequestTimeout, but carries a distinct 2026 meaning (header/body/_meta
-// mismatch), so it stays a named local rather than ErrorCode.RequestTimeout.
-const HEADER_MISMATCH = -32001
-const UNSUPPORTED_PROTOCOL_VERSION = -32004
+export { shouldDispatchMcp2026Request } from "./http-2026-boundary.js"
 
 const HTTP_BAD_REQUEST = 400
 const HTTP_NOT_FOUND = 404
@@ -24,73 +20,11 @@ const PRIVATE_RESOURCE_TTL_MS = 60_000
 
 type CacheScope = "public" | "private"
 
-interface JsonRpcRequest {
-  readonly jsonrpc: "2.0"
-  readonly id?: string | number | null
-  readonly method: string
-  readonly params?: unknown
-}
-
-interface JsonRpcErrorObject {
-  readonly code: number
-  readonly message: string
-  readonly data?: unknown
-}
-
-interface JsonRpcErrorResponse {
-  readonly jsonrpc: "2.0"
-  readonly id: string | number | null
-  readonly error: JsonRpcErrorObject
-}
-
 interface JsonRpcSuccessResponse {
   readonly jsonrpc: "2.0"
   readonly id: string | number | null
   readonly result: unknown
 }
-
-interface HeaderValidation {
-  readonly request: JsonRpcRequest
-  readonly params: Record<string, unknown>
-  readonly id: string | number | null
-}
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const firstHeader = (value: string | ReadonlyArray<string> | undefined): string | undefined => {
-  if (typeof value === "string") return value
-  return value?.[0]
-}
-
-const requestId = (body: unknown): string | number | null => {
-  if (!isRecord(body)) return null
-  const id = body.id
-  return typeof id === "string" || typeof id === "number" || id === null ? id : null
-}
-
-const metaProtocolVersion = (body: unknown): string | undefined => {
-  if (!isRecord(body) || !isRecord(body.params) || !isRecord(body.params._meta)) return undefined
-  const version = body.params._meta["io.modelcontextprotocol/protocolVersion"]
-  return typeof version === "string" ? version : undefined
-}
-
-const bodyMethod = (body: unknown): string | undefined => {
-  if (!isRecord(body)) return undefined
-  return typeof body.method === "string" ? body.method : undefined
-}
-
-// A request is handled by the 2026 stateless dispatcher when it carries a signal the
-// legacy SDK Streamable HTTP transport never emits: the Mcp-Method routing header
-// (mandatory in the 2026 transport), a 2026 protocol version inside params._meta, or
-// the server/discover bootstrap call. We deliberately do NOT trigger on
-// MCP-Protocol-Version alone — the SDK client sends that header with its own negotiated
-// version, so routing on it would hijack legacy clients once the SDK advertises
-// 2026-07-28. The header is still required (and validated) once a request is dispatched.
-export const shouldDispatchMcp2026Request = (req: Request): boolean =>
-  firstHeader(req.headers["mcp-method"]) !== undefined
-  || metaProtocolVersion(req.body) === MCP_2026_PROTOCOL_VERSION
-  || bodyMethod(req.body) === "server/discover"
 
 const jsonRpcError = (
   id: string | number | null,
@@ -127,141 +61,6 @@ const httpStatusForErrorCode = (code: number): number => {
   if (code === ErrorCode.MethodNotFound) return HTTP_NOT_FOUND
   if (code === ErrorCode.InternalError) return HTTP_INTERNAL_SERVER_ERROR
   return HTTP_BAD_REQUEST
-}
-
-const acceptsModernResponseTypes = (req: Request): boolean => {
-  const accept = firstHeader(req.headers.accept)
-  if (accept === undefined) return false
-  const parts = accept.split(",").map(part => (part.split(";")[0] ?? "").trim().toLowerCase())
-  return parts.includes("application/json") && parts.includes("text/event-stream")
-}
-
-const validateJsonRpcRequest = (body: unknown): JsonRpcRequest | JsonRpcErrorObject => {
-  if (Array.isArray(body)) {
-    return { code: ErrorCode.InvalidRequest, message: "Batch JSON-RPC requests are not supported" }
-  }
-  if (!isRecord(body)) {
-    return { code: ErrorCode.InvalidRequest, message: "Request body must be a single JSON-RPC object" }
-  }
-  if (body.jsonrpc !== "2.0") {
-    return { code: ErrorCode.InvalidRequest, message: "Request body must include jsonrpc: \"2.0\"" }
-  }
-  if (typeof body.method !== "string" || body.method === "") {
-    return { code: ErrorCode.InvalidRequest, message: "Request body must include a non-empty method" }
-  }
-  return {
-    jsonrpc: "2.0",
-    id: requestId(body),
-    method: body.method,
-    params: body.params
-  }
-}
-
-const requiredStringHeader = (req: Request, name: string): string | JsonRpcErrorObject => {
-  const header = firstHeader(req.headers[name.toLowerCase()])
-  if (header === undefined || header.trim() === "") {
-    return { code: HEADER_MISMATCH, message: `Header mismatch: required ${name} header is missing` }
-  }
-  return header
-}
-
-const validateMeta = (params: Record<string, unknown>): JsonRpcErrorObject | undefined => {
-  if (!isRecord(params._meta)) {
-    return { code: HEADER_MISMATCH, message: "Header mismatch: params._meta is required" }
-  }
-  if (params._meta["io.modelcontextprotocol/protocolVersion"] !== MCP_2026_PROTOCOL_VERSION) {
-    return {
-      code: HEADER_MISMATCH,
-      message: "Header mismatch: params._meta protocol version must be 2026-07-28"
-    }
-  }
-  if (!isRecord(params._meta["io.modelcontextprotocol/clientInfo"])) {
-    return { code: HEADER_MISMATCH, message: "Header mismatch: clientInfo metadata is required" }
-  }
-  if (!isRecord(params._meta["io.modelcontextprotocol/clientCapabilities"])) {
-    return { code: HEADER_MISMATCH, message: "Header mismatch: clientCapabilities metadata is required" }
-  }
-  return undefined
-}
-
-const validateHeadersAndMeta = (req: Request): HeaderValidation | JsonRpcErrorResponse => {
-  const id = requestId(req.body)
-  const parsed = validateJsonRpcRequest(req.body)
-  if ("code" in parsed) return jsonRpcError(id, parsed.code, parsed.message, parsed.data)
-
-  if (!acceptsModernResponseTypes(req)) {
-    return jsonRpcError(
-      parsed.id ?? null,
-      HEADER_MISMATCH,
-      "Header mismatch: Accept header must include application/json and text/event-stream"
-    )
-  }
-
-  const protocolHeader = requiredStringHeader(req, "MCP-Protocol-Version")
-  if (typeof protocolHeader !== "string") {
-    return jsonRpcError(parsed.id ?? null, protocolHeader.code, protocolHeader.message, protocolHeader.data)
-  }
-  if (protocolHeader !== MCP_2026_PROTOCOL_VERSION) {
-    return jsonRpcError(
-      parsed.id ?? null,
-      UNSUPPORTED_PROTOCOL_VERSION,
-      "Unsupported protocol version",
-      { supported: [MCP_2026_PROTOCOL_VERSION], requested: protocolHeader }
-    )
-  }
-
-  const methodHeader = requiredStringHeader(req, "Mcp-Method")
-  if (typeof methodHeader !== "string") {
-    return jsonRpcError(parsed.id ?? null, methodHeader.code, methodHeader.message, methodHeader.data)
-  }
-  if (methodHeader !== parsed.method) {
-    return jsonRpcError(
-      parsed.id ?? null,
-      HEADER_MISMATCH,
-      `Header mismatch: Mcp-Method header value '${methodHeader}' does not match body value '${parsed.method}'`
-    )
-  }
-
-  const params = isRecord(parsed.params) ? parsed.params : {}
-  const metaError = validateMeta(params)
-  if (metaError !== undefined) {
-    return jsonRpcError(parsed.id ?? null, metaError.code, metaError.message, metaError.data)
-  }
-
-  const nameValidation = validateNameHeader(req, parsed.method, params)
-  if (nameValidation !== undefined) {
-    return jsonRpcError(parsed.id ?? null, nameValidation.code, nameValidation.message, nameValidation.data)
-  }
-
-  return { request: parsed, params, id: parsed.id ?? null }
-}
-
-const validateNameHeader = (
-  req: Request,
-  method: string,
-  params: Record<string, unknown>
-): JsonRpcErrorObject | undefined => {
-  if (method !== "tools/call" && method !== "resources/read") return undefined
-
-  const nameHeader = requiredStringHeader(req, "Mcp-Name")
-  if (typeof nameHeader !== "string") return nameHeader
-
-  const bodyName = method === "tools/call" ? params.name : params.uri
-  if (typeof bodyName !== "string" || bodyName === "") {
-    return {
-      code: ErrorCode.InvalidParams,
-      message: method === "tools/call"
-        ? "Invalid params: tools/call requires params.name"
-        : "Invalid params: resources/read requires params.uri"
-    }
-  }
-  if (nameHeader !== bodyName) {
-    return {
-      code: HEADER_MISMATCH,
-      message: `Header mismatch: Mcp-Name header value '${nameHeader}' does not match body value '${bodyName}'`
-    }
-  }
-  return undefined
 }
 
 const complete = <T extends object>(result: T): T & { readonly resultType: "complete" } => ({
@@ -302,37 +101,15 @@ export const dispatchMcp2026Request = async (
 ): Promise<void> => {
   res.setHeader("Content-Type", "application/json")
 
-  const validation = validateHeadersAndMeta(req)
+  const validation = parseHeaderValidatedRequest(req)
   if ("error" in validation) {
     res.status(httpStatusForErrorCode(validation.error.code)).json(validation)
     return
   }
 
   try {
-    switch (validation.request.method) {
-      case "server/discover":
-        writeSuccess(res, validation.id, handlers.serverDiscover())
-        return
-
-      case "tools/list":
-        writeSuccess(res, validation.id, cacheable(await handlers.listTools(), PUBLIC_LIST_TTL_MS, "public"))
-        return
-
+    switch (validation.kind) {
       case "tools/call":
-        // defensive: validateHeadersAndMeta already rejects a tools/call whose params.name is not
-        // a string (Mcp-Name header presence + body match), so this re-check is never hit.
-        /* v8 ignore start */
-        if (typeof validation.params.name !== "string") {
-          writeError(
-            res,
-            HTTP_BAD_REQUEST,
-            validation.id,
-            ErrorCode.InvalidParams,
-            "Invalid params: tools/call requires params.name"
-          )
-          return
-        }
-        /* v8 ignore stop */
         writeSuccess(
           res,
           validation.id,
@@ -347,29 +124,7 @@ export const dispatchMcp2026Request = async (
         )
         return
 
-      case "resources/list":
-        writeSuccess(res, validation.id, cacheable(await handlers.listResources(), PRIVATE_RESOURCE_TTL_MS, "private"))
-        return
-
-      case "resources/templates/list":
-        writeSuccess(res, validation.id, cacheable(handlers.listResourceTemplates(), PUBLIC_LIST_TTL_MS, "public"))
-        return
-
       case "resources/read":
-        // defensive: validateHeadersAndMeta already rejects a resources/read whose params.uri is
-        // not a string (Mcp-Name header presence + body match), so this re-check is never hit.
-        /* v8 ignore start */
-        if (typeof validation.params.uri !== "string") {
-          writeError(
-            res,
-            HTTP_BAD_REQUEST,
-            validation.id,
-            ErrorCode.InvalidParams,
-            "Invalid params: resources/read requires params.uri"
-          )
-          return
-        }
-        /* v8 ignore stop */
         writeSuccess(
           res,
           validation.id,
@@ -379,6 +134,27 @@ export const dispatchMcp2026Request = async (
             "private"
           )
         )
+        return
+
+      case "other":
+        break
+    }
+
+    switch (validation.request.method) {
+      case "server/discover":
+        writeSuccess(res, validation.id, handlers.serverDiscover())
+        return
+
+      case "tools/list":
+        writeSuccess(res, validation.id, cacheable(await handlers.listTools(), PUBLIC_LIST_TTL_MS, "public"))
+        return
+
+      case "resources/list":
+        writeSuccess(res, validation.id, cacheable(await handlers.listResources(), PRIVATE_RESOURCE_TTL_MS, "private"))
+        return
+
+      case "resources/templates/list":
+        writeSuccess(res, validation.id, cacheable(handlers.listResourceTemplates(), PUBLIC_LIST_TTL_MS, "public"))
         return
 
       default:

--- a/src/mcp/input-schema-compat.ts
+++ b/src/mcp/input-schema-compat.ts
@@ -1,3 +1,5 @@
+import { Schema } from "effect"
+
 import { collectJsonSchemaDefinitions } from "./json-schema-refs.js"
 
 export interface McpInputSchema {
@@ -11,15 +13,37 @@ export interface McpInputSchema {
 type ObjectSchemaField = "properties" | "$defs"
 
 const ROOT_COMPOSITION_KEYS = new Set(["anyOf", "oneOf", "allOf"])
+const UnknownRecordSchema = Schema.Record({ key: Schema.String, value: Schema.Unknown })
+const UnknownArraySchema = Schema.Array(Schema.Unknown)
+type UnknownRecord = Schema.Schema.Type<typeof UnknownRecordSchema>
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
+const parseUnknownRecord = (value: unknown): UnknownRecord | undefined => {
+  try {
+    return Schema.decodeUnknownSync(UnknownRecordSchema)(value)
+  } catch {
+    return undefined
+  }
+}
+
+const parseUnknownRecordArray = (value: unknown): ReadonlyArray<UnknownRecord> => {
+  try {
+    return Schema.decodeUnknownSync(UnknownArraySchema)(value).flatMap((item) => {
+      const record = parseUnknownRecord(item)
+      return record === undefined ? [] : [record]
+    })
+  } catch {
+    return []
+  }
+}
 
 const mergeObjectFields = (
   sources: ReadonlyArray<unknown>
 ): Record<string, unknown> | undefined => {
   const merged = sources.reduce<Record<string, unknown>>(
-    (acc, source) => isRecord(source) ? { ...source, ...acc } : acc,
+    (acc, source) => {
+      const record = parseUnknownRecord(source)
+      return record === undefined ? acc : { ...record, ...acc }
+    },
     {}
   )
   return Object.keys(merged).length > 0 ? merged : undefined
@@ -28,7 +52,7 @@ const mergeObjectFields = (
 const rootCompositionBranches = (schema: object): ReadonlyArray<Record<string, unknown>> =>
   [...ROOT_COMPOSITION_KEYS].flatMap((key) => {
     const branches = Reflect.get(schema, key)
-    return Array.isArray(branches) ? branches.filter(isRecord) : []
+    return parseUnknownRecordArray(branches)
   })
 
 const schemaAndCompositionDescendants = (

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -36,7 +36,13 @@ import {
   toListedHulyTool,
   toListedTool
 } from "./protocol-tool-exposure.js"
-import { handleProxyToolCall, INVOKE_TOOL_TOOL_NAME, isProxyToolName, proxyToolDefinitions } from "./proxy-tools.js"
+import {
+  handleProxyToolCall,
+  INVOKE_TOOL_TOOL_NAME,
+  InvokeToolParamsSchema,
+  isProxyToolName,
+  proxyToolDefinitions
+} from "./proxy-tools.js"
 import { listResourceTemplates } from "./resources.js"
 import type { ToolRegistry } from "./tools/index.js"
 import {
@@ -163,8 +169,10 @@ export const fetchLatestNpmVersion = async (fetchImpl: typeof fetch = fetch): Pr
   }
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
+const invokeToolEditMode = (args: unknown): string | undefined => {
+  const decoded = Schema.decodeUnknownEither(InvokeToolParamsSchema)(args)
+  return decoded._tag === "Right" ? deriveEditMode(decoded.right.toolName, decoded.right.arguments) : undefined
+}
 
 export const createMcpProtocolHandlers = (
   resolveClients: () => Promise<ClientBundle>,
@@ -284,9 +292,7 @@ export const createMcpProtocolHandlers = (
       if (isProxyToolName(name)) {
         if (exposure.context.resolvedMode !== "proxy") return returnError(createUnknownToolError(name))
 
-        const editMode = name === INVOKE_TOOL_TOOL_NAME && isRecord(args) && typeof args.toolName === "string"
-          ? deriveEditMode(args.toolName, args.arguments)
-          : undefined
+        const editMode = name === INVOKE_TOOL_TOOL_NAME ? invokeToolEditMode(args) : undefined
 
         let clients: ClientBundle | undefined
         if (name === INVOKE_TOOL_TOOL_NAME) {

--- a/src/mcp/proxy-tool-catalog.ts
+++ b/src/mcp/proxy-tool-catalog.ts
@@ -27,37 +27,103 @@ export const makeToolSearchQuery = (value: string): ToolSearchQuery => ToolSearc
 export const makeSearchToolLimit = (value: number): SearchToolLimit => SearchToolLimit.make(value)
 export const SEARCH_DEFAULT_LIMIT_VALUE = makeSearchToolLimit(SEARCH_DEFAULT_LIMIT)
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
+const UnknownRecordSchema = Schema.Record({ key: Schema.String, value: Schema.Unknown })
+const ToolInputSummarySchema = UnknownRecordSchema.pipe(
+  Schema.extend(
+    Schema.Struct({
+      properties: Schema.optionalWith(UnknownRecordSchema, { exact: true }),
+      required: Schema.optionalWith(Schema.Array(Schema.String), { exact: true })
+    })
+  )
+)
+type ToolInputSummary = Schema.Schema.Type<typeof ToolInputSummarySchema>
 
-const stringArray = (value: unknown): ReadonlyArray<string> =>
-  Array.isArray(value) && value.every((item) => typeof item === "string") ? value : []
+type ToolInputSummaryParseResult =
+  | { readonly _tag: "success"; readonly summary: ToolInputSummary }
+  | { readonly _tag: "invalid"; readonly issue: string }
+type ToolParameterNamesParseResult =
+  | { readonly _tag: "names"; readonly names: ReadonlyArray<ToolParameterName> }
+  | { readonly _tag: "invalid"; readonly issue: string }
 
-const parseToolParameterName = (value: string): ToolParameterName | undefined => {
-  const decoded = Schema.decodeUnknownEither(ToolParameterName)(value)
-  return Either.isRight(decoded) ? decoded.right : undefined
+const INVALID_INPUT_SCHEMA_SUMMARY_ISSUE =
+  "inputSchema summary must expose object properties keyed by non-empty strings and an optional string required array"
+
+const parseToolInputSummary = (value: unknown): ToolInputSummaryParseResult => {
+  const decoded = Schema.decodeUnknownEither(ToolInputSummarySchema)(value)
+  return Either.isRight(decoded)
+    ? { _tag: "success", summary: decoded.right }
+    : { _tag: "invalid", issue: INVALID_INPUT_SCHEMA_SUMMARY_ISSUE }
 }
 
-const schemaProperties = (schema: object): ReadonlyArray<ToolParameterName> => {
-  const properties = isRecord(schema) ? schema.properties : undefined
-  return isRecord(properties)
-    ? Object.keys(properties).map(parseToolParameterName).filter((name) => name !== undefined)
-    : []
+const parseToolParameterNames = (values: ReadonlyArray<string>): ToolParameterNamesParseResult => {
+  const names = values.map((value) => {
+    const decoded = Schema.decodeUnknownEither(ToolParameterName)(value)
+    return decoded._tag === "Right" ? decoded.right : undefined
+  })
+  const parsedNames = names.filter((name): name is ToolParameterName => name !== undefined)
+  if (parsedNames.length !== names.length) return { _tag: "invalid", issue: INVALID_INPUT_SCHEMA_SUMMARY_ISSUE }
+  return { _tag: "names", names: parsedNames }
 }
 
-const schemaRequired = (schema: unknown): ReadonlyArray<string> => isRecord(schema) ? stringArray(schema.required) : []
+const schemaProperties = (summary: ToolInputSummary): ToolParameterNamesParseResult =>
+  parseToolParameterNames(Object.keys(summary.properties ?? {}))
+
+const schemaRequired = (summary: ToolInputSummary): ToolParameterNamesParseResult =>
+  parseToolParameterNames(summary.required ?? [])
+
+type ToolParamSummaryStatus = "available" | "empty" | "invalid_input_schema"
 
 export const toolParamSummary = (
   tool: ToolDefinition
 ): {
   readonly requiredParams: ReadonlyArray<ToolParameterName>
   readonly optionalParams: ReadonlyArray<ToolParameterName>
+  readonly parameterSummaryStatus: ToolParamSummaryStatus
+  readonly parameterSummaryIssue?: string
 } => {
-  const required = new Set(schemaRequired(tool.inputSchema))
-  const properties = schemaProperties(tool.inputSchema)
+  const parsed = parseToolInputSummary(tool.inputSchema)
+  if (parsed._tag === "invalid") {
+    return {
+      requiredParams: [],
+      optionalParams: [],
+      parameterSummaryStatus: "invalid_input_schema",
+      parameterSummaryIssue: parsed.issue
+    }
+  }
+  const summary = parsed.summary
+  const requiredResult = schemaRequired(summary)
+  if (requiredResult._tag === "invalid") {
+    return {
+      requiredParams: [],
+      optionalParams: [],
+      parameterSummaryStatus: "invalid_input_schema",
+      parameterSummaryIssue: requiredResult.issue
+    }
+  }
+  const propertiesResult = schemaProperties(summary)
+  if (propertiesResult._tag === "invalid") {
+    return {
+      requiredParams: [],
+      optionalParams: [],
+      parameterSummaryStatus: "invalid_input_schema",
+      parameterSummaryIssue: propertiesResult.issue
+    }
+  }
+  const required = new Set(requiredResult.names)
+  const properties = propertiesResult.names
+  const requiredWithoutProperty = [...required].filter((name) => !properties.includes(name))
+  if (requiredWithoutProperty.length > 0) {
+    return {
+      requiredParams: [],
+      optionalParams: [],
+      parameterSummaryStatus: "invalid_input_schema",
+      parameterSummaryIssue: "inputSchema required entries must refer to declared properties"
+    }
+  }
   return {
     requiredParams: properties.filter((name) => required.has(name)),
-    optionalParams: properties.filter((name) => !required.has(name))
+    optionalParams: properties.filter((name) => !required.has(name)),
+    parameterSummaryStatus: properties.length === 0 ? "empty" : "available"
   }
 }
 

--- a/src/mcp/proxy-tools.ts
+++ b/src/mcp/proxy-tools.ts
@@ -56,7 +56,7 @@ const SearchToolsParamsSchema = Schema.Struct({
 const ToolNameParamsSchema = Schema.Struct({
   toolName: ToolName
 })
-const InvokeToolParamsSchema = Schema.Struct({
+export const InvokeToolParamsSchema = Schema.Struct({
   toolName: ToolName,
   arguments: Schema.optionalWith(Schema.Unknown, { exact: true })
 })
@@ -69,13 +69,29 @@ const ProxyToolCategorySchema = Schema.Struct({
 const ListToolCategoriesResultSchema = Schema.Struct({
   categories: Schema.Array(ProxyToolCategorySchema)
 })
-const ToolSearchMatchSchema = Schema.Struct({
+const ToolSearchMatchBaseSchema = Schema.Struct({
   name: ToolName,
   category: ToolCategory,
   description: ToolDescription,
   requiredParams: Schema.Array(ToolParameterName),
   optionalParams: Schema.Array(ToolParameterName)
 })
+const ToolSearchMatchSchema = Schema.Union(
+  ToolSearchMatchBaseSchema.pipe(
+    Schema.extend(Schema.Struct({ parameterSummaryStatus: Schema.Literal("available") }))
+  ),
+  ToolSearchMatchBaseSchema.pipe(
+    Schema.extend(Schema.Struct({ parameterSummaryStatus: Schema.Literal("empty") }))
+  ),
+  ToolSearchMatchBaseSchema.pipe(
+    Schema.extend(
+      Schema.Struct({
+        parameterSummaryStatus: Schema.Literal("invalid_input_schema"),
+        parameterSummaryIssue: Schema.String
+      })
+    )
+  )
+)
 const SearchToolsResultSchema = Schema.Struct({
   matches: Schema.Array(ToolSearchMatchSchema)
 })
@@ -210,24 +226,24 @@ export const proxyToolDefinitions: ReadonlyArray<ToolDefinition> = [
 export const isProxyToolName = (name: string): name is ToolName =>
   PROXY_TOOL_NAMES.some((toolName) => toolName === name)
 
+type DecodeOrErrorResult<A> =
+  | { readonly _tag: "success"; readonly params: A }
+  | { readonly _tag: "error"; readonly response: McpToolResponse }
+
 const decodeOrError = <A, I>(
   schema: Schema.Schema<A, I, never>,
   input: unknown,
   toolName: ToolName
-): A | McpToolResponse => {
+): DecodeOrErrorResult<A> => {
   const decoded = Schema.decodeUnknownEither(schema)(input ?? {})
-  if (Either.isRight(decoded)) return decoded.right
-  return mapParseErrorToMcp(decoded.left, toolName)
+  if (Either.isRight(decoded)) return { _tag: "success", params: decoded.right }
+  return { _tag: "error", response: mapParseErrorToMcp(decoded.left, toolName) }
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const isMcpToolResponse = (value: unknown): value is McpToolResponse => isRecord(value) && Array.isArray(value.content)
-
 const searchTools = (registry: ToolRegistry, args: unknown): McpToolResponse => {
-  const params = decodeOrError(SearchToolsParamsSchema, args, SEARCH_TOOLS_TOOL_NAME)
-  if (isMcpToolResponse(params)) return params
+  const decoded = decodeOrError(SearchToolsParamsSchema, args, SEARCH_TOOLS_TOOL_NAME)
+  if (decoded._tag === "error") return decoded.response
+  const params = decoded.params
   const limit = params.limit ?? SEARCH_DEFAULT_LIMIT_VALUE
   const matches = searchToolDefinitions(registry, params.query, limit).map((tool) => {
     const paramSummary = toolParamSummary(tool)
@@ -236,15 +252,20 @@ const searchTools = (registry: ToolRegistry, args: unknown): McpToolResponse => 
       category: tool.category,
       description: tool.description,
       requiredParams: paramSummary.requiredParams,
-      optionalParams: paramSummary.optionalParams
+      optionalParams: paramSummary.optionalParams,
+      parameterSummaryStatus: paramSummary.parameterSummaryStatus,
+      ...(paramSummary.parameterSummaryIssue === undefined
+        ? {}
+        : { parameterSummaryIssue: paramSummary.parameterSummaryIssue })
     }
   })
   return createSuccessResponse({ matches })
 }
 
 const getToolSchema = (registry: ToolRegistry, args: unknown): McpToolResponse => {
-  const params = decodeOrError(ToolNameParamsSchema, args, GET_TOOL_SCHEMA_TOOL_NAME)
-  if (isMcpToolResponse(params)) return params
+  const decoded = decodeOrError(ToolNameParamsSchema, args, GET_TOOL_SCHEMA_TOOL_NAME)
+  if (decoded._tag === "error") return decoded.response
+  const params = decoded.params
 
   const tool = registry.tools.get(params.toolName)
   if (tool === undefined) return createUnknownToolError(params.toolName)
@@ -269,8 +290,9 @@ const invokeTool = async (
   args: unknown,
   clients: InvokeToolClients
 ): Promise<McpToolResponse> => {
-  const params = decodeOrError(InvokeToolParamsSchema, args, INVOKE_TOOL_TOOL_NAME)
-  if (isMcpToolResponse(params)) return params
+  const decoded = decodeOrError(InvokeToolParamsSchema, args, INVOKE_TOOL_TOOL_NAME)
+  if (decoded._tag === "error") return decoded.response
+  const params = decoded.params
 
   if (!registry.tools.has(params.toolName)) return createUnknownToolError(params.toolName)
 
@@ -305,8 +327,8 @@ interface ProxyToolCallInput {
 export const handleProxyToolCall = async (input: ProxyToolCallInput): Promise<McpToolResponse> => {
   switch (input.toolName) {
     case LIST_TOOL_CATEGORIES_TOOL_NAME: {
-      const params = decodeOrError(EmptyProxyParamsSchema, input.args, LIST_TOOL_CATEGORIES_TOOL_NAME)
-      if (isMcpToolResponse(params)) return params
+      const decoded = decodeOrError(EmptyProxyParamsSchema, input.args, LIST_TOOL_CATEGORIES_TOOL_NAME)
+      if (decoded._tag === "error") return decoded.response
       return listCategories(input.proxyCandidateRegistry)
     }
     case SEARCH_TOOLS_TOOL_NAME:

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -73,20 +73,30 @@ const parseToolExposureConfigEffect = (
   return Effect.fail(new McpServerError({ message: parsed.message }))
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
+const CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo"
+const Mcp2026ClientInfoRequestSchema = Schema.Struct({
+  params: Schema.Struct({
+    _meta: Schema.Struct({
+      [CLIENT_INFO_META_KEY]: Schema.Unknown
+    })
+  })
+})
+const LegacyClientInfoRequestSchema = Schema.Struct({
+  params: Schema.Struct({
+    clientInfo: Schema.optionalWith(Schema.Unknown, { exact: true })
+  })
+})
 
 const clientInfoFromMcp2026Request = (req: Request): McpClientInfoLike | undefined => {
-  const body = req.body
-  if (!isRecord(body) || !isRecord(body.params) || !isRecord(body.params._meta)) return undefined
-  const clientInfo = body.params._meta["io.modelcontextprotocol/clientInfo"]
-  return parseMcpClientInfo(clientInfo)
+  const decoded = Schema.decodeUnknownEither(Mcp2026ClientInfoRequestSchema)(req.body)
+  if (decoded._tag === "Left") return undefined
+  return parseMcpClientInfo(decoded.right.params._meta[CLIENT_INFO_META_KEY])
 }
 
 const clientInfoFromLegacyHttpRequest = (req: Request): McpClientInfoLike | undefined => {
-  const body = req.body
-  if (!isRecord(body) || !isRecord(body.params)) return undefined
-  return parseMcpClientInfo(body.params.clientInfo) ?? clientInfoFromMcp2026Request(req)
+  const decoded = Schema.decodeUnknownEither(LegacyClientInfoRequestSchema)(req.body)
+  if (decoded._tag === "Left") return clientInfoFromMcp2026Request(req)
+  return parseMcpClientInfo(decoded.right.params.clientInfo) ?? clientInfoFromMcp2026Request(req)
 }
 
 interface McpServerOperations {

--- a/test/domain/schemas.approval-requests.test.ts
+++ b/test/domain/schemas.approval-requests.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, Exit, Predicate, Schema } from "effect"
+import { Effect, Exit, Schema } from "effect"
 import { expect } from "vitest"
 
 import {
@@ -18,6 +18,7 @@ import {
   parseRejectApprovalRequestParams,
   rejectApprovalRequestParamsJsonSchema
 } from "../../src/domain/schemas/approval-requests.js"
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 
 describe("approval request schemas", () => {
   it.effect("parses list/get approval request params", () =>
@@ -83,9 +84,9 @@ describe("approval request schemas", () => {
     }))
 
   it("emits client-safe JSON Schema for approval request tool inputs", () => {
-    expect(Predicate.isRecord(listApprovalRequestsParamsJsonSchema)).toBe(true)
-    expect(Predicate.isRecord(getApprovalRequestParamsJsonSchema)).toBe(true)
-    expect(Predicate.isRecord(addApprovalRequestParamsJsonSchema)).toBe(true)
+    expect(parseJsonSchemaRecord(listApprovalRequestsParamsJsonSchema)).toBeDefined()
+    expect(parseJsonSchemaRecord(getApprovalRequestParamsJsonSchema)).toBeDefined()
+    expect(parseJsonSchemaRecord(addApprovalRequestParamsJsonSchema)).toBeDefined()
     expect(listApprovalRequestsParamsJsonSchema).toMatchObject({
       type: "object",
       properties: {

--- a/test/domain/schemas.chat-message-attachments.test.ts
+++ b/test/domain/schemas.chat-message-attachments.test.ts
@@ -7,8 +7,7 @@ import {
   listChatMessageAttachmentsParamsJsonSchema,
   parseAddChatMessageAttachmentParams,
   parseListChatMessageAttachmentsParams,
-  parseUpdateChatMessageAttachmentParams,
-  withChatMessageAttachmentTargetVariantDescriptions
+  parseUpdateChatMessageAttachmentParams
 } from "../../src/domain/schemas/chat-message-attachments.js"
 
 type JsonSchemaRecord = {
@@ -124,19 +123,5 @@ describe("chat message attachment schemas", () => {
     expect(propertySchema(replyTarget, "replyId").description).toContain("thread reply ID")
     expect(asRecord(addChatMessageAttachmentParamsJsonSchema).title).toBe("AddChatMessageAttachmentParams")
     expect(asRecord(addChatMessageAttachmentParamsJsonSchema).description).toContain("Provide exactly one")
-  })
-
-  it("leaves unsupported target JSON schema shapes unchanged", () => {
-    const arraySchema: object = []
-    const noProperties = {}
-    const noTarget = { properties: {} }
-    const noAnyOf = { properties: { target: {} } }
-    const nonObjectVariant = { properties: { target: { anyOf: ["not-an-object"] } } }
-
-    expect(withChatMessageAttachmentTargetVariantDescriptions(arraySchema)).toBe(arraySchema)
-    expect(withChatMessageAttachmentTargetVariantDescriptions(noProperties)).toBe(noProperties)
-    expect(withChatMessageAttachmentTargetVariantDescriptions(noTarget)).toBe(noTarget)
-    expect(withChatMessageAttachmentTargetVariantDescriptions(noAnyOf)).toBe(noAnyOf)
-    expect(withChatMessageAttachmentTargetVariantDescriptions(nonObjectVariant)).toEqual(nonObjectVariant)
   })
 })

--- a/test/domain/schemas.issue-102-closeout.test.ts
+++ b/test/domain/schemas.issue-102-closeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, Exit, Predicate } from "effect"
+import { Effect, Exit } from "effect"
 import { expect } from "vitest"
 
 import {
@@ -8,6 +8,7 @@ import {
   parseUpsertProjectTargetPreferenceParams,
   upsertProjectTargetPreferenceParamsJsonSchema
 } from "../../src/domain/schemas.js"
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 
 describe("issue #102 schemas", () => {
   it.effect("accepts document snapshot lookup by teamspace, document, and snapshot identifier", () =>
@@ -36,19 +37,21 @@ describe("issue #102 schemas", () => {
     }))
 
   it("emits client-safe JSON Schema for ProjectTargetPreference prop values", () => {
-    if (!Predicate.isRecord(upsertProjectTargetPreferenceParamsJsonSchema)) {
+    const rootSchema = parseJsonSchemaRecord(upsertProjectTargetPreferenceParamsJsonSchema)
+    if (rootSchema === undefined) {
       throw new Error("Expected root schema object")
     }
-    const rootProperties = upsertProjectTargetPreferenceParamsJsonSchema.properties
-    if (!Predicate.isRecord(rootProperties)) {
+    const rootProperties = parseJsonSchemaRecord(rootSchema.properties)
+    if (rootProperties === undefined) {
       throw new Error("Expected root schema properties")
     }
-    const props = rootProperties.props
-    if (!Predicate.isRecord(props) || !Predicate.isRecord(props.items)) {
+    const props = parseJsonSchemaRecord(rootProperties.props)
+    const propsItems = parseJsonSchemaRecord(props?.items)
+    if (props === undefined || propsItems === undefined) {
       throw new Error("Expected props array schema")
     }
-    const itemProperties = props.items.properties
-    if (!Predicate.isRecord(itemProperties)) {
+    const itemProperties = parseJsonSchemaRecord(propsItems.properties)
+    if (itemProperties === undefined) {
       throw new Error("Expected props item properties")
     }
 

--- a/test/domain/schemas.message-templates.test.ts
+++ b/test/domain/schemas.message-templates.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, Either, Predicate } from "effect"
+import { Effect, Either } from "effect"
 import { expect } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import {
   getMessageTemplateParamsJsonSchema,
   listMessageTemplateFieldsParamsJsonSchema,
@@ -15,9 +16,9 @@ import {
 } from "../../src/domain/schemas/message-templates.js"
 
 const schemaPropertyDescription = (schema: unknown, name: string): string | undefined => {
-  const properties = Predicate.isRecord(schema) ? schema.properties : undefined
-  const property = Predicate.isRecord(properties) ? properties[name] : undefined
-  if (!Predicate.isRecord(property)) {
+  const properties = parseJsonSchemaRecord(parseJsonSchemaRecord(schema)?.properties)
+  const property = parseJsonSchemaRecord(properties?.[name])
+  if (property === undefined) {
     throw new Error(`Missing JSON Schema property: ${name}`)
   }
   return typeof property.description === "string" ? property.description : undefined

--- a/test/domain/schemas.preferences.test.ts
+++ b/test/domain/schemas.preferences.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, Exit, Predicate, Schema } from "effect"
+import { Effect, Exit, Schema } from "effect"
 import { expect } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import {
   getSpacePreferenceParamsJsonSchema,
   GetSpacePreferenceResultSchema,
@@ -48,8 +49,8 @@ describe("preference schemas", () => {
     }))
 
   it("emits client-safe JSON Schema for SpacePreference tool inputs", () => {
-    expect(Predicate.isRecord(listSpacePreferencesParamsJsonSchema)).toBe(true)
-    expect(Predicate.isRecord(getSpacePreferenceParamsJsonSchema)).toBe(true)
+    expect(parseJsonSchemaRecord(listSpacePreferencesParamsJsonSchema)).toBeDefined()
+    expect(parseJsonSchemaRecord(getSpacePreferenceParamsJsonSchema)).toBeDefined()
     expect(listSpacePreferencesParamsJsonSchema).toMatchObject({
       type: "object",
       properties: {

--- a/test/domain/schemas/domain-contracts.property.test.ts
+++ b/test/domain/schemas/domain-contracts.property.test.ts
@@ -58,6 +58,7 @@ import {
   updateIssueParamsJsonSchema,
   UpdateIssueParamsSchema
 } from "../../../src/domain/schemas/issues.js"
+import { parseJsonSchemaRecord } from "../../../src/domain/schemas/json-schema.js"
 import {
   UPDATE_LABEL_FIELDS,
   updateLabelParamsJsonSchema,
@@ -136,9 +137,6 @@ interface UpdateSchemaCase {
   readonly values: Readonly<Record<string, unknown>>
   readonly mutuallyExclusiveFieldSets?: ReadonlyArray<ReadonlyArray<string>>
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
 
 const decodeSucceeds = (schema: Schema.Schema.AnyNoContext, input: unknown): boolean =>
   Schema.decodeUnknownEither(schema)(input)._tag === "Right"
@@ -606,10 +604,8 @@ describe("access-link and document state-machine properties", () => {
       { if: { required: ["replace_all"] }, then: { required: ["old_text", "new_text"] } }
     ]))
 
-    const properties: Record<string, unknown> = isRecord(editDocumentParamsJsonSchema.properties)
-      ? editDocumentParamsJsonSchema.properties
-      : {}
-    const oldText = isRecord(properties.old_text) ? properties.old_text : {}
+    const properties = parseJsonSchemaRecord(editDocumentParamsJsonSchema.properties) ?? {}
+    const oldText = parseJsonSchemaRecord(properties.old_text) ?? {}
     expect(oldText.pattern).toBe("\\S")
     expect(EDIT_DOCUMENT_UPDATE_FIELD_GROUPS).toEqual(["title", "content", "old_text/new_text"])
   })
@@ -620,7 +616,7 @@ describe("update schema runtime and JSON Schema agreement", () => {
     for (const testCase of updateSchemaCases) {
       expectDecodeFailure(testCase.schema, testCase.base)
       expect(jsonSchemaRequiredFields(testCase.jsonSchema)).toEqual(testCase.fields)
-      const properties = isRecord(testCase.jsonSchema.properties) ? testCase.jsonSchema.properties : {}
+      const properties = parseJsonSchemaRecord(testCase.jsonSchema.properties) ?? {}
 
       for (const field of testCase.fields) {
         expect(properties).toHaveProperty(field)

--- a/test/mcp/http-transport.test.ts
+++ b/test/mcp/http-transport.test.ts
@@ -1436,14 +1436,15 @@ describe("2026 dispatcher validation errors", () => {
 
   const post = async (body: unknown, headers: Request["headers"]): Promise<{
     status: number | undefined
+    id: unknown
     error: { code: number; message: string } | undefined
   }> => {
     const handlers = createMcpHandlers(createMockMcpServer, undefined, undefined, modernHandlerFactory)
     const res = createMockResponse()
     await handlers.post(createMockRequest(body, headers), res)
     const calls = getResponseCalls(res)
-    const json = calls.json[0]?.[0] as { error?: { code: number; message: string } } | undefined
-    return { status: calls.status[0]?.[0], error: json?.error }
+    const json = calls.json[0]?.[0] as { id?: unknown; error?: { code: number; message: string } } | undefined
+    return { status: calls.status[0]?.[0], id: json?.id, error: json?.error }
   }
 
   const cases: ReadonlyArray<{
@@ -1471,8 +1472,20 @@ describe("2026 dispatcher validation errors", () => {
       message: "jsonrpc"
     },
     {
+      name: "rejects a missing jsonrpc version",
+      body: { method: "tools/list", id: 1, params: { _meta: meta } },
+      headers: modernHeaders("tools/list"),
+      message: "jsonrpc"
+    },
+    {
       name: "rejects an empty method",
       body: { ...validBody("tools/list"), method: "" },
+      headers: modernHeaders("tools/list"),
+      message: "non-empty method"
+    },
+    {
+      name: "rejects a missing method",
+      body: { jsonrpc: "2.0", id: 1, params: { _meta: meta } },
       headers: modernHeaders("tools/list"),
       message: "non-empty method"
     },
@@ -1534,6 +1547,23 @@ describe("2026 dispatcher validation errors", () => {
       message: "clientInfo metadata is required"
     },
     {
+      name: "rejects a non-object clientInfo in _meta",
+      body: {
+        jsonrpc: "2.0",
+        method: "tools/list",
+        id: 1,
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": "test",
+            "io.modelcontextprotocol/clientCapabilities": {}
+          }
+        }
+      },
+      headers: modernHeaders("tools/list"),
+      message: "clientInfo metadata is required"
+    },
+    {
       name: "rejects a missing clientCapabilities in _meta",
       body: {
         jsonrpc: "2.0",
@@ -1543,6 +1573,23 @@ describe("2026 dispatcher validation errors", () => {
           _meta: {
             "io.modelcontextprotocol/protocolVersion": "2026-07-28",
             "io.modelcontextprotocol/clientInfo": { name: "t", version: "1" }
+          }
+        }
+      },
+      headers: modernHeaders("tools/list"),
+      message: "clientCapabilities metadata is required"
+    },
+    {
+      name: "rejects a non-object clientCapabilities in _meta",
+      body: {
+        jsonrpc: "2.0",
+        method: "tools/list",
+        id: 1,
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": { name: "t", version: "1" },
+            "io.modelcontextprotocol/clientCapabilities": null
           }
         }
       },
@@ -1558,6 +1605,24 @@ describe("2026 dispatcher validation errors", () => {
     })
   }
 
+  it("preserves a valid request id when rejecting a malformed JSON-RPC envelope", async () => {
+    const result = await post(
+      { ...validBody("tools/list"), jsonrpc: "1.0", id: 123 },
+      modernHeaders("tools/list")
+    )
+    expect(result.id).toBe(123)
+    expect(result.error?.message).toContain("jsonrpc")
+  })
+
+  it("returns null id when rejecting a malformed JSON-RPC envelope with an invalid id", async () => {
+    const result = await post(
+      { ...validBody("tools/list"), jsonrpc: "1.0", id: { nested: true } },
+      modernHeaders("tools/list")
+    )
+    expect(result.id).toBeNull()
+    expect(result.error?.message).toContain("jsonrpc")
+  })
+
   it("returns Method not found (404) for an unknown 2026 method", async () => {
     const result = await post(validBody("does/not/exist"), modernHeaders("does/not/exist"))
     expect(result.status).toBe(404)
@@ -1572,9 +1637,33 @@ describe("2026 dispatcher validation errors", () => {
     expect(result.error?.message).toContain("tools/call requires params.name")
   })
 
+  it("rejects tools/call whose body has an empty params.name", async () => {
+    const result = await post(
+      { jsonrpc: "2.0", method: "tools/call", id: 1, params: { name: "", _meta: meta } },
+      modernHeaders("tools/call", "some_tool")
+    )
+    expect(result.error?.message).toContain("tools/call requires params.name")
+  })
+
+  it("rejects tools/call whose Mcp-Name header does not match params.name", async () => {
+    const result = await post(
+      { jsonrpc: "2.0", method: "tools/call", id: 1, params: { name: "actual_tool", _meta: meta } },
+      modernHeaders("tools/call", "other_tool")
+    )
+    expect(result.error?.message).toContain("does not match body value 'actual_tool'")
+  })
+
   it("rejects resources/read whose body omits params.uri", async () => {
     const result = await post(
       { jsonrpc: "2.0", method: "resources/read", id: 1, params: { _meta: meta } },
+      modernHeaders("resources/read", "huly://projects/HULY")
+    )
+    expect(result.error?.message).toContain("resources/read requires params.uri")
+  })
+
+  it("rejects resources/read whose body has an empty params.uri", async () => {
+    const result = await post(
+      { jsonrpc: "2.0", method: "resources/read", id: 1, params: { uri: "", _meta: meta } },
       modernHeaders("resources/read", "huly://projects/HULY")
     )
     expect(result.error?.message).toContain("resources/read requires params.uri")
@@ -1670,6 +1759,33 @@ describe("2026 dispatcher null-id and routing branches", () => {
   it("returns a null id on a successful id-less dispatch", async () => {
     const { json } = await postRaw(noId("tools/list"), modernHeaders("tools/list"))
     expect(json?.id).toBeNull()
+    expect(json?.error).toBeUndefined()
+  })
+
+  it("returns a null id on a successful id-less tools/call dispatch", async () => {
+    const { json } = await postRaw(
+      noId("tools/call", { name: "get_huly_context", _meta: modernMeta }),
+      modernHeaders("tools/call", "get_huly_context")
+    )
+    expect(json?.id).toBeNull()
+    expect(json?.error).toBeUndefined()
+  })
+
+  it("returns a null id on a successful id-less resources/read dispatch", async () => {
+    const { json } = await postRaw(
+      noId("resources/read", { uri: "huly://projects/HULY", _meta: modernMeta }),
+      modernHeaders("resources/read", "huly://projects/HULY")
+    )
+    expect(json?.id).toBeNull()
+    expect(json?.error).toBeUndefined()
+  })
+
+  it("accepts modern Accept header entries with media type parameters", async () => {
+    const headers = {
+      ...modernHeaders("tools/list"),
+      accept: "application/json; charset=utf-8, text/event-stream; boundary=events"
+    }
+    const { json } = await postRaw(noId("tools/list"), headers)
     expect(json?.error).toBeUndefined()
   })
 

--- a/test/mcp/input-schema-compat.property.test.ts
+++ b/test/mcp/input-schema-compat.property.test.ts
@@ -2,6 +2,7 @@ import { describe } from "@effect/vitest"
 import * as fc from "fast-check"
 import { expect, it } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import type { McpInputSchema } from "../../src/mcp/input-schema-compat.js"
 import { toClientCompatibleInputSchema } from "../../src/mcp/input-schema-compat.js"
 import { collectJsonSchemaDefinitions } from "../../src/mcp/json-schema-refs.js"
@@ -73,13 +74,13 @@ const generatedSchemaArbitrary: fc.Arbitrary<McpInputSchema> = fc.record({
   allOf: branches.slice(3).map((branch, index) => nodeToSchema(branch, index))
 }))
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
 const compositionBranches = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> =>
   ROOT_COMPOSITION_KEYS.flatMap((key) => {
     const value = schema[key]
-    return Array.isArray(value) ? value.filter(isRecord) : []
+    return (Array.isArray(value) ? value : []).flatMap((item) => {
+      const record = parseJsonSchemaRecord(item)
+      return record === undefined ? [] : [record]
+    })
   })
 
 const descendants = (schema: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> => [
@@ -91,7 +92,10 @@ const expectedMergedField = (schema: McpInputSchema, field: "properties" | "$def
   descendants(schema)
     .map((descendant) => descendant[field])
     .reduce<Record<string, unknown>>(
-      (merged, value) => isRecord(value) ? { ...value, ...merged } : merged,
+      (merged, value) => {
+        const record = parseJsonSchemaRecord(value)
+        return record === undefined ? merged : { ...record, ...merged }
+      },
       {}
     )
 
@@ -112,8 +116,8 @@ describe("toClientCompatibleInputSchema properties", () => {
         expect(sanitized.required).toEqual(schema.required)
         expect(sanitizedAgain).toEqual(sanitized)
 
-        const properties = isRecord(sanitized.properties) ? sanitized.properties : {}
-        const defs = isRecord(sanitized.$defs) ? sanitized.$defs : {}
+        const properties = parseJsonSchemaRecord(sanitized.properties) ?? {}
+        const defs = parseJsonSchemaRecord(sanitized.$defs) ?? {}
 
         expect(properties).toEqual(expectedMergedField(schema, "properties"))
         expect(defs).toEqual(collectJsonSchemaDefinitions(schema) ?? {})

--- a/test/mcp/input-schema-compat.test.ts
+++ b/test/mcp/input-schema-compat.test.ts
@@ -1,17 +1,16 @@
 import { describe } from "@effect/vitest"
 import { expect, it } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import type { McpInputSchema } from "../../src/mcp/input-schema-compat.js"
 import { toClientCompatibleInputSchema } from "../../src/mcp/input-schema-compat.js"
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
 const expectRecord = (value: unknown): Record<string, unknown> => {
-  if (!isRecord(value)) {
+  const record = parseJsonSchemaRecord(value)
+  if (record === undefined) {
     throw new Error("Expected record")
   }
-  return value
+  return record
 }
 
 describe("toClientCompatibleInputSchema", () => {
@@ -105,5 +104,26 @@ describe("toClientCompatibleInputSchema", () => {
     expect(sanitized.description).toBe("Provide personId or email.")
     expect(properties.personId).toBeDefined()
     expect(properties.email).toBeDefined()
+  })
+
+  it("ignores non-object composition branches", () => {
+    const schema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            project: { type: "string" }
+          }
+        },
+        "not-a-schema",
+        null
+      ]
+    }
+
+    const sanitized = toClientCompatibleInputSchema(schema)
+    const properties = expectRecord(sanitized.properties)
+
+    expect(properties.project).toBeDefined()
+    expect(sanitized.anyOf).toBeUndefined()
   })
 })

--- a/test/mcp/json-schema-refs.test.ts
+++ b/test/mcp/json-schema-refs.test.ts
@@ -1,18 +1,17 @@
 import { describe } from "@effect/vitest"
 import { expect, it } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import {
   stripCollidingSchemaIds,
   stripCollidingSchemaIdsProperties,
   stripCollidingSchemaIdsRecord
 } from "../../src/mcp/json-schema-refs.js"
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
 const expectRecord = (value: unknown): Record<string, unknown> => {
-  if (!isRecord(value)) throw new Error("Expected record")
-  return value
+  const record = parseJsonSchemaRecord(value)
+  if (record === undefined) throw new Error("Expected record")
+  return record
 }
 
 describe("stripCollidingSchemaIds", () => {

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -512,6 +512,61 @@ const arraySchemaProbeTool = defineTool(
   () => Effect.succeed({ ok: true })
 )
 
+const malformedSummaryProbeTool = defineTool(
+  {
+    name: "malformed_summary_probe",
+    description: "malformed summary probe tool",
+    inputSchema: {
+      type: "object",
+      properties: {
+        "": { type: "string" },
+        kept: { type: "string" }
+      },
+      required: ["kept"]
+    },
+    resultSchema: Schema.Struct({ ok: Schema.Boolean }),
+    category: "test"
+  },
+  Schema.decodeUnknown(Schema.Unknown),
+  () => Effect.succeed({ ok: true })
+)
+
+const malformedRequiredProbeTool = defineTool(
+  {
+    name: "malformed_required_probe",
+    description: "malformed required probe tool",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kept: { type: "string" }
+      },
+      required: [""]
+    },
+    resultSchema: Schema.Struct({ ok: Schema.Boolean }),
+    category: "test"
+  },
+  Schema.decodeUnknown(Schema.Unknown),
+  () => Effect.succeed({ ok: true })
+)
+
+const undeclaredRequiredProbeTool = defineTool(
+  {
+    name: "undeclared_required_probe",
+    description: "undeclared required probe tool",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kept: { type: "string" }
+      },
+      required: ["missing"]
+    },
+    resultSchema: Schema.Struct({ ok: Schema.Boolean }),
+    category: "test"
+  },
+  Schema.decodeUnknown(Schema.Unknown),
+  () => Effect.succeed({ ok: true })
+)
+
 const diagnosticProbeRegistry: ToolRegistry = {
   tools: new Map([[diagnosticProbeTool.name, diagnosticProbeTool]]),
   definitions: [diagnosticProbeTool],
@@ -541,6 +596,16 @@ const nullDispatchProxyRegistry: ToolRegistry = {
 const arraySchemaProbeRegistry: ToolRegistry = {
   tools: new Map([[arraySchemaProbeTool.name, arraySchemaProbeTool]]),
   definitions: [arraySchemaProbeTool],
+  handleToolCall: async () => null
+}
+
+const malformedSummaryProbeRegistry: ToolRegistry = {
+  tools: new Map([
+    [malformedSummaryProbeTool.name, malformedSummaryProbeTool],
+    [malformedRequiredProbeTool.name, malformedRequiredProbeTool],
+    [undeclaredRequiredProbeTool.name, undeclaredRequiredProbeTool]
+  ]),
+  definitions: [malformedSummaryProbeTool, malformedRequiredProbeTool, undeclaredRequiredProbeTool],
   handleToolCall: async () => null
 }
 
@@ -1104,6 +1169,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(editMatch.optionalParams).toEqual(
       expect.arrayContaining(["title", "content", "old_text", "new_text"])
     )
+    expect(editMatch.parameterSummaryStatus).toBe("available")
 
     if (!isJsonObject(schemaResult) || !isJsonObject(schemaResult.inputSchema)) {
       throw new Error("expected schema lookup result")
@@ -1116,7 +1182,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(schemaResult.inputSchema).toHaveProperty("allOf")
   })
 
-  it("ranks exact tool-name matches first and handles non-record input schemas in summaries", async () => {
+  it("ranks exact tool-name matches first and flags non-record input schema summaries", async () => {
     const handlers = createMcpProtocolHandlers(
       unusedResolveClients,
       createTelemetryProbe().telemetry,
@@ -1138,7 +1204,83 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
         category: "test",
         description: "array schema probe tool",
         requiredParams: [],
-        optionalParams: []
+        optionalParams: [],
+        parameterSummaryStatus: "invalid_input_schema",
+        parameterSummaryIssue:
+          "inputSchema summary must expose object properties keyed by non-empty strings and an optional string required array"
+      }]
+    })
+  })
+
+  it("surfaces invalid proxy search summary schemas instead of dropping parameter names", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(malformedSummaryProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const response = await handlers.callTool({
+      params: { name: "search_tools", arguments: { query: "malformed_summary_probe", limit: 1 } }
+    })
+
+    expect(response.isError).not.toBe(true)
+    expect(response.structuredContent?.result).toEqual({
+      matches: [{
+        name: "malformed_summary_probe",
+        category: "test",
+        description: "malformed summary probe tool",
+        requiredParams: [],
+        optionalParams: [],
+        parameterSummaryStatus: "invalid_input_schema",
+        parameterSummaryIssue:
+          "inputSchema summary must expose object properties keyed by non-empty strings and an optional string required array"
+      }]
+    })
+  })
+
+  it("surfaces invalid proxy search required summaries", async () => {
+    const handlers = createMcpProtocolHandlers(
+      unusedResolveClients,
+      createTelemetryProbe().telemetry,
+      protocolRegistries(malformedSummaryProbeRegistry),
+      makeValidContext,
+      liveNowClock,
+      () => Promise.resolve("0.0.0"),
+      proxyExposureOptions()
+    )
+
+    const malformedRequired = await handlers.callTool({
+      params: { name: "search_tools", arguments: { query: "malformed_required_probe", limit: 1 } }
+    })
+    const undeclaredRequired = await handlers.callTool({
+      params: { name: "search_tools", arguments: { query: "undeclared_required_probe", limit: 1 } }
+    })
+
+    expect(malformedRequired.structuredContent?.result).toEqual({
+      matches: [{
+        name: "malformed_required_probe",
+        category: "test",
+        description: "malformed required probe tool",
+        requiredParams: [],
+        optionalParams: [],
+        parameterSummaryStatus: "invalid_input_schema",
+        parameterSummaryIssue:
+          "inputSchema summary must expose object properties keyed by non-empty strings and an optional string required array"
+      }]
+    })
+    expect(undeclaredRequired.structuredContent?.result).toEqual({
+      matches: [{
+        name: "undeclared_required_probe",
+        category: "test",
+        description: "undeclared required probe tool",
+        requiredParams: [],
+        optionalParams: [],
+        parameterSummaryStatus: "invalid_input_schema",
+        parameterSummaryIssue: "inputSchema required entries must refer to declared properties"
       }]
     })
   })
@@ -1158,9 +1300,10 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
   })
 
   it("validates proxy meta-tool arguments before returning catalog data", async () => {
+    const probe = createTelemetryProbe()
     const handlers = createMcpProtocolHandlers(
       buildStubClients(),
-      createTelemetryProbe().telemetry,
+      probe.telemetry,
       protocolRegistries(toolRegistry),
       makeValidContext,
       liveNowClock,
@@ -1175,6 +1318,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(search.isError).toBe(true)
     expect(schema.isError).toBe(true)
     expect(invoked.isError).toBe(true)
+    expect(assertAt(probe.toolCalled, 2).editMode).toBeUndefined()
   })
 
   it("invokes a proxy candidate and wraps the target result with warnings", async () => {

--- a/test/mcp/proxy-tools.property.test.ts
+++ b/test/mcp/proxy-tools.property.test.ts
@@ -47,6 +47,10 @@ const registryFromDefinitions = (definitions: ReadonlyArray<RegisteredTool>): To
 })
 
 describe("proxy tool search properties", () => {
+  it("returns no matches for non-empty queries with no searchable tokens", () => {
+    expect(searchToolDefinitions(toolRegistry, makeToolSearchQuery("-"), makeSearchToolLimit(50))).toEqual([])
+  })
+
   it("returns only tools from the searched candidate registry", () => {
     fc.assert(
       fc.property(queryArbitrary, searchLimitArbitrary, (query, limit) => {

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -23,9 +23,10 @@ import {
   McpError,
   ReadResourceRequestSchema
 } from "@modelcontextprotocol/sdk/types.js"
-import { Context, Effect, Fiber, Layer } from "effect"
+import { Context, Effect, Fiber, Layer, Schema } from "effect"
 import { expect } from "vitest"
 import { sanitizeHulyRuntimeConfigFromEnv, sanitizeHulyRuntimeConfigFromHeaders } from "../../src/config/config.js"
+import { parseJsonSchemaRecord } from "../../src/domain/schemas/json-schema.js"
 import { HulyClient, type HulyClientOperations } from "../../src/huly/client.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
 import { WorkspaceClient } from "../../src/huly/workspace-client.js"
@@ -229,35 +230,55 @@ const requiredModeSets = (tool: ToolDefinition): ReadonlyArray<string> => {
     : []
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
 const assertSchemaObject = (value: unknown): Record<string, unknown> => {
-  if (!isRecord(value)) {
+  const record = parseJsonSchemaRecord(value)
+  if (record === undefined) {
     throw new Error("Expected schema object")
   }
-  return value
+  return record
 }
 
-interface ListedToolForTest {
-  readonly name: string
-  readonly inputSchema: unknown
+const JsonRpcSuccessResponseForTestSchema = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: Schema.NullOr(Schema.Union(Schema.String, Schema.Number)),
+  result: Schema.Unknown,
+  error: Schema.optionalWith(Schema.Never, { exact: true })
+})
+const JsonRpcRequestIdForTestSchema = Schema.Struct({
+  id: Schema.optionalWith(Schema.Unknown, { exact: true })
+})
+
+const assertJsonRpcSuccessResult = (value: unknown): unknown => {
+  const decoded = Schema.decodeUnknownEither(JsonRpcSuccessResponseForTestSchema)(value)
+  if (decoded._tag === "Left") {
+    throw new Error("Expected JSON-RPC success response")
+  }
+  return decoded.right.result
 }
 
-const isListedToolForTest = (value: unknown): value is ListedToolForTest =>
-  isRecord(value) && typeof value.name === "string" && "inputSchema" in value
+const jsonRpcIdFromBody = (value: unknown): string | number | null => {
+  const decoded = Schema.decodeUnknownEither(JsonRpcRequestIdForTestSchema)(value)
+  if (decoded._tag === "Left") return null
+  const id = decoded.right.id
+  return typeof id === "string" || typeof id === "number" ? id : null
+}
+
+const ListedToolForTestSchema = Schema.Struct({
+  name: Schema.String,
+  inputSchema: Schema.Unknown
+})
+type ListedToolForTest = Schema.Schema.Type<typeof ListedToolForTestSchema>
+
+const ListToolsResponseForTestSchema = Schema.Struct({
+  tools: Schema.Array(ListedToolForTestSchema)
+})
 
 const assertListToolsResponse = (value: unknown): { readonly tools: ReadonlyArray<ListedToolForTest> } => {
-  if (!isRecord(value)) {
-    throw new Error("Expected ListTools response object")
-  }
-
-  const tools = value.tools
-  if (!Array.isArray(tools) || !tools.every(isListedToolForTest)) {
+  try {
+    return Schema.decodeUnknownSync(ListToolsResponseForTestSchema)(value)
+  } catch {
     throw new Error("Expected ListTools response with tool definitions")
   }
-
-  return { tools }
 }
 
 // --- Test Helpers ---
@@ -1617,13 +1638,7 @@ describe("McpServerService.layer operations", () => {
             },
             on: () => undefined
           })
-          const resultAt = (index: number): unknown => {
-            const body = assertAt(responses, index).body
-            if (!isRecord(body) || !("result" in body)) {
-              throw new Error("Expected JSON-RPC success response")
-            }
-            return body.result
-          }
+          const resultAt = (index: number): unknown => assertJsonRpcSuccessResult(assertAt(responses, index).body)
 
           yield* Effect.promise(() =>
             handler(makeRequest("codex", { name: "codex-cli", version: "1.0.0" }), makeResponse())
@@ -1702,9 +1717,7 @@ describe("McpServerService.layer operations", () => {
                   const handler = capturedHandlers.get(ListToolsRequestSchema)
                   if (handler === undefined) throw new Error("expected list tools handler")
                   const result = await handler()
-                  const id = isRecord(body) && (typeof body.id === "string" || typeof body.id === "number")
-                    ? body.id
-                    : null
+                  const id = jsonRpcIdFromBody(body)
                   res.status(200).json({ jsonrpc: "2.0", id, result })
                 }
               }) as never,
@@ -1762,13 +1775,7 @@ describe("McpServerService.layer operations", () => {
             headers: { accept: "application/json, text/event-stream" },
             on: () => undefined
           })
-          const resultAt = (index: number): unknown => {
-            const body = assertAt(responses, index).body
-            if (!isRecord(body) || !("result" in body)) {
-              throw new Error("Expected JSON-RPC success response")
-            }
-            return body.result
-          }
+          const resultAt = (index: number): unknown => assertJsonRpcSuccessResult(assertAt(responses, index).body)
 
           const fiber = yield* Effect.fork(
             ops.run().pipe(

--- a/test/mcp/tools/inventory.test.ts
+++ b/test/mcp/tools/inventory.test.ts
@@ -5,6 +5,7 @@ import type { Category as HulyInventoryCategory, Product as HulyInventoryProduct
 import { Effect } from "effect"
 import { expect } from "vitest"
 
+import { parseJsonSchemaRecord } from "../../../src/domain/schemas/json-schema.js"
 import type { HulyClientOperations } from "../../../src/huly/client.js"
 import { inventory } from "../../../src/huly/huly-plugins.js"
 import { testMarkupUrlConfig } from "../../../src/huly/operations/markup.js"
@@ -94,17 +95,12 @@ const storageClient: HulyStorageOperations = {
   getFileUrl: (blobId: string) => `https://test.huly.io/files?file=${blobId}`
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
 const toolInputPropertyDescription = (toolName: string, propertyName: string): string | undefined => {
   const tool = toolRegistry.definitions.find((definition) => definition.name === toolName)
-  const inputSchema = tool?.inputSchema
-  if (!isRecord(inputSchema)) return undefined
-  const properties = inputSchema.properties
-  if (!isRecord(properties)) return undefined
-  const property = properties[propertyName]
-  if (!isRecord(property)) return undefined
+  const inputSchema = parseJsonSchemaRecord(tool?.inputSchema)
+  const properties = parseJsonSchemaRecord(inputSchema?.properties)
+  const property = parseJsonSchemaRecord(properties?.[propertyName])
+  if (property === undefined) return undefined
   return typeof property.description === "string" ? property.description : undefined
 }
 


### PR DESCRIPTION
gpt 55

## Summary

Removes the custom `isRecord`/`Predicate.isRecord` helper pattern from the codebase and moves those checks behind Effect Schema parsers.

## What changed

- Replaced MCP 2026 dispatcher and input-schema compatibility record guards with schema-owned parsing.
- Added shared JSON Schema parser helpers and reused them in schema decoration and schema-introspection tests.
- Replaced the remaining role-assignment storage object guard with an Effect Schema decode.
- Added HTTP regression coverage for missing JSON-RPC fields and malformed `_meta` client metadata.

## Why

The old helper duplicated boundary parsing already owned by schemas and made it easy for ad hoc structural checks to drift from parser contracts. This keeps boundary and schema-shape handling in parser APIs instead of custom predicate functions.

## Validation

- `rg -o 'isRecord' . | wc -l` -> `0`\n- `pnpm check-all`\n\nNote: `verify-sdk-parity` emitted the existing warning that `.reference/platform/models` is missing and skipped that optional parity area; the command completed successfully.