### PR TITLE
[codex] Make local release package-specific

### DIFF
--- a/docs/NPM_PRODUCTION_RELEASE.md
+++ b/docs/NPM_PRODUCTION_RELEASE.md
@@ -8,7 +8,7 @@ The one-command flow is:
 pnpm local-release
 ```
 
-That command versions the package from the pending changeset when one exists, builds the npm bundle with `pnpm dlx esbuild` so host-local native binaries are not required, verifies the bundled version, publishes to npm with the default `latest` dist-tag, pushes the release commit and git tag, and creates a latest GitHub release. It fails before changing files if npm auth is not available.
+That command versions packages from pending changesets when they exist, computes which package versions are not yet published on npm, builds only those package bundles with `pnpm dlx esbuild` so host-local native binaries are not required, verifies the bundled versions, publishes to npm with the default `latest` dist-tag, pushes the release commit and git tags, and creates the MCP GitHub release when MCP changed. It fails before changing files if npm auth is not available.
 
 ## Preflight
 
@@ -16,7 +16,7 @@ That command versions the package from the pending changeset when one exists, bu
 - Confirm the worktree is clean.
 - Confirm `gh auth status` and npm publish access before the final publish step.
 - Keep OTP/2FA values out of shell history and logs.
-- The tool-scope filtering release is expected to bump `@firfi/huly-mcp` from `0.43.0` to `0.44.0`.
+- Confirm the expected changesets only bump the intended package. A CLI-only changeset should publish `@firfi/huly-cli` without bumping or rebuilding `@firfi/huly-mcp`.
 
 ```bash
 git checkout master
@@ -25,6 +25,7 @@ git status --short
 gh auth status
 npm whoami
 npm dist-tag ls @firfi/huly-mcp
+npm dist-tag ls @firfi/huly-cli || true
 ```
 
 ## Publish Production
@@ -40,20 +41,45 @@ The script runs:
 - `changeset version`
 - registry metadata sync
 - release metadata commit
-- host-safe bundle build through `pnpm dlx esbuild`
-- `pnpm verify-version`
+- package publish-plan detection from npm registry versions
+- host-safe bundle build through `pnpm dlx esbuild` for packages that need publishing
+- package bundle version verification
+- CLI integration coverage verification and live CLI integration when `@firfi/huly-cli` needs publishing
 - `changeset publish` without a prerelease tag, so npm `latest` moves
 - release commit/tag push
-- latest GitHub release creation
+- latest GitHub release creation when `@firfi/huly-mcp` changed
 
-Run `pnpm check-all` and the local Huly integration suites before starting the production release. The publish script intentionally does not run them because host machines may have platform-specific `node_modules` binaries from a different environment.
+Run `pnpm check-all` and the local Huly integration suites before starting the production release. The publish script runs the CLI live integration gate only when the CLI package needs publishing. It does not run the full MCP integration suite automatically.
+
+## Rerunning After A Failed Release
+
+`pnpm local-release` is intended to be rerunnable. If it created the changeset release commit and then failed during build, verification, publish, push, or GitHub release creation, fix the underlying problem and run the same command again from clean `master`.
+
+The rerun recomputes local package versions against npm:
+
+- Packages whose local version is already published are skipped.
+- Packages whose local version is missing from npm are built, verified, and published.
+- A CLI-only release skips MCP build and MCP GitHub release creation.
+- If all package versions are already published, the script still pushes the current `master` and any tags already created at `HEAD`.
+
+If host-local `node_modules` contains the wrong native binary, the script's release builds still use `pnpm dlx esbuild`. For normal development commands, repair local dependencies with:
+
+```bash
+pnpm rebuild esbuild
+# or, if node_modules came from another machine/container:
+rm -rf node_modules packages/huly-cli/node_modules
+pnpm install --frozen-lockfile
+```
 
 ## Verify After Publish
 
 ```bash
 npm dist-tag ls @firfi/huly-mcp
 npm view @firfi/huly-mcp@latest version
+npm dist-tag ls @firfi/huly-cli
+npm view @firfi/huly-cli@latest version
 npx -y @firfi/huly-mcp@latest
