### PR TITLE
Fix CLI Gmail runtime dependency

### DIFF
--- a/.changeset/fix-cli-gmail-dependency.md
+++ b/.changeset/fix-cli-gmail-dependency.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-cli": patch
+---
+
+Declare the Gmail plugin runtime dependency so packed CLI installations can start successfully.

--- a/packages/huly-cli/package.json
+++ b/packages/huly-cli/package.json
@@ -29,6 +29,7 @@
     "@hcengineering/contact": "0.7.0",
     "@hcengineering/core": "0.7.26",
     "@hcengineering/document": "0.7.0",
+    "@hcengineering/gmail": "0.7.0",
     "@hcengineering/inventory": "0.7.0",
     "@hcengineering/love": "0.7.0",
     "@hcengineering/notification": "0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@hcengineering/document':
         specifier: 0.7.0
         version: 0.7.0
+      '@hcengineering/gmail':
+        specifier: 0.7.0
+        version: 0.7.0
       '@hcengineering/inventory':
         specifier: 0.7.0
         version: 0.7.0


### PR DESCRIPTION
## What changed

- declare `@hcengineering/gmail@0.7.0` as a runtime dependency of `@firfi/huly-cli`
- update the workspace lockfile
- add a patch changeset for the CLI package

## Why

The CLI bundle includes a runtime `require("@hcengineering/gmail")`, but the packed CLI package did not declare that dependency. Fresh pnpm and npm installs therefore failed at startup with `MODULE_NOT_FOUND`.

## Validation

- `pnpm check-all`
- packed CLI installed and `huly --help` executed successfully with both pnpm and npm
- `pnpm install --frozen-lockfile --ignore-scripts`
