### PR TITLE
Fix person email resolution

### DIFF
--- a/src/huly/operations/contacts-shared.ts
+++ b/src/huly/operations/contacts-shared.ts
@@ -4,7 +4,6 @@ import { SocialIdType } from "@hcengineering/core"
 import { Effect, Option, Schema } from "effect"
 
 import { Count, Email, type NonEmptyString, PersonName, type PersonRefInput } from "../../domain/schemas/shared.js"
-import { isNonEmpty } from "../../utils/assertions.js"
 import type { HulyClient, HulyClientError } from "../client.js"
 import { PersonIdentifierAmbiguousError, PersonNotAnEmployeeError, PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
@@ -25,25 +24,10 @@ export const findPersonById = (
 export const findPersonByEmail = (
   client: HulyClient["Type"],
   email: string
-): Effect.Effect<HulyPerson | undefined, HulyClientError> =>
-  Effect.gen(function*() {
-    const channels = yield* client.findAll<Channel>(
-      contact.class.Channel,
-      {
-        value: email,
-        provider: contact.channelProvider.Email
-      }
-    )
-
-    if (!isNonEmpty(channels)) {
-      return undefined
-    }
-
-    const channel = channels[0]
-    return yield* client.findOne<HulyPerson>(
-      contact.class.Person,
-      { _id: toRef<HulyPerson>(channel.attachedTo) }
-    )
+): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  Option.match(Schema.decodeUnknownOption(Email)(email), {
+    onNone: () => Effect.succeed(undefined),
+    onSome: (parsedEmail) => findPersonByExactEmail(client, parsedEmail)
   })
 
 export const batchGetEmailsForPersons = <T extends Doc>(

--- a/src/huly/operations/organizations.ts
+++ b/src/huly/operations/organizations.ts
@@ -33,7 +33,8 @@ import type {
   InvalidContactProviderError,
   NoUpdateFieldsError,
   OrganizationIdentifierAmbiguousError,
-  OrganizationNotFoundError
+  OrganizationNotFoundError,
+  PersonIdentifierAmbiguousError
 } from "../errors.js"
 import { PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
@@ -50,7 +51,7 @@ import { type DirectUpdateEntry, mergeUpdateEntries, requireUpdateFields } from 
 export { addOrganizationChannel } from "./contact-channels.js"
 
 type ListOrganizationsError = HulyClientError
-type CreateOrganizationError = HulyClientError | PersonNotFoundError
+type CreateOrganizationError = HulyClientError | PersonIdentifierAmbiguousError | PersonNotFoundError
 type GetOrganizationError =
   | HulyClientError
   | OrganizationIdentifierAmbiguousError
@@ -66,17 +67,19 @@ type AddOrganizationMemberError =
   | HulyClientError
   | OrganizationIdentifierAmbiguousError
   | OrganizationNotFoundError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
 type RemoveOrganizationMemberError =
   | HulyClientError
   | OrganizationIdentifierAmbiguousError
   | OrganizationNotFoundError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
 
 const resolvePersonIdentifier = (
   client: HulyClient["Type"],
   identifier: string
-): Effect.Effect<HulyPerson, HulyClientError | PersonNotFoundError> =>
+): Effect.Effect<HulyPerson, HulyClientError | PersonIdentifierAmbiguousError | PersonNotFoundError> =>
   Effect.gen(function*() {
     const byId = Option.fromNullable(yield* findPersonById(client, identifier))
     return yield* Option.match(byId, {
@@ -96,7 +99,7 @@ const resolvePersonIdentifier = (
 const resolvePersonIdentifiers = (
   client: HulyClient["Type"],
   identifiers: ReadonlyArray<string>
-): Effect.Effect<Array<Ref<HulyPerson>>, HulyClientError | PersonNotFoundError> =>
+): Effect.Effect<Array<Ref<HulyPerson>>, HulyClientError | PersonIdentifierAmbiguousError | PersonNotFoundError> =>
   Effect.gen(function*() {
     const resolvedPeople: Array<HulyPerson> = []
 

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -283,7 +283,7 @@ export const mapDomainErrorToMcp = (
   warnings: ReadonlyArray<ToolWarning> = []
 ): McpErrorResponseWithMeta => {
   if (INVALID_PARAMS_TAGS.has(error._tag)) {
-    return createErrorResponse(error.message, McpErrorCode.InvalidParams, undefined, warnings)
+    return createErrorResponse(error.message, McpErrorCode.InvalidParams, error._tag, warnings)
   }
   const prefix = INTERNAL_ERROR_PREFIX[error._tag]
   const message = prefix !== undefined ? `${prefix}: ${error.message}` : error.message

--- a/test/huly/operations/contacts-extended.test.ts
+++ b/test/huly/operations/contacts-extended.test.ts
@@ -392,6 +392,28 @@ describe("Contacts Extended Coverage", () => {
   })
 
   describe("getPerson by email (findPersonByEmail path)", () => {
+    it.effect("finds person by SocialIdentity email when no email channel exists", () =>
+      Effect.gen(function*() {
+        const mockPerson = createMockPerson()
+        const socialIdentity = createMockSocialIdentity({
+          value: "john@example.com",
+          attachedTo: "person-123" as Ref<HulyPerson>
+        })
+
+        const testLayer = createTestLayer({
+          persons: [mockPerson],
+          socialIdentities: [socialIdentity]
+        })
+
+        const result = yield* getPerson({ email: Email.make("john@example.com") }).pipe(
+          Effect.provide(testLayer)
+        )
+
+        expect(result.id).toBe("person-123")
+        expect(result.firstName).toBe("John")
+        expect(result.lastName).toBe("Doe")
+      }))
+
     it.effect("finds person by email when channel exists", () =>
       Effect.gen(function*() {
         const mockPerson = createMockPerson()
@@ -411,6 +433,64 @@ describe("Contacts Extended Coverage", () => {
 
         expect(result.id).toBe("person-123")
         expect(result.email).toBe("john@example.com")
+      }))
+
+    it.effect("does not treat SocialIdentity and email channel for the same person as ambiguous", () =>
+      Effect.gen(function*() {
+        const mockPerson = createMockPerson()
+        const socialIdentity = createMockSocialIdentity({
+          value: "john@example.com",
+          attachedTo: "person-123" as Ref<HulyPerson>
+        })
+        const mockChannel = createMockChannel({
+          value: "john@example.com",
+          attachedTo: "person-123" as Ref<Doc>
+        })
+
+        const testLayer = createTestLayer({
+          persons: [mockPerson],
+          channels: [mockChannel],
+          socialIdentities: [socialIdentity]
+        })
+
+        const result = yield* getPerson({ email: Email.make("john@example.com") }).pipe(
+          Effect.provide(testLayer)
+        )
+
+        expect(result.id).toBe("person-123")
+        expect(result.email).toBe("john@example.com")
+      }))
+
+    it.effect("returns PersonIdentifierAmbiguousError when SocialIdentity and channel point to different people", () =>
+      Effect.gen(function*() {
+        const socialPerson = createMockPerson({
+          _id: "person-social" as Ref<HulyPerson>,
+          name: "Social,Person"
+        })
+        const channelPerson = createMockPerson({
+          _id: "person-channel" as Ref<HulyPerson>,
+          name: "Channel,Person"
+        })
+        const socialIdentity = createMockSocialIdentity({
+          value: "shared@example.com",
+          attachedTo: "person-social" as Ref<HulyPerson>
+        })
+        const mockChannel = createMockChannel({
+          value: "shared@example.com",
+          attachedTo: "person-channel" as Ref<Doc>
+        })
+
+        const testLayer = createTestLayer({
+          persons: [socialPerson, channelPerson],
+          channels: [mockChannel],
+          socialIdentities: [socialIdentity]
+        })
+
+        const error = yield* Effect.flip(
+          getPerson({ email: Email.make("shared@example.com") }).pipe(Effect.provide(testLayer))
+        )
+
+        expect(error._tag).toBe("PersonIdentifierAmbiguousError")
       }))
 
     it.effect("returns PersonNotFoundError when email channel exists but person does not", () =>
@@ -841,6 +921,18 @@ describe("Contacts Extended Coverage", () => {
         }) as HulyClientOperations["findOne"]
 
         const findAllImpl: HulyClientOperations["findAll"] = ((_class: unknown, query: unknown, _options?: unknown) => {
+          if (_class === contact.class.Person) {
+            const q = query as Record<string, unknown>
+            const idFilter = q._id
+            const ids =
+              typeof idFilter === "object" && idFilter !== null && "$in" in idFilter && Array.isArray(idFilter.$in)
+                ? idFilter.$in
+                : []
+            const filtered = ids.length > 0
+              ? [person].filter(p => ids.includes(p._id))
+              : []
+            return Effect.succeed(toFindResult(filtered))
+          }
           if (_class === contact.class.Channel) {
             const q = query as Record<string, unknown>
             let filtered = [channel]

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -90,7 +90,7 @@ import { funnelIdentifier, funnelReference, leadIdentifier } from "../helpers/br
 describe("Error Mapping to MCP", () => {
   describe("mapDomainErrorToMcp", () => {
     describe("InvalidParams errors (-32602)", () => {
-      it.effect("maps IssueNotFoundError with no errorTag", () =>
+      it.effect("maps IssueNotFoundError with its errorTag", () =>
         Effect.gen(function*() {
           const error = new IssueNotFoundError({
             identifier: "HULY-123",
@@ -100,7 +100,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-          expect(response._meta.errorTag).toBeUndefined()
+          expect(response._meta.errorTag).toBe("IssueNotFoundError")
           expect(assertAt(response.content, 0).text).toBe(
             "Issue 'HULY-123' not found in project 'HULY'"
           )
@@ -140,6 +140,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+          expect(response._meta.errorTag).toBe("PersonNotFoundError")
           expect(assertAt(response.content, 0).text).toBe(
             "Person 'john@example.com' not found"
           )
@@ -155,6 +156,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+          expect(response._meta.errorTag).toBe("PersonIdentifierAmbiguousError")
           expect(assertAt(response.content, 0).text).toBe(
             "Person identifier 'Smith,Bill' matched 2 people; use an exact email address instead"
           )
@@ -252,7 +254,7 @@ describe("Error Mapping to MCP", () => {
           expect(assertAt(response.content, 0).text).toBe("Calendar 'cal-9' not found or not accessible")
         }))
 
-      it.effect("maps typed space role lookup errors as invalid params without errorTag", () =>
+      it.effect("maps typed space role lookup errors as invalid params with errorTag", () =>
         Effect.gen(function*() {
           const errors = [
             new SpaceNotTypedError({
@@ -278,7 +280,7 @@ describe("Error Mapping to MCP", () => {
 
             expect(response.isError).toBe(true)
             expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-            expect(response._meta.errorTag).toBeUndefined()
+            expect(response._meta.errorTag).toBe(error._tag)
             expect(assertAt(response.content, 0).text).toBe(error.message)
           }
         }))
@@ -290,7 +292,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-          expect(response._meta.errorTag).toBeUndefined()
+          expect(response._meta.errorTag).toBe("DirectMessageNotFoundError")
           expect(assertAt(response.content, 0).text).toBe("Direct message 'Kerr,Shannon' not found")
         }))
 
@@ -304,7 +306,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-          expect(response._meta.errorTag).toBeUndefined()
+          expect(response._meta.errorTag).toBe("DirectMessageIdentifierAmbiguousError")
           expect(assertAt(response.content, 0).text).toBe(
             "Direct message 'Kerr,Shannon' is ambiguous (2 matches); use the DM _id"
           )
@@ -352,7 +354,7 @@ describe("Error Mapping to MCP", () => {
 
             expect(response.isError).toBe(true)
             expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-            expect(response._meta.errorTag).toBeUndefined()
+            expect(response._meta.errorTag).toBe(error._tag)
             expect(assertAt(response.content, 0).text).toBe(error.message)
           }
         }))
@@ -404,7 +406,7 @@ describe("Error Mapping to MCP", () => {
 
             expect(response.isError).toBe(true)
             expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-            expect(response._meta.errorTag).toBeUndefined()
+            expect(response._meta.errorTag).toBe(error._tag)
             expect(assertAt(response.content, 0).text).toBe(error.message)
           }
         }))
@@ -419,7 +421,7 @@ describe("Error Mapping to MCP", () => {
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-          expect(response._meta.errorTag).toBeUndefined()
+          expect(response._meta.errorTag).toBe("DocumentContentCorruptedError")
           expect(assertAt(response.content, 0).text).toBe(
             "Document content is unreadable or corrupted. Use edit_document with the full content field to replace and repair it."
           )
@@ -457,7 +459,7 @@ describe("Error Mapping to MCP", () => {
 
             expect(response.isError).toBe(true)
             expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
-            expect(response._meta.errorTag).toBeUndefined()
+            expect(response._meta.errorTag).toBe(error._tag)
             expect(assertAt(response.content, 0).text).toBe(error.message)
           }
         }))

--- a/test/mcp/tools/spaces.test.ts
+++ b/test/mcp/tools/spaces.test.ts
@@ -143,7 +143,7 @@ describe("spaceTools", () => {
 
       expect(result.isError).toBe(true)
       expect(result._meta?.errorCode).toBe(McpErrorCode.InvalidParams)
-      expect(result._meta?.errorTag).toBeUndefined()
+      expect(result._meta?.errorTag).toBe("SpaceNotTypedError")
       expect(assertAt(result.content, 0).text).toBe(
         "Space 'General' (space-1) is not typed; role members can only be changed on spaces with a SpaceType"
       )


### PR DESCRIPTION
## Summary

- Resolve person email lookups through both Huly `SocialIdentity` records and contact email channels.
- Preserve same-person de-duplication and surface `PersonIdentifierAmbiguousError` when exact email matches different people.
- Add internal telemetry `errorTag` metadata for typed invalid-parameter domain errors while keeping MCP wire responses unchanged.

## Root Cause

`get_person` by email used the shared `findPersonByEmail` path, but that exported helper only checked contact email channels. Workspace-member email addresses can exist as `SocialIdentity` records without a contact email channel, so those lookups could incorrectly return `PersonNotFoundError`.

## Validation

- `pnpm vitest run test/huly/operations/contacts-extended.test.ts test/mcp/error-mapping.test.ts test/mcp/tools/spaces.test.ts`
- `pnpm check-all`
- Full local Huly integration suite: `791 passed, 0 failed, 28 skipped`