+npx -y @firfi/huly-cli@latest --help
 ```
 
 Expected result:

--- a/scripts/local_release.sh
+++ b/scripts/local_release.sh
@@ -6,6 +6,7 @@ CLI_PACKAGE_NAME="@firfi/huly-cli"
 RELEASE_BRANCH="master"
 CHANGES_DIR=".changeset"
 CHANGES_VERSION="2.30.0"
+ESBUILD_VERSION="0.27.2"
 
 show_dist_tags() {
   local package_name="$1"
@@ -26,6 +27,39 @@ show_dist_tags() {
   return 1
 }
 
+published_version() {
+  local package_name="$1"
+  local allow_missing="$2"
+  local output
+  local error_file
+  error_file="$(mktemp)"
+
+  if output="$(npm view "$package_name" version --json 2>"$error_file")"; then
+    rm -f "$error_file"
+    printf '%s\n' "$output" | tr -d '"'
+    return 0
+  fi
+
+  if [[ "$allow_missing" == "true" ]] && grep -q "E404" "$error_file"; then
+    rm -f "$error_file"
+    return 0
+  fi
+
+  cat "$error_file" >&2
+  rm -f "$error_file"
+  return 1
+}
+
+package_needs_publish() {
+  local package_name="$1"
+  local local_version="$2"
+  local allow_missing="$3"
+  local registry_version
+
+  registry_version="$(published_version "$package_name" "$allow_missing")"
+  [[ "$registry_version" != "$local_version" ]]
+}
+
 stage_if_exists() {
   local path
   for path in "$@"; do
@@ -33,6 +67,32 @@ stage_if_exists() {
       git add "$path"
     fi
   done
+}
+
+build_mcp_package() {
+  local package_version="$1"
+
+  pnpm dlx "esbuild@$ESBUILD_VERSION" src/index.ts \
+    --bundle \
+    --platform=node \
+    --format=cjs \
+    --outfile=dist/index.cjs \
+    --external:ws \
+    "--define:PKG_VERSION=\"$package_version\""
+  pnpm verify-version
+}
+
+build_cli_package() {
+  local package_version="$1"
+
+  pnpm dlx "esbuild@$ESBUILD_VERSION" packages/huly-cli/src/index.ts \
+    --bundle \
+    --platform=node \
+    --format=cjs \
+    --outfile=packages/huly-cli/dist/index.cjs \
+    --external:ws \
+    "--define:PKG_VERSION=\"$package_version\""
+  pnpm --filter "$CLI_PACKAGE_NAME" verify-version
 }
 
 current_branch="$(git branch --show-current)"
@@ -64,14 +124,42 @@ fi
 
 mcp_package_version="$(node -p "require('./package.json').version")"
 cli_package_version="$(node -p "require('./packages/huly-cli/package.json').version")"
+mcp_needs_publish=false
+cli_needs_publish=false
 
-pnpm build
-pnpm verify-version
-pnpm --filter "$CLI_PACKAGE_NAME" verify-version
-pnpm verify-cli-integration-coverage
-pnpm integration:cli
+if package_needs_publish "$MCP_PACKAGE_NAME" "$mcp_package_version" false; then
+  mcp_needs_publish=true
+fi
 
-npm_config_ignore_scripts=true pnpm dlx "@changesets/cli@$CHANGES_VERSION" publish
+if package_needs_publish "$CLI_PACKAGE_NAME" "$cli_package_version" true; then
+  cli_needs_publish=true
+fi
+
+if [[ "$mcp_needs_publish" == "false" && "$cli_needs_publish" == "false" ]]; then
+  echo "No package versions need publishing; pushing any existing release commit/tags."
+else
+  echo "Publish plan:"
+  if [[ "$mcp_needs_publish" == "true" ]]; then
+    echo "  - $MCP_PACKAGE_NAME@$mcp_package_version"
+  fi
+  if [[ "$cli_needs_publish" == "true" ]]; then
+    echo "  - $CLI_PACKAGE_NAME@$cli_package_version"
+  fi
+fi
+
+if [[ "$mcp_needs_publish" == "true" ]]; then
+  build_mcp_package "$mcp_package_version"
+fi
+
+if [[ "$cli_needs_publish" == "true" ]]; then
+  build_cli_package "$cli_package_version"
+  pnpm verify-cli-integration-coverage
+  pnpm integration:cli
+fi
+
+if [[ "$mcp_needs_publish" == "true" || "$cli_needs_publish" == "true" ]]; then
+  npm_config_ignore_scripts=true pnpm dlx "@changesets/cli@$CHANGES_VERSION" publish
+fi
 
 git push origin "$RELEASE_BRANCH"
 mapfile -t release_tags < <(git tag --points-at HEAD)
@@ -87,4 +175,4 @@ fi
 show_dist_tags "$MCP_PACKAGE_NAME" false
 show_dist_tags "$CLI_PACKAGE_NAME" false
 
-echo "Published $MCP_PACKAGE_NAME@$mcp_package_version and $CLI_PACKAGE_NAME@$cli_package_version when changed."
+echo "Release finished for changed packages."


### PR DESCRIPTION
## Summary

Makes `pnpm local-release` package-specific and rerunnable after partial failures.

The release script now computes which local package versions are not yet published on npm, then builds/verifies only those packages. A CLI-only release no longer runs the MCP build or MCP version verification path.

It also restores host-safe bundle builds with `pnpm dlx esbuild`, instead of relying on local `node_modules/.bin/esbuild`, so release builds do not fail when host `node_modules` contains a native binary from another platform/container.

## Behavior

- CLI-only release publishes `@firfi/huly-cli` without bumping/building `@firfi/huly-mcp`.
- MCP-only release still builds/verifies MCP.
- If a release commit was already created and a build/publish/push failed, rerunning recomputes npm registry state and resumes.
- If all local package versions are already published, the script skips package builds/publish and still pushes the current branch/tags.

## Validation

- `bash -n scripts/local_release.sh`
- `pnpm verify-cli-integration-coverage`
