### PR TITLE
Prevent orphaned stdio MCP processes with bounded shutdown

### DIFF
--- a/.changeset/quiet-mice-exit.md
+++ b/.changeset/quiet-mice-exit.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Exit stdio servers when their client connection closes and bound all graceful shutdown work to one ten-second deadline.

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -111,7 +111,7 @@ Manual setup for the second group-DM participant:
    printf '%s\n%s\n' \
    '{"jsonrpc":"2.0","method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":1}' \
    '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_workspace_members","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":2}' \
-     | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
+     | HULY_TOOL_MODE=native node dist/index.cjs 2>/dev/null | grep '"id":2'
    ```
 
 5. Confirm `list_employees` shows the owner plus two non-self employees with
@@ -194,7 +194,7 @@ INTEGRATION_TRANSPORT=http \
 ```bash
 printf '{"jsonrpc":"2.0","method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":1}
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_projects","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":2}
-' | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>&1 | grep '"id":2'
+' | HULY_TOOL_MODE=native node dist/index.cjs 2>&1 | grep '"id":2'
 ```
 
 Expected: JSON with `"projects": [...]`
@@ -262,7 +262,7 @@ printf '%s\n' \
 '{"jsonrpc":"2.0","method":"resources/templates/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":2}' \
 '{"jsonrpc":"2.0","method":"resources/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":3}' \
 '{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"huly://projects/HULY","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"}}},"id":4}' \
-  | MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep -E '"id":[234]'
+  | node dist/index.cjs 2>/dev/null | grep -E '"id":[234]'
 ```
 
 For HTTP header mode, send the same JSON-RPC methods to `/mcp` with `x-huly-url`, `x-huly-workspace`, and `x-huly-token` headers. Resource reads use the same request-scoped header config as tool calls.
@@ -398,9 +398,9 @@ Huly REST API is eventually consistent. Reads immediately after writes may retur
 
 ```bash
 # Update, then wait, then read in separate connections
-printf '...update...' | MCP_AUTO_EXIT=true node dist/index.cjs
+printf '...update...' | node dist/index.cjs
 sleep 2
-printf '...get...' | MCP_AUTO_EXIT=true node dist/index.cjs
+printf '...get...' | node dist/index.cjs
 ```
 
 ## Individual Tool Test Pattern
@@ -410,7 +410,7 @@ META='"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelc
 
 printf '%s\n' \
   "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"TOOL_NAME\",\"arguments\":ARGS,$META},\"id\":2}" \
-  | HULY_TOOL_MODE=native MCP_AUTO_EXIT=true node dist/index.cjs 2>/dev/null | grep '"id":2'
+  | HULY_TOOL_MODE=native node dist/index.cjs 2>/dev/null | grep '"id":2'
 ```
 
 ## Checking Results

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -199,7 +199,7 @@ printf '{"jsonrpc":"2.0","method":"server/discover","params":{"_meta":{"io.model
 
 Expected: JSON with `"projects": [...]`
 
-**Note**: `MCP_AUTO_EXIT=true` makes the server exit when stdin closes (testing only).
+**Note**: The stdio server exits whenever stdin closes; no lifecycle environment flag is required.
 
 ## API-token certification preparation
 
@@ -382,15 +382,15 @@ Key response fields used by the test script for entity IDs:
 | send_channel_message | `.id` |
 | add_thread_reply | `.id` |
 
-## MCP_AUTO_EXIT and In-Flight Request Draining
+## Stdio EOF and In-Flight Request Draining
 
-`MCP_AUTO_EXIT=true` causes the server to exit when stdin closes. The server **drains in-flight tool calls before shutting down** — i.e., if a tool handler is mid-execution when stdin closes, the server waits (up to 30s) for it to complete and write its response before proceeding with shutdown.
+The stdio server always exits when stdin closes; `MCP_AUTO_EXIT` is no longer needed and cannot disable connection ownership. The server **drains in-flight tool calls before shutting down**: if a tool handler is mid-execution when stdin closes, it gets up to five seconds to complete and write its response. Wire and resource cleanup share the remainder of one ten-second global deadline.
 
 This matters for operations that make HTTP round-trips to Huly's collaborator service (e.g., `edit_document` with content changes calls `updateMarkup`). Without draining, the stdin-close event would race against the HTTP call, and the response would be lost even though the mutation succeeded on the server.
 
 **For script authors**: the standard `printf '%s\n%s\n' | node` pattern works correctly for all tools, including slow ones. No need for `sleep` workarounds.
 
-**Implementation**: `src/mcp/server.ts` — `createMcpServer` tracks in-flight requests with a counter. The `cleanup` handler (stdin close / SIGINT / SIGTERM) calls `drainInflight()` before resuming the shutdown fiber.
+**Implementation**: `src/mcp/server.ts` routes stdin EOF/close, SIGINT/SIGTERM, and programmatic stop through one idempotent shutdown coordinator. New requests are rejected after quiescing, and request completion notifications release the drain without polling timers.
 
 ## Eventual Consistency
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,11 @@ const runConfiguredServer = (transport: McpTransportType): Effect.Effect<void, A
     const authMethod: "token" | "password" = process.env["HULY_TOKEN"] ? "token" : "password"
 
     const combinedClientLayer = buildCombinedClientLayer()
-    const [resolveClients, primeClients, closeClients] = createClientResolver(combinedClientLayer)
+    const {
+      close: closeClients,
+      prime: primeClients,
+      resolve: resolveClients
+    } = createClientResolver(combinedClientLayer)
     const resolveHttpClientLease = createHttpClientLeaseResolver(combinedClientLayer, resolveClients)
 
     if (!lazyEnvs && transport === "stdio") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ import type { RequestClientLease } from "./mcp/request-client-lifecycle.js"
 import { type ClientBundle, type McpServerError, McpServerService, type McpTransportType } from "./mcp/server.js"
 import { type ConsoleRedirectHandle, redirectConsoleToStderr } from "./mcp/stdio-output.js"
 import {
-  buildClientBundle,
   buildCombinedClientLayer,
   buildScopedClientBundle,
   type CombinedClientLayer,
@@ -70,8 +69,6 @@ const getHttpHost: Effect.Effect<HttpHost, ConfigError.ConfigError> = Config.str
 )
 
 export const getMcpAuthToken = Config.redacted("MCP_AUTH_TOKEN").pipe(Config.option)
-
-const getAutoExit = Config.boolean("MCP_AUTO_EXIT").pipe(Config.withDefault(false))
 
 const isGlamaRegistryInspection = (): boolean => process.env["GLAMA_VERSION"] !== undefined
 
@@ -115,9 +112,9 @@ const buildAppLayer = (
   httpPort: HttpPort,
   httpHost: HttpHost,
   mcpAuthToken: string | undefined,
-  autoExit: boolean,
   authMethod: "token" | "password",
   resolveClients: () => Promise<ClientBundle>,
+  closeClients: () => Promise<void>,
   resolveClientLeaseForHttpRequest: (req: Request) => Promise<RequestClientLease>
 ): Layer.Layer<McpServerService | HttpServerFactoryService, McpServerError, never> => {
   const mcpServerConfig = {
@@ -125,9 +122,9 @@ const buildAppLayer = (
     httpPort,
     httpHost,
     ...(mcpAuthToken === undefined ? {} : { mcpAuthToken }),
-    autoExit,
     authMethod,
     resolveClients,
+    closeClients,
     resolveClientLeaseForHttpRequest,
     getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(process.env),
     getRuntimeConfigContextForHttpRequest: (req: Request) =>
@@ -144,24 +141,16 @@ const runConfiguredServer = (transport: McpTransportType): Effect.Effect<void, A
     const httpHost = yield* getHttpHost
     const mcpAuthToken =
       transport === "http" ? Option.map(yield* getMcpAuthToken, Redacted.value).pipe(Option.getOrUndefined) : undefined
-    const autoExit = yield* getAutoExit
     const lazyEnvs = yield* getLazyEnvs
     const authMethod: "token" | "password" = process.env["HULY_TOKEN"] ? "token" : "password"
 
     const combinedClientLayer = buildCombinedClientLayer()
-    const [resolveClients, primeClients] = createClientResolver(combinedClientLayer)
+    const [resolveClients, primeClients, closeClients] = createClientResolver(combinedClientLayer)
     const resolveHttpClientLease = createHttpClientLeaseResolver(combinedClientLayer, resolveClients)
 
     if (!lazyEnvs && transport === "stdio") {
-      // Eager init: build client layers within the Effect pipeline to preserve
-      // typed errors (ConfigValidationError, HulyClientError, etc.).
-      // This also primes the memoized resolver for subsequent tool calls.
-      yield* Effect.gen(function* () {
-        const bundle = yield* buildClientBundle(combinedClientLayer)
-        primeClients(bundle)
-      }).pipe(
-        // A network outage must not prevent the stdio transport from accepting
-        // initialize and returning its typed, actionable tool-call failure.
+      yield* buildScopedClientBundle(combinedClientLayer).pipe(
+        Effect.tap(primeClients),
         Effect.catchTag("HulyUnavailableError", () => Effect.void)
       )
     }
@@ -172,9 +161,9 @@ const runConfiguredServer = (transport: McpTransportType): Effect.Effect<void, A
       httpPort,
       httpHost,
       mcpAuthToken,
-      autoExit,
       authMethod,
       resolveClients,
+      closeClients,
       resolveHttpClientLease
     )
 

--- a/src/mcp/create-mcp-server.ts
+++ b/src/mcp/create-mcp-server.ts
@@ -12,7 +12,11 @@ import type { ToolRegistry } from "./tools/index.js"
 
 export type { ClientBundle } from "./protocol-handlers.js"
 
-type McpServerHandle = readonly [server: Server, drainInflight: () => Promise<void>]
+export interface McpServerLifecycle {
+  readonly quiesce: () => Promise<void>
+}
+
+type McpServerHandle = readonly [server: Server, lifecycle: McpServerLifecycle]
 
 const currentClientInfoFromServer = (
   server: Server
@@ -51,5 +55,5 @@ export const createMcpServer = (
   server.setRequestHandler("resources/templates/list", handlers.listResourceTemplates)
   server.setRequestHandler("resources/read", handlers.readResource)
 
-  return [server, handlers.drainInflight]
+  return [server, { quiesce: handlers.quiesce }]
 }

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -31,6 +31,7 @@ export {
   appendToolWarnings,
   createImageSuccessResponse,
   createInvalidParamsError,
+  createServerShuttingDownError,
   createSuccessResponse,
   createUnknownToolError,
   McpErrorCode,

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -19,6 +19,7 @@ import type { McpToolResponse } from "./error-mapping.js"
 import type { McpWireResponse } from "./tool-responses.js"
 import {
   appendToolWarnings,
+  createServerShuttingDownError,
   createSuccessResponse,
   createUnknownToolError,
   mapClientResolutionErrorToMcp,
@@ -34,6 +35,7 @@ import {
   VersionToolResultSchema
 } from "./huly-context-tool.js"
 import { createResourceProtocolHandlers } from "./protocol-resource-handlers.js"
+import { createRequestAdmission } from "./request-admission.js"
 import {
   defaultExposureOptions,
   normalizeRegistries,
@@ -86,11 +88,9 @@ export interface McpProtocolHandlers {
   readonly listResources: () => Promise<ListResourcesResult>
   readonly listResourceTemplates: () => ListResourceTemplatesResult
   readonly readResource: (request: ResourceReadRequest) => Promise<ReadResourceResult>
-  readonly drainInflight: () => Promise<void>
+  readonly quiesce: () => Promise<void>
 }
 
-const DRAIN_POLL_MS = 50
-const DRAIN_TIMEOUT_MS = 30_000
 const NPM_FETCH_TIMEOUT_MS = 5_000
 const NPM_PACKAGE_NAME = "@firfi/huly-mcp"
 
@@ -121,23 +121,6 @@ export interface NowClock {
 }
 
 export const liveNowClock: NowClock = { currentTimeMillis: () => Effect.runSync(Clock.currentTimeMillis) }
-
-const createDrainInflight =
-  (getInflight: () => number, clock: NowClock): (() => Promise<void>) =>
-  () => {
-    if (getInflight() <= 0) return Promise.resolve()
-    return new Promise((resolve) => {
-      const start = clock.currentTimeMillis()
-      const check = () => {
-        if (getInflight() <= 0 || clock.currentTimeMillis() - start > DRAIN_TIMEOUT_MS) {
-          resolve()
-        } else {
-          setTimeout(check, DRAIN_POLL_MS)
-        }
-      }
-      check()
-    })
-  }
 
 /**
  * Fetch the latest published npm version. The `fetch` implementation is injected
@@ -234,14 +217,7 @@ export const createMcpProtocolHandlers = (
     currentClientInfo: exposureOptions.currentClientInfo ?? defaults.currentClientInfo,
     toolScopeFilteringActive: exposureOptions.toolScopeFilteringActive ?? defaults.toolScopeFilteringActive
   }
-  let inflight = 0
-  const drainInflight = createDrainInflight(() => inflight, clock)
-  const enter = () => {
-    inflight++
-  }
-  const leave = () => {
-    inflight--
-  }
+  const admission = createRequestAdmission()
 
   const listTools = async (): Promise<ListToolsProtocolResult> => {
     const exposure = resolveProtocolExposure(registries, protocolExposureOptions)
@@ -256,7 +232,8 @@ export const createMcpProtocolHandlers = (
   }
 
   const callTool = async (request: ToolCallRequest): Promise<McpWireResponse> => {
-    enter()
+    const lease = admission.enter()
+    if (lease === null) return toMcpResponse(createServerShuttingDownError())
     const noticeClaim = toolCallNoticeProvider.claim()
     try {
       const { arguments: args, name } = request.params
@@ -422,11 +399,11 @@ export const createMcpProtocolHandlers = (
       if (noticeClaim._tag === "Claimed") noticeClaim.release()
       throw error
     } finally {
-      leave()
+      lease.release()
     }
   }
 
-  const resourceHandlers = createResourceProtocolHandlers({ resolveClients, enter, leave })
+  const resourceHandlers = createResourceProtocolHandlers({ resolveClients, admission })
 
   return {
     listTools,
@@ -434,6 +411,6 @@ export const createMcpProtocolHandlers = (
     listResources: resourceHandlers.listResources,
     listResourceTemplates,
     readResource: resourceHandlers.readResource,
-    drainInflight
+    quiesce: admission.quiesce
   }
 }

--- a/src/mcp/protocol-resource-handlers.ts
+++ b/src/mcp/protocol-resource-handlers.ts
@@ -11,6 +11,7 @@ import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
 import { clientResolutionErrorMessage } from "./error-mapping.js"
 import { listResources, readHulyResource } from "./resources.js"
 import type { RequestAdmission, RequestLease } from "./request-admission.js"
+import { McpErrorCode, SERVER_SHUTTING_DOWN_MESSAGE } from "./tool-responses.js"
 
 interface ClientBundle {
   readonly hulyClient: HulyClient["Type"]
@@ -30,10 +31,7 @@ interface ResourceHandlerInput {
 const enterOrThrow = (admission: RequestAdmission): RequestLease => {
   const lease = admission.enter()
   if (lease !== null) return lease
-  throw new ProtocolError(
-    ProtocolErrorCode.InternalError,
-    "Huly MCP is shutting down; start a new connection before retrying"
-  )
+  throw new ProtocolError(McpErrorCode.InternalError, SERVER_SHUTTING_DOWN_MESSAGE)
 }
 
 const withResourceWarnings = (result: ReadResourceResult, warnings: ReadonlyArray<ToolWarning>): ReadResourceResult =>

--- a/src/mcp/protocol-resource-handlers.ts
+++ b/src/mcp/protocol-resource-handlers.ts
@@ -10,6 +10,7 @@ import type { HulyStorageClient } from "../huly/storage.js"
 import type { WorkspaceClientOperations } from "../huly/workspace-client.js"
 import { clientResolutionErrorMessage } from "./error-mapping.js"
 import { listResources, readHulyResource } from "./resources.js"
+import type { RequestAdmission, RequestLease } from "./request-admission.js"
 
 interface ClientBundle {
   readonly hulyClient: HulyClient["Type"]
@@ -23,8 +24,16 @@ interface ResourceReadRequest {
 
 interface ResourceHandlerInput {
   readonly resolveClients: () => Promise<ClientBundle>
-  readonly enter: () => void
-  readonly leave: () => void
+  readonly admission: RequestAdmission
+}
+
+const enterOrThrow = (admission: RequestAdmission): RequestLease => {
+  const lease = admission.enter()
+  if (lease !== null) return lease
+  throw new ProtocolError(
+    ProtocolErrorCode.InternalError,
+    "Huly MCP is shutting down; start a new connection before retrying"
+  )
 }
 
 const withResourceWarnings = (result: ReadResourceResult, warnings: ReadonlyArray<ToolWarning>): ReadResourceResult =>
@@ -83,7 +92,7 @@ export const createResourceProtocolHandlers = (
   readonly readResource: (request: ResourceReadRequest) => Promise<ReadResourceResult>
 } => {
   const listResourcesHandler = async (): Promise<ListResourcesResult> => {
-    input.enter()
+    const lease = enterOrThrow(input.admission)
     try {
       let clients: ClientBundle
       try {
@@ -99,12 +108,12 @@ export const createResourceProtocolHandlers = (
       if (Exit.isSuccess(resourceList)) return resourceList.value
       return throwResourceListError(resourceList.cause)
     } finally {
-      input.leave()
+      lease.release()
     }
   }
 
   const readResource = async (request: ResourceReadRequest): Promise<ReadResourceResult> => {
-    input.enter()
+    const lease = enterOrThrow(input.admission)
     try {
       const { uri } = request.params
       const clients = await resolveResourceClientsOrThrow(input.resolveClients, (error) =>
@@ -121,7 +130,7 @@ export const createResourceProtocolHandlers = (
       if (Exit.isSuccess(resourceRead)) return withResourceWarnings(resourceRead.value, warnings)
       return throwResourceReadError(uri, resourceRead.cause)
     } finally {
-      input.leave()
+      lease.release()
     }
   }
 

--- a/src/mcp/request-admission.ts
+++ b/src/mcp/request-admission.ts
@@ -1,0 +1,41 @@
+export interface RequestLease {
+  readonly release: () => void
+}
+
+export interface RequestAdmission {
+  readonly enter: () => RequestLease | null
+  readonly quiesce: () => Promise<void>
+}
+
+export const createRequestAdmission = (): RequestAdmission => {
+  const state = { accepting: true, active: 0 }
+  const drainWaiters = new Set<() => void>()
+
+  const releaseDrains = (): void => {
+    if (state.active !== 0) return
+    for (const resolve of drainWaiters) resolve()
+    drainWaiters.clear()
+  }
+
+  const enter = (): RequestLease | null => {
+    if (!state.accepting) return null
+    state.active++
+    const leaseState = { released: false }
+    return {
+      release: () => {
+        if (leaseState.released) return
+        leaseState.released = true
+        state.active--
+        releaseDrains()
+      }
+    }
+  }
+
+  const quiesce = (): Promise<void> => {
+    state.accepting = false
+    if (state.active === 0) return Promise.resolve()
+    return new Promise((resolve) => drainWaiters.add(resolve))
+  }
+
+  return { enter, quiesce }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,7 +7,7 @@ import type { McpRequestContext, Server } from "@modelcontextprotocol/server"
 import { serveStdio, type StdioServerTransport } from "@modelcontextprotocol/server/stdio"
 import { Config, Context, Deferred, Effect, Layer, Ref, Schema } from "effect"
 
-import { type ClientBundle, createMcpServer } from "./create-mcp-server.js"
+import { type ClientBundle, createMcpServer, type McpServerLifecycle } from "./create-mcp-server.js"
 import type { HttpHost, HttpPort, HttpServerFactoryService, HttpTransportError } from "./http-transport.js"
 import { DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, startHttpTransport } from "./http-transport.js"
 import { buildHulyContext, type ToolExposureContext } from "./huly-context-tool.js"
@@ -17,6 +17,15 @@ import {
   createRequestClientLifecycle,
   type RequestClientLease
 } from "./request-client-lifecycle.js"
+import {
+  executeBoundedStdioShutdown,
+  liveStdioProcessPort,
+  makeStdioShutdownCoordinator,
+  type StdioProcessPort,
+  type StdioShutdownCoordinator,
+  type StdioShutdownReason,
+  type StdioShutdownResources
+} from "./stdio-shutdown.js"
 
 import { type SanitizedHulyRuntimeConfigContext, sanitizeHulyRuntimeConfigFromEnv } from "../config/config.js"
 import type { GetHulyContextResult } from "../domain/schemas/index.js"
@@ -40,7 +49,6 @@ interface McpServerConfigData {
   readonly httpPort?: HttpPort
   readonly httpHost?: HttpHost
   readonly mcpAuthToken?: string
-  readonly autoExit?: boolean
   readonly authMethod?: "token" | "password"
 }
 
@@ -51,6 +59,8 @@ interface McpServerConfigCallbacks {
   readonly getRuntimeConfigContextForHttpRequest?: (req: Request) => SanitizedHulyRuntimeConfigContext
   readonly createServer?: (instructions?: HostedHulyMigrationInstructions) => Server
   readonly createStdioTransport?: () => StdioServerTransport
+  readonly closeClients?: () => Promise<void>
+  readonly stdioProcess?: StdioProcessPort
   readonly writeError?: (message: string) => void
 }
 
@@ -82,6 +92,36 @@ interface McpServerRunControl {
   readonly shutdown: Deferred.Deferred<void>
   readonly done: Deferred.Deferred<void>
 }
+
+const requestShutdown = (coordinator: StdioShutdownCoordinator, reason: StdioShutdownReason): void => {
+  Effect.runSync(coordinator.request(reason))
+}
+
+const awaitStdioLifecycleEvent = (
+  coordinator: StdioShutdownCoordinator,
+  stdioProcess: StdioProcessPort
+): Effect.Effect<void> =>
+  Effect.async<void>((resume) => {
+    const listenerState = { remove: () => {} }
+    const request = (reason: StdioShutdownReason) => {
+      listenerState.remove()
+      requestShutdown(coordinator, reason)
+      resume(Effect.void)
+    }
+    listenerState.remove = stdioProcess.listen({
+      stdinEof: () => request("stdin-eof"),
+      stdinClose: () => request("stdin-close"),
+      sigint: () => request("sigint"),
+      sigterm: () => request("sigterm")
+    })
+    return Effect.sync(() => listenerState.remove())
+  })
+
+const drainStdioRequests = (lifecycles: ReadonlySet<McpServerLifecycle>): Effect.Effect<void, unknown> =>
+  Effect.tryPromise(() => Promise.all([...lifecycles].map((lifecycle) => lifecycle.quiesce())).then(() => {}))
+
+const promiseCleanup = (cleanup: (() => Promise<void>) | undefined): Effect.Effect<void, unknown> =>
+  cleanup === undefined ? Effect.void : Effect.tryPromise(cleanup)
 
 export class McpServerService extends Context.Tag("@hulymcp/McpServer")<McpServerService, McpServerOperations>() {
   static layer(config: McpServerConfig): Layer.Layer<McpServerService, McpServerError, TelemetryService> {
@@ -157,9 +197,12 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<McpServe
               yield* Effect.gen(function* () {
                 if (config.transport === "stdio") {
                   const stdioRuntimeConfig = getRuntimeConfigContext()
-                  const drains = new Set<() => Promise<void>>()
+                  const lifecycles = new Set<McpServerLifecycle>()
+                  const coordinator = yield* makeStdioShutdownCoordinator(() => {
+                    for (const lifecycle of lifecycles) void lifecycle.quiesce()
+                  })
                   const createStdioServer = () => {
-                    const [server, drainInflight] = createMcpServer(
+                    const [server, lifecycle] = createMcpServer(
                       config.resolveClients,
                       telemetry,
                       registries,
@@ -172,12 +215,7 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<McpServe
                       }),
                       hostedHulyMigrationInstructionsForOrigin(stdioRuntimeConfig.huly.url.origin)
                     )
-                    drains.add(drainInflight)
-                    const previousOnClose = server.onclose
-                    server.onclose = () => {
-                      drains.delete(drainInflight)
-                      previousOnClose?.()
-                    }
+                    lifecycles.add(lifecycle)
                     return server
                   }
                   const stdioHandle = serveStdio(createStdioServer, {
@@ -185,38 +223,27 @@ export class McpServerService extends Context.Tag("@hulymcp/McpServer")<McpServe
                     ...(config.createStdioTransport === undefined ? {} : { transport: config.createStdioTransport() }),
                     onerror: (error) => writeError(`MCP stdio handler error: ${error.message}`)
                   })
-                  yield* Effect.raceFirst(
-                    Effect.async<void, McpServerError>((resume) => {
-                      const removeListeners = () => {
-                        process.off("SIGINT", cleanup)
-                        process.off("SIGTERM", cleanup)
-                        if (config.autoExit) {
-                          process.stdin.off("end", cleanup)
-                          process.stdin.off("close", cleanup)
-                        }
-                      }
-                      const cleanup = () => {
-                        removeListeners()
-                        resume(Effect.void)
-                      }
-
-                      process.on("SIGINT", cleanup)
-                      process.on("SIGTERM", cleanup)
-
-                      if (config.autoExit) {
-                        process.stdin.on("end", cleanup)
-                        process.stdin.on("close", cleanup)
-                      }
-
-                      return Effect.sync(removeListeners)
-                    }),
-                    Deferred.await(control.shutdown)
+                  const stdioProcess = config.stdioProcess ?? liveStdioProcessPort
+                  const shutdownResources: StdioShutdownResources = {
+                    drain: drainStdioRequests(lifecycles),
+                    closeWire: Effect.tryPromise(() => stdioHandle.close()),
+                    closeTelemetry: Effect.tryPromise(() => telemetry.shutdown()),
+                    closeClients: promiseCleanup(config.closeClients),
+                    forceExit: (code) => Effect.sync(() => stdioProcess.forceExit(code)),
+                    writeDiagnostic: (message) => Effect.sync(() => writeError(message))
+                  }
+                  const awaitStop = Deferred.await(control.shutdown).pipe(
+                    Effect.tap(() => coordinator.request("stop")),
+                    Effect.asVoid
                   )
 
-                  yield* Effect.promise(() => Promise.all([...drains].map((drain) => drain())))
-                  yield* flushTelemetry
-
-                  yield* Effect.promise(() => stdioHandle.close())
+                  yield* Effect.raceFirst(awaitStdioLifecycleEvent(coordinator, stdioProcess), awaitStop).pipe(
+                    Effect.ensuring(
+                      coordinator
+                        .request("runtime-interruption")
+                        .pipe(Effect.zipRight(executeBoundedStdioShutdown(coordinator, shutdownResources)))
+                    )
+                  )
                 } else {
                   const port = config.httpPort ?? DEFAULT_HTTP_PORT
                   const host = config.httpHost ?? DEFAULT_HTTP_HOST

--- a/src/mcp/stdio-shutdown.ts
+++ b/src/mcp/stdio-shutdown.ts
@@ -70,6 +70,14 @@ const complete = (state: StdioShutdownState, outcome: StdioShutdownOutcome): Std
   return { _tag: "Complete", reason: state.reason, outcome }
 }
 
+const completeTransition = (
+  state: StdioShutdownState,
+  outcome: StdioShutdownOutcome
+): readonly [boolean, StdioShutdownState] => {
+  const next = complete(state, outcome)
+  return [next !== state, next]
+}
+
 export const makeStdioShutdownCoordinator = (
   onQuiesce: () => void = () => {}
 ): Effect.Effect<StdioShutdownCoordinator> =>
@@ -94,9 +102,10 @@ export const makeStdioShutdownCoordinator = (
       claimExecution: Ref.getAndSet(executionClaimed, true).pipe(Effect.map((claimed) => !claimed)),
       beginClosing: Ref.update(state, beginClosing),
       complete: (outcome) =>
-        Ref.update(state, (current) => complete(current, outcome)).pipe(
-          Effect.zipRight(Deferred.succeed(completed, undefined)),
-          Effect.asVoid
+        Ref.modify(state, (current) => completeTransition(current, outcome)).pipe(
+          Effect.flatMap((transitioned) =>
+            transitioned ? Deferred.succeed(completed, undefined).pipe(Effect.asVoid) : Effect.void
+          )
         ),
       awaitComplete: Deferred.await(completed),
       state: Ref.get(state)

--- a/src/mcp/stdio-shutdown.ts
+++ b/src/mcp/stdio-shutdown.ts
@@ -18,11 +18,15 @@ export type StdioShutdownState =
 export interface StdioShutdownCoordinator {
   readonly request: (reason: StdioShutdownReason) => Effect.Effect<boolean>
   readonly awaitRequest: Effect.Effect<StdioShutdownReason>
-  readonly claimExecution: Effect.Effect<boolean>
-  readonly beginClosing: Effect.Effect<void>
-  readonly complete: (outcome: StdioShutdownOutcome) => Effect.Effect<void>
   readonly awaitComplete: Effect.Effect<void>
   readonly state: Effect.Effect<StdioShutdownState>
+  readonly execute: (resources: StdioShutdownResources) => Effect.Effect<void>
+}
+
+interface StdioShutdownInternals {
+  readonly claimExecution: Effect.Effect<boolean>
+  readonly beginClosing: (reason: StdioShutdownReason) => Effect.Effect<void>
+  readonly complete: (reason: StdioShutdownReason, outcome: StdioShutdownOutcome) => Effect.Effect<void>
 }
 
 export interface StdioShutdownResources {
@@ -62,22 +66,6 @@ export const liveStdioProcessPort: StdioProcessPort = {
   forceExit: (code) => process.exit(code)
 }
 
-const beginClosing = (state: StdioShutdownState): StdioShutdownState =>
-  state._tag === "Quiescing" ? { _tag: "Closing", reason: state.reason } : state
-
-const complete = (state: StdioShutdownState, outcome: StdioShutdownOutcome): StdioShutdownState => {
-  if (state._tag === "Complete" || state._tag === "Running") return state
-  return { _tag: "Complete", reason: state.reason, outcome }
-}
-
-const completeTransition = (
-  state: StdioShutdownState,
-  outcome: StdioShutdownOutcome
-): readonly [boolean, StdioShutdownState] => {
-  const next = complete(state, outcome)
-  return [next !== state, next]
-}
-
 export const makeStdioShutdownCoordinator = (
   onQuiesce: () => void = () => {}
 ): Effect.Effect<StdioShutdownCoordinator> =>
@@ -96,54 +84,68 @@ export const makeStdioShutdownCoordinator = (
         )
       )
 
-    return {
+    const internals: StdioShutdownInternals = {
+      claimExecution: Ref.getAndSet(executionClaimed, true).pipe(Effect.map((claimed) => !claimed)),
+      beginClosing: (reason) => Ref.set(state, { _tag: "Closing", reason }),
+      complete: (reason, outcome) =>
+        Ref.set(state, { _tag: "Complete", reason, outcome }).pipe(
+          Effect.zipRight(Deferred.succeed(completed, undefined)),
+          Effect.asVoid
+        )
+    }
+    const coordinator: StdioShutdownCoordinator = {
       request,
       awaitRequest: Deferred.await(requested),
-      claimExecution: Ref.getAndSet(executionClaimed, true).pipe(Effect.map((claimed) => !claimed)),
-      beginClosing: Ref.update(state, beginClosing),
-      complete: (outcome) =>
-        Ref.modify(state, (current) => completeTransition(current, outcome)).pipe(
-          Effect.flatMap((transitioned) =>
-            transitioned ? Deferred.succeed(completed, undefined).pipe(Effect.asVoid) : Effect.void
-          )
-        ),
       awaitComplete: Deferred.await(completed),
-      state: Ref.get(state)
+      state: Ref.get(state),
+      execute: (resources) => executeShutdown(coordinator, internals, resources)
     }
+    return coordinator
   })
 
 const ignoreCloseFailure = (effect: Effect.Effect<void, unknown>): Effect.Effect<void> => Effect.ignore(effect)
 
 const runGracefulShutdown = (
-  coordinator: StdioShutdownCoordinator,
+  internals: StdioShutdownInternals,
+  reason: StdioShutdownReason,
   resources: StdioShutdownResources
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* resources.drain.pipe(Effect.disconnect, Effect.timeoutOption(STDIO_DRAIN_ALLOWANCE), Effect.ignore)
-    yield* coordinator.beginClosing
+    yield* internals.beginClosing(reason)
     yield* Effect.all([resources.closeWire, resources.closeTelemetry, resources.closeClients].map(ignoreCloseFailure), {
       concurrency: "unbounded",
       discard: true
     })
-    yield* coordinator.complete("graceful")
+    yield* internals.complete(reason, "graceful")
   })
 
-const forceShutdown = (coordinator: StdioShutdownCoordinator, resources: StdioShutdownResources): Effect.Effect<void> =>
+const forceShutdown = (
+  internals: StdioShutdownInternals,
+  reason: StdioShutdownReason,
+  resources: StdioShutdownResources
+): Effect.Effect<void> =>
   Effect.sleep(STDIO_SHUTDOWN_DEADLINE).pipe(
     Effect.zipRight(resources.writeDiagnostic(FORCED_STDIO_EXIT_DIAGNOSTIC)),
     Effect.zipRight(resources.forceExit(FORCED_STDIO_EXIT_CODE)),
-    Effect.zipRight(coordinator.complete("forced"))
+    Effect.zipRight(internals.complete(reason, "forced"))
   )
+
+const executeShutdown = (
+  coordinator: StdioShutdownCoordinator,
+  internals: StdioShutdownInternals,
+  resources: StdioShutdownResources
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const reason = yield* coordinator.awaitRequest
+    if (!(yield* internals.claimExecution)) return yield* coordinator.awaitComplete
+    yield* Effect.raceFirst(
+      runGracefulShutdown(internals, reason, resources).pipe(Effect.disconnect, Effect.interruptible),
+      forceShutdown(internals, reason, resources).pipe(Effect.disconnect, Effect.interruptible)
+    )
+  }).pipe(Effect.asVoid)
 
 export const executeBoundedStdioShutdown = (
   coordinator: StdioShutdownCoordinator,
   resources: StdioShutdownResources
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    yield* coordinator.awaitRequest
-    if (!(yield* coordinator.claimExecution)) return yield* coordinator.awaitComplete
-    yield* Effect.raceFirst(
-      runGracefulShutdown(coordinator, resources).pipe(Effect.disconnect, Effect.interruptible),
-      forceShutdown(coordinator, resources).pipe(Effect.disconnect, Effect.interruptible)
-    )
-  }).pipe(Effect.asVoid)
+): Effect.Effect<void> => coordinator.execute(resources)

--- a/src/mcp/stdio-shutdown.ts
+++ b/src/mcp/stdio-shutdown.ts
@@ -1,0 +1,140 @@
+import { Deferred, Effect, Ref } from "effect"
+
+export const STDIO_DRAIN_ALLOWANCE = "5 seconds"
+export const STDIO_SHUTDOWN_DEADLINE = "10 seconds"
+export const FORCED_STDIO_EXIT_CODE = 1
+export const FORCED_STDIO_EXIT_DIAGNOSTIC = "Huly MCP stdio shutdown exceeded 10 seconds; forcing process exit"
+
+export type StdioShutdownReason = "stdin-eof" | "stdin-close" | "sigint" | "sigterm" | "stop" | "runtime-interruption"
+
+export type StdioShutdownOutcome = "graceful" | "forced"
+
+export type StdioShutdownState =
+  | { readonly _tag: "Running" }
+  | { readonly _tag: "Quiescing"; readonly reason: StdioShutdownReason }
+  | { readonly _tag: "Closing"; readonly reason: StdioShutdownReason }
+  | { readonly _tag: "Complete"; readonly reason: StdioShutdownReason; readonly outcome: StdioShutdownOutcome }
+
+export interface StdioShutdownCoordinator {
+  readonly request: (reason: StdioShutdownReason) => Effect.Effect<boolean>
+  readonly awaitRequest: Effect.Effect<StdioShutdownReason>
+  readonly claimExecution: Effect.Effect<boolean>
+  readonly beginClosing: Effect.Effect<void>
+  readonly complete: (outcome: StdioShutdownOutcome) => Effect.Effect<void>
+  readonly awaitComplete: Effect.Effect<void>
+  readonly state: Effect.Effect<StdioShutdownState>
+}
+
+export interface StdioShutdownResources {
+  readonly drain: Effect.Effect<void, unknown>
+  readonly closeWire: Effect.Effect<void, unknown>
+  readonly closeTelemetry: Effect.Effect<void, unknown>
+  readonly closeClients: Effect.Effect<void, unknown>
+  readonly forceExit: (code: typeof FORCED_STDIO_EXIT_CODE) => Effect.Effect<void>
+  readonly writeDiagnostic: (message: typeof FORCED_STDIO_EXIT_DIAGNOSTIC) => Effect.Effect<void>
+}
+
+export interface StdioShutdownHandlers {
+  readonly stdinEof: () => void
+  readonly stdinClose: () => void
+  readonly sigint: () => void
+  readonly sigterm: () => void
+}
+
+export interface StdioProcessPort {
+  readonly listen: (handlers: StdioShutdownHandlers) => () => void
+  readonly forceExit: (code: typeof FORCED_STDIO_EXIT_CODE) => void
+}
+
+export const liveStdioProcessPort: StdioProcessPort = {
+  listen: (handlers) => {
+    process.stdin.on("end", handlers.stdinEof)
+    process.stdin.on("close", handlers.stdinClose)
+    process.on("SIGINT", handlers.sigint)
+    process.on("SIGTERM", handlers.sigterm)
+    return () => {
+      process.stdin.off("end", handlers.stdinEof)
+      process.stdin.off("close", handlers.stdinClose)
+      process.off("SIGINT", handlers.sigint)
+      process.off("SIGTERM", handlers.sigterm)
+    }
+  },
+  forceExit: (code) => process.exit(code)
+}
+
+const beginClosing = (state: StdioShutdownState): StdioShutdownState =>
+  state._tag === "Quiescing" ? { _tag: "Closing", reason: state.reason } : state
+
+const complete = (state: StdioShutdownState, outcome: StdioShutdownOutcome): StdioShutdownState => {
+  if (state._tag === "Complete" || state._tag === "Running") return state
+  return { _tag: "Complete", reason: state.reason, outcome }
+}
+
+export const makeStdioShutdownCoordinator = (
+  onQuiesce: () => void = () => {}
+): Effect.Effect<StdioShutdownCoordinator> =>
+  Effect.gen(function* () {
+    const state = yield* Ref.make<StdioShutdownState>({ _tag: "Running" })
+    const requested = yield* Deferred.make<StdioShutdownReason>()
+    const completed = yield* Deferred.make<void>()
+    const executionClaimed = yield* Ref.make(false)
+
+    const request = (reason: StdioShutdownReason): Effect.Effect<boolean> =>
+      Ref.modify(state, (current): readonly [boolean, StdioShutdownState] =>
+        current._tag === "Running" ? [true, { _tag: "Quiescing", reason }] : [false, current]
+      ).pipe(
+        Effect.tap((accepted) =>
+          accepted ? Effect.sync(onQuiesce).pipe(Effect.zipRight(Deferred.succeed(requested, reason))) : Effect.void
+        )
+      )
+
+    return {
+      request,
+      awaitRequest: Deferred.await(requested),
+      claimExecution: Ref.getAndSet(executionClaimed, true).pipe(Effect.map((claimed) => !claimed)),
+      beginClosing: Ref.update(state, beginClosing),
+      complete: (outcome) =>
+        Ref.update(state, (current) => complete(current, outcome)).pipe(
+          Effect.zipRight(Deferred.succeed(completed, undefined)),
+          Effect.asVoid
+        ),
+      awaitComplete: Deferred.await(completed),
+      state: Ref.get(state)
+    }
+  })
+
+const ignoreCloseFailure = (effect: Effect.Effect<void, unknown>): Effect.Effect<void> => Effect.ignore(effect)
+
+const runGracefulShutdown = (
+  coordinator: StdioShutdownCoordinator,
+  resources: StdioShutdownResources
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* resources.drain.pipe(Effect.disconnect, Effect.timeoutOption(STDIO_DRAIN_ALLOWANCE), Effect.ignore)
+    yield* coordinator.beginClosing
+    yield* Effect.all([resources.closeWire, resources.closeTelemetry, resources.closeClients].map(ignoreCloseFailure), {
+      concurrency: "unbounded",
+      discard: true
+    })
+    yield* coordinator.complete("graceful")
+  })
+
+const forceShutdown = (coordinator: StdioShutdownCoordinator, resources: StdioShutdownResources): Effect.Effect<void> =>
+  Effect.sleep(STDIO_SHUTDOWN_DEADLINE).pipe(
+    Effect.zipRight(resources.writeDiagnostic(FORCED_STDIO_EXIT_DIAGNOSTIC)),
+    Effect.zipRight(resources.forceExit(FORCED_STDIO_EXIT_CODE)),
+    Effect.zipRight(coordinator.complete("forced"))
+  )
+
+export const executeBoundedStdioShutdown = (
+  coordinator: StdioShutdownCoordinator,
+  resources: StdioShutdownResources
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* coordinator.awaitRequest
+    if (!(yield* coordinator.claimExecution)) return yield* coordinator.awaitComplete
+    yield* Effect.raceFirst(
+      runGracefulShutdown(coordinator, resources).pipe(Effect.disconnect, Effect.interruptible),
+      forceShutdown(coordinator, resources).pipe(Effect.disconnect, Effect.interruptible)
+    )
+  }).pipe(Effect.asVoid)

--- a/src/mcp/tool-responses.ts
+++ b/src/mcp/tool-responses.ts
@@ -116,6 +116,13 @@ export const appendToolWarnings = (
 export const createUnknownToolError = (toolName: string): McpErrorResponseWithMeta =>
   createErrorResponse(`Unknown tool: ${toolName}`, McpErrorCode.InvalidParams, "UnknownTool")
 
+export const createServerShuttingDownError = (): McpErrorResponseWithMeta =>
+  createErrorResponse(
+    "Huly MCP is shutting down; start a new connection before retrying",
+    McpErrorCode.InternalError,
+    "ServerShuttingDown"
+  )
+
 export const createInvalidParamsError = (message: string, errorTag?: string): McpErrorResponseWithMeta =>
   createErrorResponse(message, McpErrorCode.InvalidParams, errorTag)
 

--- a/src/mcp/tool-responses.ts
+++ b/src/mcp/tool-responses.ts
@@ -116,12 +116,10 @@ export const appendToolWarnings = (
 export const createUnknownToolError = (toolName: string): McpErrorResponseWithMeta =>
   createErrorResponse(`Unknown tool: ${toolName}`, McpErrorCode.InvalidParams, "UnknownTool")
 
+export const SERVER_SHUTTING_DOWN_MESSAGE = "Huly MCP is shutting down; start a new connection before retrying"
+
 export const createServerShuttingDownError = (): McpErrorResponseWithMeta =>
-  createErrorResponse(
-    "Huly MCP is shutting down; start a new connection before retrying",
-    McpErrorCode.InternalError,
-    "ServerShuttingDown"
-  )
+  createErrorResponse(SERVER_SHUTTING_DOWN_MESSAGE, McpErrorCode.InternalError, "ServerShuttingDown")
 
 export const createInvalidParamsError = (message: string, errorTag?: string): McpErrorResponseWithMeta =>
   createErrorResponse(message, McpErrorCode.InvalidParams, errorTag)

--- a/src/runtime/huly-clients.ts
+++ b/src/runtime/huly-clients.ts
@@ -1,4 +1,4 @@
-import { Cause, Chunk, Context, Effect, Exit, Layer, Runtime, Scope } from "effect"
+import { Cause, Chunk, Context, Effect, Exit, Fiber, Layer, Runtime, Scope } from "effect"
 
 import { type ConfigValidationError, HulyConfigService } from "../config/config.js"
 import { HulyClient, type HulyClientError } from "../huly/client.js"
@@ -30,29 +30,43 @@ export const buildCombinedClientLayer = (): CombinedClientLayer => {
   return Layer.merge(Layer.merge(hulyClientLayer, storageClientLayer), workspaceClientLayer)
 }
 
-export const buildClientBundle = (
-  combinedClientLayer: CombinedClientLayer
-): Effect.Effect<ClientBundle, HulyClientBundleError> =>
-  buildScopedClientBundle(combinedClientLayer).pipe(Effect.map(({ bundle }) => bundle))
+export interface ScopedClientBundle {
+  readonly bundle: ClientBundle
+  readonly close: () => Promise<void>
+}
+
+interface ClientAcquisition {
+  readonly promise: Promise<ScopedClientBundle>
+  readonly close: () => Promise<void>
+}
+
+const makeScopeClose = (scope: Scope.CloseableScope): (() => Promise<void>) => {
+  const state: { promise: Promise<void> | null } = { promise: null }
+  return () => {
+    if (state.promise === null) state.promise = Effect.runPromise(Scope.close(scope, Exit.void))
+    return state.promise
+  }
+}
 
 export const buildScopedClientBundle = (
   combinedClientLayer: CombinedClientLayer
-): Effect.Effect<{ readonly bundle: ClientBundle; readonly close: () => Promise<void> }, HulyClientBundleError> =>
-  Effect.gen(function* () {
-    const scope = yield* Scope.make()
-    const close = (): Promise<void> => Effect.runPromise(Scope.close(scope, Exit.void))
-    const ctx = yield* Layer.buildWithScope(combinedClientLayer, scope).pipe(
-      Effect.tapError(() => Scope.close(scope, Exit.void))
-    )
-    return {
-      bundle: {
-        hulyClient: Context.get(ctx, HulyClient),
-        storageClient: Context.get(ctx, HulyStorageClient),
-        workspaceClient: Context.get(ctx, WorkspaceClient)
-      },
-      close
-    }
-  })
+): Effect.Effect<ScopedClientBundle, HulyClientBundleError> =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      const ctx = yield* restore(Layer.buildWithScope(combinedClientLayer, scope)).pipe(
+        Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void))
+      )
+      return {
+        bundle: {
+          hulyClient: Context.get(ctx, HulyClient),
+          storageClient: Context.get(ctx, HulyStorageClient),
+          workspaceClient: Context.get(ctx, WorkspaceClient)
+        },
+        close: makeScopeClose(scope)
+      }
+    })
+  )
 
 /**
  * Create a memoized client resolver that builds layers on first call
@@ -61,29 +75,66 @@ export const buildScopedClientBundle = (
  */
 export const createClientResolver = (
   combinedClientLayer: CombinedClientLayer
-): readonly [resolve: () => Promise<ClientBundle>, prime: (bundle: ClientBundle) => void] => {
-  let clientsPromise: Promise<ClientBundle> | null = null
+): readonly [
+  resolve: () => Promise<ClientBundle>,
+  prime: (scoped: ScopedClientBundle) => void,
+  close: () => Promise<void>
+] => {
+  const state: { active: Promise<ScopedClientBundle> | null; closePromise: Promise<void> | null; closed: boolean } = {
+    active: null,
+    closePromise: null,
+    closed: false
+  }
+  const acquisitions = new Set<ClientAcquisition>()
+
+  const startAcquisition = (): ClientAcquisition => {
+    const fiber = Effect.runFork(buildScopedClientBundle(combinedClientLayer))
+    const promise = Effect.runPromise(Fiber.join(fiber))
+    return {
+      promise,
+      close: () =>
+        Effect.runPromise(Fiber.interrupt(fiber)).then(() =>
+          promise.then(
+            (scoped) => scoped.close(),
+            () => Promise.resolve()
+          )
+        )
+    }
+  }
 
   const resolve = (): Promise<ClientBundle> => {
-    if (clientsPromise === null) {
-      const acquisition = Effect.runPromise(buildClientBundle(combinedClientLayer))
-      clientsPromise = acquisition
-      void acquisition.catch((error: unknown) => {
+    if (state.closed) return Promise.reject(new Error("Process-scoped Huly clients are closed"))
+    if (state.active === null) {
+      const acquisition = startAcquisition()
+      acquisitions.add(acquisition)
+      state.active = acquisition.promise
+      void acquisition.promise.catch((error: unknown) => {
         const unavailable =
           error instanceof HulyUnavailableError ||
           (Runtime.isFiberFailure(error) &&
             Chunk.toArray(Cause.failures(error[Runtime.FiberFailureCauseId])).some(
               (failure) => failure instanceof HulyUnavailableError
             ))
-        if (unavailable && clientsPromise === acquisition) clientsPromise = null
+        if (unavailable && state.active === acquisition.promise) state.active = null
       })
     }
-    return clientsPromise
+    return state.active.then(({ bundle }) => bundle)
   }
 
-  const prime = (bundle: ClientBundle): void => {
-    clientsPromise = Promise.resolve(bundle)
+  const prime = (scoped: ScopedClientBundle): void => {
+    if (state.closed) throw new Error("Cannot prime closed process-scoped Huly clients")
+    const acquisition = Promise.resolve(scoped)
+    acquisitions.add({ promise: acquisition, close: scoped.close })
+    state.active = acquisition
   }
 
-  return [resolve, prime] as const
+  const close = (): Promise<void> => {
+    state.closed = true
+    if (state.closePromise === null) {
+      state.closePromise = Promise.all([...acquisitions].map((acquisition) => acquisition.close())).then(() => {})
+    }
+    return state.closePromise
+  }
+
+  return [resolve, prime, close] as const
 }

--- a/src/runtime/huly-clients.ts
+++ b/src/runtime/huly-clients.ts
@@ -77,7 +77,7 @@ export const buildScopedClientBundle = (
 /**
  * Create a memoized client resolver that builds layers on first call
  * and keeps the scope alive for the process lifetime.
- * Returns [resolver, prime] — prime pre-populates the cache from an existing bundle.
+ * The named operations support lazy resolution, eager priming, and exact-once closure.
  */
 export const createClientResolver = (combinedClientLayer: CombinedClientLayer): ClientResolver => {
   const state: { active: Promise<ScopedClientBundle> | null; closePromise: Promise<void> | null; closed: boolean } = {

--- a/src/runtime/huly-clients.ts
+++ b/src/runtime/huly-clients.ts
@@ -35,6 +35,12 @@ export interface ScopedClientBundle {
   readonly close: () => Promise<void>
 }
 
+export interface ClientResolver {
+  readonly resolve: () => Promise<ClientBundle>
+  readonly prime: (scoped: ScopedClientBundle) => void
+  readonly close: () => Promise<void>
+}
+
 interface ClientAcquisition {
   readonly promise: Promise<ScopedClientBundle>
   readonly close: () => Promise<void>
@@ -73,13 +79,7 @@ export const buildScopedClientBundle = (
  * and keeps the scope alive for the process lifetime.
  * Returns [resolver, prime] — prime pre-populates the cache from an existing bundle.
  */
-export const createClientResolver = (
-  combinedClientLayer: CombinedClientLayer
-): readonly [
-  resolve: () => Promise<ClientBundle>,
-  prime: (scoped: ScopedClientBundle) => void,
-  close: () => Promise<void>
-] => {
+export const createClientResolver = (combinedClientLayer: CombinedClientLayer): ClientResolver => {
   const state: { active: Promise<ScopedClientBundle> | null; closePromise: Promise<void> | null; closed: boolean } = {
     active: null,
     closePromise: null,
@@ -136,5 +136,5 @@ export const createClientResolver = (
     return state.closePromise
   }
 
-  return [resolve, prime, close] as const
+  return { resolve, prime, close }
 }

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -1841,7 +1841,7 @@ describe("createMcpProtocolHandlers — resource handlers", () => {
   })
 })
 
-describe("createMcpProtocolHandlers — drainInflight", () => {
+describe("createMcpProtocolHandlers — quiesce", () => {
   it("resolves immediately when nothing is in flight", async () => {
     const handlers = createMcpProtocolHandlers(
       buildStubClients(),
@@ -1849,7 +1849,7 @@ describe("createMcpProtocolHandlers — drainInflight", () => {
       emptyRegistry,
       unusedGetHulyContext
     )
-    await expect(handlers.drainInflight()).resolves.toBeUndefined()
+    await expect(handlers.quiesce()).resolves.toBeUndefined()
   })
 
   it("waits for an in-flight call to complete, then resolves", async () => {
@@ -1866,27 +1866,53 @@ describe("createMcpProtocolHandlers — drainInflight", () => {
 
     // enter() runs synchronously, so inflight becomes 1 before the first await
     const callPromise = handlers.callTool({ params: { name: "list_projects", arguments: {} } })
-    const drainPromise = handlers.drainInflight()
+    const drainPromise = handlers.quiesce()
 
     release(await buildStubClients()())
     await callPromise
     await expect(drainPromise).resolves.toBeUndefined()
   })
 
-  it("stops draining once the timeout elapses even if a call is still in flight", async () => {
-    const neverResolves = new Promise<ClientBundle>(() => {})
-    // Clock readings: callTool start, drain start, drain check (> 30s after start) -> timeout branch
-    const clock = queuedClock([0, 0, 31_000])
+  it("rejects a new tool call after quiescing without acquiring clients", async () => {
+    let resolutions = 0
     const handlers = createMcpProtocolHandlers(
-      () => neverResolves,
+      () => {
+        resolutions++
+        return buildStubClients()()
+      },
       createTelemetryProbe().telemetry,
       toolRegistry,
-      unusedGetHulyContext,
-      clock
+      unusedGetHulyContext
     )
 
-    void handlers.callTool({ params: { name: "list_projects", arguments: {} } })
-    await expect(handlers.drainInflight()).resolves.toBeUndefined()
+    await handlers.quiesce()
+    const response = await handlers.callTool({ params: { name: "list_projects", arguments: {} } })
+
+    expect(response).toMatchObject({ isError: true })
+    expect(response.content[0]?.text).toContain("shutting down")
+    expect(resolutions).toBe(0)
+  })
+
+  it("delivers an accepted tool response before quiescing finishes", async () => {
+    let release: (bundle: ClientBundle) => void = () => {}
+    const gate = new Promise<ClientBundle>((resolve) => {
+      release = resolve
+    })
+    const handlers = createMcpProtocolHandlers(
+      () => gate,
+      createTelemetryProbe().telemetry,
+      toolRegistry,
+      unusedGetHulyContext
+    )
+
+    const call = handlers.callTool({ params: { name: "list_projects", arguments: {} } })
+    const quiescing = handlers.quiesce()
+    release(await buildStubClients()())
+
+    const response = await call
+    await quiescing
+
+    expect(response.isError).not.toBe(true)
   })
 })
 

--- a/test/mcp/request-admission.test.ts
+++ b/test/mcp/request-admission.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { createRequestAdmission } from "../../src/mcp/request-admission.js"
+
+describe("request admission", () => {
+  it("quiesces synchronously and resolves when every accepted request releases", async () => {
+    const admission = createRequestAdmission()
+    const first = admission.enter()
+    const second = admission.enter()
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+
+    const drained = admission.quiesce()
+    expect(admission.enter()).toBeNull()
+
+    first?.release()
+    first?.release()
+    let settled = false
+    void drained.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    second?.release()
+    await expect(drained).resolves.toBeUndefined()
+  })
+
+  it("drains immediately when no request is active", async () => {
+    const admission = createRequestAdmission()
+
+    await expect(admission.quiesce()).resolves.toBeUndefined()
+    expect(admission.enter()).toBeNull()
+  })
+})

--- a/test/mcp/server-http.test.ts
+++ b/test/mcp/server-http.test.ts
@@ -67,6 +67,32 @@ const runningFactory = (
 ): HttpServerFactory => makeTestHttpServerFactory(listening.resolve, (message) => writes.push(message))
 
 describe("McpServerService released HTTP integration", () => {
+  it("keeps HTTP running when stdin emits EOF", async () => {
+    const listening = deferred<http.Server>()
+    const writes: Array<string> = []
+    const bundle = await clientBundle()
+    const layer = McpServerService.layer({
+      transport: "http",
+      httpPort: 0,
+      httpHost: "127.0.0.1",
+      resolveClients: async () => bundle,
+      getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(runtimeEnv)
+    }).pipe(Layer.provide(TelemetryService.testLayer()))
+    const context = await Effect.runPromise(Layer.build(layer).pipe(Effect.scoped))
+    const operations = Context.get(context, McpServerService)
+    const fiber = Effect.runFork(
+      operations.run().pipe(Effect.provideService(HttpServerFactoryService, runningFactory(listening, writes)))
+    )
+    const server = await listening.promise
+
+    process.stdin.emit("end")
+    await Promise.resolve()
+
+    expect(server.listening).toBe(true)
+    await Effect.runPromise(operations.stop())
+    await Effect.runPromise(Fiber.join(fiber))
+  })
+
   it("uses request runtime config and releases a request-scoped client lease", async () => {
     const listening = deferred<http.Server>()
     const writes: Array<string> = []

--- a/test/mcp/server-parseToolsets.test.ts
+++ b/test/mcp/server-parseToolsets.test.ts
@@ -33,13 +33,7 @@ const resolveClientsFromLayer = (
 }
 
 const buildTestServerLayer = (
-  config: {
-    transport: "stdio" | "http"
-    httpPort?: number
-    httpHost?: string
-    autoExit?: boolean
-    authMethod?: "token" | "password"
-  },
+  config: { transport: "stdio" | "http"; httpPort?: number; httpHost?: string; authMethod?: "token" | "password" },
   layers: Layer.Layer<HulyClient | HulyStorageClient | WorkspaceClient | TelemetryService>,
   writeError?: (message: string) => void
 ) =>

--- a/test/mcp/server-stdio-lifecycle.test.ts
+++ b/test/mcp/server-stdio-lifecycle.test.ts
@@ -1,7 +1,8 @@
 import { PassThrough } from "node:stream"
 
-import { Context, Effect, Fiber, Layer } from "effect"
-import { describe, it } from "vitest"
+import { it } from "@effect/vitest"
+import { Context, Effect, Fiber, Layer, TestClock } from "effect"
+import { describe, expect } from "vitest"
 
 import { sanitizeHulyRuntimeConfigFromEnv } from "../../src/config/config.js"
 import { HulyClient } from "../../src/huly/client.js"
@@ -11,6 +12,7 @@ import { HttpServerFactoryService } from "../../src/mcp/http-transport.js"
 import { createDefaultMcpSdkServer } from "../../src/mcp/sdk-server.js"
 import type { ClientBundle } from "../../src/mcp/server.js"
 import { McpServerService } from "../../src/mcp/server.js"
+import type { StdioProcessPort, StdioShutdownHandlers } from "../../src/mcp/stdio-shutdown.js"
 import { TelemetryService } from "../../src/telemetry/telemetry.js"
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio"
 import { inertHttpServerFactory } from "./http-test-support.js"
@@ -35,12 +37,53 @@ class FailingCloseTransport extends StdioServerTransport {
   }
 }
 
+class RecordingStdioProcess implements StdioProcessPort {
+  private handlers: StdioShutdownHandlers | null = null
+  private readonly waiters = new Set<() => void>()
+  readonly forcedExitCodes: Array<1> = []
+  listenerRegistrations = 0
+
+  listen(handlers: StdioShutdownHandlers): () => void {
+    this.handlers = handlers
+    this.listenerRegistrations++
+    for (const resolve of this.waiters) resolve()
+    this.waiters.clear()
+    return () => {
+      if (this.handlers === handlers) this.handlers = null
+    }
+  }
+
+  forceExit(code: 1): void {
+    this.forcedExitCodes.push(code)
+  }
+
+  awaitListening(): Promise<void> {
+    return this.handlers === null ? new Promise((resolve) => this.waiters.add(resolve)) : Promise.resolve()
+  }
+
+  emitEof(): void {
+    this.handlers?.stdinEof()
+  }
+
+  emitSigterm(): void {
+    this.handlers?.sigterm()
+  }
+}
+
+class CountingCloseTransport extends StdioServerTransport {
+  closes = 0
+
+  override close(): Promise<void> {
+    this.closes++
+    return super.close()
+  }
+}
+
 describe("McpServerService released stdio lifecycle", () => {
   it("lets the SDK report owned stdio wire close failures out of band", async () => {
     const bundle = await clientBundle()
     const layer = McpServerService.layer({
       transport: "stdio",
-      autoExit: true,
       resolveClients: async () => bundle,
       createServer: createDefaultMcpSdkServer,
       createStdioTransport: () => new FailingCloseTransport(new PassThrough(), new PassThrough()),
@@ -79,7 +122,6 @@ describe("McpServerService released stdio lifecycle", () => {
     const bundle = await clientBundle()
     const layer = McpServerService.layer({
       transport: "stdio",
-      autoExit: true,
       resolveClients: async () => bundle,
       createServer: createDefaultMcpSdkServer,
       createStdioTransport: () => new StdioServerTransport(input, output),
@@ -95,4 +137,135 @@ describe("McpServerService released stdio lifecycle", () => {
     process.stdin.emit("end")
     await Effect.runPromise(Fiber.join(fiber))
   })
+
+  it("treats EOF as unconditional ownership loss and coalesces a racing signal", async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const transport = new CountingCloseTransport(input, output)
+    const stdioProcess = new RecordingStdioProcess()
+    const bundle = await clientBundle()
+    let telemetryCloses = 0
+    let clientCloses = 0
+    const layer = McpServerService.layer({
+      transport: "stdio",
+      resolveClients: async () => bundle,
+      closeClients: async () => {
+        clientCloses++
+      },
+      createServer: createDefaultMcpSdkServer,
+      createStdioTransport: () => transport,
+      stdioProcess,
+      getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(runtimeEnv)
+    }).pipe(
+      Layer.provide(
+        TelemetryService.testLayer({
+          shutdown: async () => {
+            telemetryCloses++
+          }
+        })
+      )
+    )
+    const context = await Effect.runPromise(Layer.build(layer).pipe(Effect.scoped))
+    const operations = Context.get(context, McpServerService)
+    const fiber = Effect.runFork(
+      operations.run().pipe(Effect.provideService(HttpServerFactoryService, unusedHttpFactory))
+    )
+
+    await stdioProcess.awaitListening()
+    stdioProcess.emitEof()
+    stdioProcess.emitSigterm()
+    await Effect.runPromise(Fiber.join(fiber))
+
+    expect(transport.closes).toBe(1)
+    expect(telemetryCloses).toBe(1)
+    expect(clientCloses).toBe(1)
+    expect(stdioProcess.forcedExitCodes).toEqual([])
+  })
+
+  it.scoped("forces one exit when a top-level external close exceeds the global deadline", () =>
+    Effect.gen(function* () {
+      const stdioProcess = new RecordingStdioProcess()
+      const errors: Array<string> = []
+      const bundle = yield* Effect.promise(clientBundle)
+      const neverCloses = new Promise<void>(() => {})
+      const layer = McpServerService.layer({
+        transport: "stdio",
+        resolveClients: async () => bundle,
+        closeClients: () => neverCloses,
+        createServer: createDefaultMcpSdkServer,
+        createStdioTransport: () => new StdioServerTransport(new PassThrough(), new PassThrough()),
+        stdioProcess,
+        writeError: (message) => errors.push(message),
+        getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(runtimeEnv)
+      }).pipe(Layer.provide(TelemetryService.testLayer()))
+      const context = yield* Layer.build(layer)
+      const operations = Context.get(context, McpServerService)
+      const fiber = yield* operations
+        .run()
+        .pipe(Effect.provideService(HttpServerFactoryService, unusedHttpFactory), Effect.fork)
+
+      yield* Effect.promise(() => stdioProcess.awaitListening())
+      yield* Effect.sync(() => stdioProcess.emitEof())
+      yield* TestClock.adjust("10 seconds")
+      yield* Fiber.join(fiber)
+
+      expect(stdioProcess.forcedExitCodes).toEqual([1])
+      expect(errors).toEqual(["Huly MCP stdio shutdown exceeded 10 seconds; forcing process exit"])
+    })
+  )
+
+  it.scoped("abandons an accepted request after its allowance and still completes before the global deadline", () =>
+    Effect.gen(function* () {
+      const input = new PassThrough()
+      const output = new PassThrough()
+      const stdioProcess = new RecordingStdioProcess()
+      const requestStarted = yield* Effect.makeLatch(false)
+      const neverResolves = new Promise<ClientBundle>(() => {})
+      const errors: Array<string> = []
+      const layer = McpServerService.layer({
+        transport: "stdio",
+        resolveClients: () => {
+          Effect.runSync(requestStarted.open)
+          return neverResolves
+        },
+        createServer: createDefaultMcpSdkServer,
+        createStdioTransport: () => new StdioServerTransport(input, output),
+        stdioProcess,
+        writeError: (message) => errors.push(message),
+        getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(runtimeEnv)
+      }).pipe(Layer.provide(TelemetryService.testLayer()))
+      const context = yield* Layer.build(layer)
+      const operations = Context.get(context, McpServerService)
+      const fiber = yield* operations
+        .run()
+        .pipe(Effect.provideService(HttpServerFactoryService, unusedHttpFactory), Effect.fork)
+
+      yield* Effect.promise(() => stdioProcess.awaitListening())
+      yield* Effect.sync(() => {
+        input.write(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "shutdown-test", version: "1.0.0" }
+            }
+          })}\n`
+        )
+        input.write(
+          `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "list_projects", arguments: {} } })}\n`
+        )
+      })
+      yield* requestStarted.await
+      yield* Effect.sync(() => stdioProcess.emitEof())
+      yield* Effect.yieldNow()
+      yield* TestClock.adjust("10 seconds")
+      yield* Fiber.join(fiber)
+
+      expect(stdioProcess.forcedExitCodes).toEqual([])
+      expect(errors).not.toContain("Huly MCP stdio shutdown exceeded 10 seconds; forcing process exit")
+    })
+  )
 })

--- a/test/mcp/server-stdio-lifecycle.test.ts
+++ b/test/mcp/server-stdio-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { PassThrough } from "node:stream"
 
+import { Server } from "@modelcontextprotocol/server"
 import { it } from "@effect/vitest"
 import { Context, Effect, Fiber, Layer, TestClock } from "effect"
 import { describe, expect } from "vitest"
@@ -79,6 +80,19 @@ class CountingCloseTransport extends StdioServerTransport {
   }
 }
 
+class CountingSdkServer extends Server {
+  closes = 0
+
+  constructor() {
+    super({ name: "shutdown-test", version: "1.0.0" }, { capabilities: { resources: {}, tools: {} } })
+  }
+
+  override close(): Promise<void> {
+    this.closes++
+    return super.close()
+  }
+}
+
 describe("McpServerService released stdio lifecycle", () => {
   it("lets the SDK report owned stdio wire close failures out of band", async () => {
     const bundle = await clientBundle()
@@ -146,13 +160,23 @@ describe("McpServerService released stdio lifecycle", () => {
     const bundle = await clientBundle()
     let telemetryCloses = 0
     let clientCloses = 0
+    const sdkServers: Array<CountingSdkServer> = []
+    const sdkCreatedState = { resolve: () => {} }
+    const sdkCreated = new Promise<void>((resolve) => {
+      sdkCreatedState.resolve = resolve
+    })
     const layer = McpServerService.layer({
       transport: "stdio",
       resolveClients: async () => bundle,
       closeClients: async () => {
         clientCloses++
       },
-      createServer: createDefaultMcpSdkServer,
+      createServer: () => {
+        const server = new CountingSdkServer()
+        sdkServers.push(server)
+        sdkCreatedState.resolve()
+        return server
+      },
       createStdioTransport: () => transport,
       stdioProcess,
       getRuntimeConfigContext: () => sanitizeHulyRuntimeConfigFromEnv(runtimeEnv)
@@ -172,11 +196,27 @@ describe("McpServerService released stdio lifecycle", () => {
     )
 
     await stdioProcess.awaitListening()
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "server/discover",
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {}
+          }
+        }
+      })}\n`
+    )
+    await sdkCreated
     stdioProcess.emitEof()
     stdioProcess.emitSigterm()
     await Effect.runPromise(Fiber.join(fiber))
 
     expect(transport.closes).toBe(1)
+    expect(sdkServers).toHaveLength(1)
+    expect(sdkServers[0]?.closes).toBe(1)
     expect(telemetryCloses).toBe(1)
     expect(clientCloses).toBe(1)
     expect(stdioProcess.forcedExitCodes).toEqual([])

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -107,7 +107,6 @@ const buildTestServerLayer = (
     httpPort?: number
     httpHost?: string
     mcpAuthToken?: string
-    autoExit?: boolean
     authMethod?: "token" | "password"
     createServer?: (instructions?: HostedHulyMigrationInstructions) => Server
     writeError?: (message: string) => void
@@ -739,7 +738,7 @@ describe("Tool definition descriptions", () => {
 
 // --- McpServerService.layer run/stop tests ---
 
-const buildStdioService = (config?: { autoExit?: boolean; telemetryOps?: Partial<TelemetryOperations> }) => {
+const buildStdioService = (config?: { telemetryOps?: Partial<TelemetryOperations> }) => {
   const telemetryLayer = config?.telemetryOps
     ? TelemetryService.testLayer(config.telemetryOps)
     : TelemetryService.testLayer()
@@ -749,7 +748,7 @@ const buildStdioService = (config?: { autoExit?: boolean; telemetryOps?: Partial
     WorkspaceClient.testLayer({}),
     telemetryLayer
   )
-  return buildTestServerLayer({ transport: "stdio", autoExit: config?.autoExit ?? true }, layers)
+  return buildTestServerLayer({ transport: "stdio" }, layers)
 }
 
 describe("McpServerService.layer operations", () => {
@@ -785,10 +784,10 @@ describe("McpServerService.layer operations", () => {
 
   describe("run() stdio transport", () => {
     it.scoped(
-      "run completes when stdin ends (autoExit)",
+      "run completes when stdin ends",
       () =>
         Effect.gen(function* () {
-          const serverLayer = buildStdioService({ autoExit: true })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -807,7 +806,7 @@ describe("McpServerService.layer operations", () => {
       "run completes when SIGINT received",
       () =>
         Effect.gen(function* () {
-          const serverLayer = buildStdioService({ autoExit: false })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -834,7 +833,6 @@ describe("McpServerService.layer operations", () => {
           )
           const serverLayer = McpServerService.layer({
             transport: "stdio",
-            autoExit: true,
             createServer: createMockServer,
             resolveClients: resolveClientsFromLayer(layers)
           }).pipe(Layer.provide(layers))
@@ -856,7 +854,7 @@ describe("McpServerService.layer operations", () => {
       "run fails with already-running error on second call",
       () =>
         Effect.gen(function* () {
-          const serverLayer = buildStdioService({ autoExit: true })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -891,7 +889,6 @@ describe("McpServerService.layer operations", () => {
         const serverLayer = buildTestServerLayer(
           {
             transport: "stdio",
-            autoExit: true,
             createServer: (instructions) => {
               const server = createDefaultMcpSdkServer(instructions)
               server.connect = () => Promise.reject(new Error("connection refused"))
@@ -917,7 +914,7 @@ describe("McpServerService.layer operations", () => {
       () =>
         Effect.gen(function* () {
           mockCloseBehavior = () => Promise.reject(new Error("close failed"))
-          const serverLayer = buildStdioService({ autoExit: true })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -941,10 +938,10 @@ describe("McpServerService.layer operations", () => {
     )
 
     it.scoped(
-      "run cleanup removes signal listeners when fiber is interrupted (autoExit=true)",
+      "run cleanup removes signal listeners when fiber is interrupted",
       () =>
         Effect.gen(function* () {
-          const serverLayer = buildStdioService({ autoExit: true })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -959,10 +956,10 @@ describe("McpServerService.layer operations", () => {
     )
 
     it.scoped(
-      "run cleanup works when autoExit is false",
+      "run cleanup works",
       () =>
         Effect.gen(function* () {
-          const serverLayer = buildStdioService({ autoExit: false })
+          const serverLayer = buildStdioService({})
           const ctx = yield* Layer.build(serverLayer)
           const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
 
@@ -971,7 +968,7 @@ describe("McpServerService.layer operations", () => {
           )
 
           yield* Effect.promise(() => new Promise((r) => setTimeout(r, 50)))
-          // Interrupt to trigger the cleanup/teardown with autoExit=false branch
+          // Interrupt to trigger cleanup through the interruption-safe finalizer.
           yield* Fiber.interrupt(fiber)
         }),
       { timeout: 5000 }
@@ -983,7 +980,6 @@ describe("McpServerService.layer operations", () => {
         let shutdownCalled = false
         return Effect.gen(function* () {
           const serverLayer = buildStdioService({
-            autoExit: true,
             telemetryOps: {
               shutdown: async () => {
                 shutdownCalled = true
@@ -1018,7 +1014,6 @@ describe("McpServerService.layer operations", () => {
         let shutdownCalled = false
         return Effect.gen(function* () {
           const serverLayer = buildStdioService({
-            autoExit: true,
             telemetryOps: {
               shutdown: async () => {
                 shutdownCalled = true
@@ -1108,7 +1103,6 @@ describe("McpServerService.layer operations", () => {
           const serverLayer = buildTestServerLayer(
             {
               transport: "stdio",
-              autoExit: true,
               createServer: (instructions) => {
                 const server = createDefaultMcpSdkServer(instructions)
                 server.close = () => Promise.reject(new Error("server close failed"))
@@ -1243,7 +1237,7 @@ describe("McpServerService.layer operations", () => {
       createServer: (instructions?: HostedHulyMigrationInstructions) => Server = createMockServer
     ) =>
       Effect.gen(function* () {
-        const serverLayer = buildTestServerLayer({ transport: "stdio", autoExit: true, createServer }, layers)
+        const serverLayer = buildTestServerLayer({ transport: "stdio", createServer }, layers)
         const ctx = yield* Layer.build(serverLayer)
         const ops = yield* McpServerService.pipe(Effect.provide(Layer.succeedContext(ctx)))
         const fiber = yield* Effect.fork(
@@ -1267,7 +1261,6 @@ describe("McpServerService.layer operations", () => {
       Effect.gen(function* () {
         const serverLayer = McpServerService.layer({
           transport: "stdio",
-          autoExit: true,
           createServer: createMockServer,
           createStdioTransport: createTestStdioTransport,
           resolveClients

--- a/test/mcp/stdio-process-lifecycle.test.ts
+++ b/test/mcp/stdio-process-lifecycle.test.ts
@@ -1,0 +1,176 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { once } from "node:events"
+import { resolve } from "node:path"
+import { createInterface } from "node:readline"
+
+import { beforeAll, describe, expect, it } from "vitest"
+
+const builtServerPath = resolve(process.cwd(), "dist/index.cjs")
+const PROCESS_BOUND_MS = 8_000
+const SECRET = "subprocess-secret-token"
+const PAYLOAD_MARKER = "lifecycle-secret-payload"
+
+interface SpawnedServer {
+  readonly child: ChildProcessWithoutNullStreams
+  readonly exit: Promise<{ readonly code: number | null; readonly signal: string | null }>
+  readonly firstLine: Promise<string>
+  readonly pid: number
+  readonly stderr: () => string
+  readonly stdout: () => string
+}
+
+const withBound = <A>(promise: Promise<A>, label: string): Promise<A> =>
+  new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} exceeded ${PROCESS_BOUND_MS}ms`)), PROCESS_BOUND_MS)
+    void promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolvePromise(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
+const spawnServer = (): SpawnedServer => {
+  const { MCP_AUTO_EXIT: _ignoredAutoExit, ...inheritedEnvironment } = process.env
+  const child = spawn(process.execPath, [builtServerPath], {
+    env: {
+      ...inheritedEnvironment,
+      HULY_MCP_TELEMETRY: "0",
+      HULY_TOKEN: SECRET,
+      HULY_URL: "https://huly.example.com",
+      HULY_WORKSPACE: "workspace",
+      LAZY_ENVS: "true"
+    }
+  })
+  const pid = child.pid
+  if (pid === undefined) throw new Error("Spawned stdio server did not expose a PID")
+
+  const output = { stderr: "", stdout: "" }
+  child.stdout.setEncoding("utf8")
+  child.stderr.setEncoding("utf8")
+  child.stdout.on("data", (chunk: string) => {
+    output.stdout += chunk
+  })
+  child.stderr.on("data", (chunk: string) => {
+    output.stderr += chunk
+  })
+  const lines = createInterface({ input: child.stdout })
+  const firstLine = once(lines, "line").then(([line]) => (typeof line === "string" ? line : ""))
+  const exit = once(child, "exit").then(([code, signal]) => ({
+    code: typeof code === "number" ? code : null,
+    signal: typeof signal === "string" ? signal : null
+  }))
+
+  child.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "server/discover",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "io.modelcontextprotocol/clientInfo": { name: PAYLOAD_MARKER, version: "1.0.0" }
+        }
+      }
+    })}\n`
+  )
+
+  return { child, exit, firstLine, pid, stderr: () => output.stderr, stdout: () => output.stdout }
+}
+
+const processExists = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const assertProtocolOnlyStdout = (stdout: string): void => {
+  const lines = stdout
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+  expect(lines.length).toBeGreaterThan(0)
+  for (const line of lines) {
+    expect(() => JSON.parse(line)).not.toThrow()
+    expect(line).toContain('"jsonrpc":"2.0"')
+  }
+}
+
+const assertSanitizedStderr = (stderr: string): void => {
+  expect(stderr).not.toContain(SECRET)
+  expect(stderr).not.toContain(PAYLOAD_MARKER)
+}
+
+const ensureStopped = (server: SpawnedServer): void => {
+  if (processExists(server.pid)) server.child.kill("SIGKILL")
+}
+
+describe("built stdio process lifecycle", () => {
+  beforeAll(() => {
+    const child = spawn("pnpm", ["build:mcp"], { cwd: process.cwd(), stdio: "ignore" })
+    return withBound(
+      once(child, "exit").then(([code]) => {
+        if (code !== 0) throw new Error(`pnpm build:mcp exited with ${String(code)}`)
+      }),
+      "MCP build"
+    )
+  })
+
+  it("exits successfully and removes its PID on stdin EOF without MCP_AUTO_EXIT", async () => {
+    const server = spawnServer()
+    try {
+      await withBound(server.firstLine, "stdio discovery")
+      server.child.stdin.end()
+      const result = await withBound(server.exit, "EOF shutdown")
+
+      expect(result).toEqual({ code: 0, signal: null })
+      expect(processExists(server.pid)).toBe(false)
+      assertProtocolOnlyStdout(server.stdout())
+      assertSanitizedStderr(server.stderr())
+    } finally {
+      ensureStopped(server)
+    }
+  })
+
+  it("runs bounded cleanup and removes its PID on SIGTERM", async () => {
+    const server = spawnServer()
+    try {
+      await withBound(server.firstLine, "stdio discovery")
+      server.child.kill("SIGTERM")
+      const result = await withBound(server.exit, "SIGTERM shutdown")
+
+      expect(result).toEqual({ code: 0, signal: null })
+      expect(processExists(server.pid)).toBe(false)
+      assertProtocolOnlyStdout(server.stdout())
+      assertSanitizedStderr(server.stderr())
+    } finally {
+      ensureStopped(server)
+    }
+  })
+
+  it("coalesces racing EOF and SIGTERM without leaving a PID", async () => {
+    const server = spawnServer()
+    try {
+      await withBound(server.firstLine, "stdio discovery")
+      server.child.stdin.end()
+      server.child.kill("SIGTERM")
+      const result = await withBound(server.exit, "racing shutdown")
+
+      expect([0, 1]).toContain(result.code)
+      expect(result.signal).toBeNull()
+      expect(processExists(server.pid)).toBe(false)
+      assertProtocolOnlyStdout(server.stdout())
+      assertSanitizedStderr(server.stderr())
+    } finally {
+      ensureStopped(server)
+    }
+  })
+})

--- a/test/mcp/stdio-process-lifecycle.test.ts
+++ b/test/mcp/stdio-process-lifecycle.test.ts
@@ -4,12 +4,15 @@ import { createServer as createTcpServer, type Socket } from "node:net"
 import { resolve } from "node:path"
 import { createInterface } from "node:readline"
 
+import { Schema } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
 
 const builtServerPath = resolve(process.cwd(), "dist/index.cjs")
 const PROCESS_BOUND_MS = 13_000
 const SECRET = "subprocess-secret-token"
 const PAYLOAD_MARKER = "lifecycle-secret-payload"
+const JsonRpcEnvelopeSchema = Schema.Struct({ id: Schema.Number, jsonrpc: Schema.Literal("2.0") })
+const parseJsonRpcLine = Schema.decodeUnknownSync(Schema.parseJson(JsonRpcEnvelopeSchema))
 
 interface SpawnedServer {
   readonly child: ChildProcessWithoutNullStreams
@@ -65,11 +68,11 @@ const spawnServer = (environment: Readonly<NodeJS.ProcessEnv> = {}): SpawnedServ
   const firstLine = once(lines, "line").then(([line]) => (typeof line === "string" ? line : ""))
   const responseWaiters = new Map<number, (line: string) => void>()
   lines.on("line", (line) => {
-    for (const [id, resolveResponse] of responseWaiters) {
-      if (!line.includes(`"id":${id}`)) continue
-      responseWaiters.delete(id)
-      resolveResponse(line)
-    }
+    const envelope = parseJsonRpcLine(line)
+    const resolveResponse = responseWaiters.get(envelope.id)
+    if (resolveResponse === undefined) return
+    responseWaiters.delete(envelope.id)
+    resolveResponse(line)
   })
   const exit = once(child, "exit").then(([code, signal]) => ({
     code: typeof code === "number" ? code : null,
@@ -113,8 +116,7 @@ const assertProtocolOnlyStdout = (stdout: string): void => {
     .filter((line) => line.length > 0)
   expect(lines.length).toBeGreaterThan(0)
   for (const line of lines) {
-    expect(() => JSON.parse(line)).not.toThrow()
-    expect(line).toContain('"jsonrpc":"2.0"')
+    expect(parseJsonRpcLine(line).jsonrpc).toBe("2.0")
   }
 }
 
@@ -252,7 +254,9 @@ describe("built stdio process lifecycle", () => {
     } finally {
       ensureStopped(server)
       for (const socket of sockets) socket.destroy()
-      stalledHuly.close()
+      await new Promise<void>((resolveClose, reject) => {
+        stalledHuly.close((error) => (error === undefined ? resolveClose() : reject(error)))
+      })
     }
   }, 20_000)
 })

--- a/test/mcp/stdio-process-lifecycle.test.ts
+++ b/test/mcp/stdio-process-lifecycle.test.ts
@@ -1,12 +1,13 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { once } from "node:events"
+import { createServer as createTcpServer, type Socket } from "node:net"
 import { resolve } from "node:path"
 import { createInterface } from "node:readline"
 
 import { beforeAll, describe, expect, it } from "vitest"
 
 const builtServerPath = resolve(process.cwd(), "dist/index.cjs")
-const PROCESS_BOUND_MS = 8_000
+const PROCESS_BOUND_MS = 13_000
 const SECRET = "subprocess-secret-token"
 const PAYLOAD_MARKER = "lifecycle-secret-payload"
 
@@ -17,6 +18,7 @@ interface SpawnedServer {
   readonly pid: number
   readonly stderr: () => string
   readonly stdout: () => string
+  readonly responseLine: (id: number) => Promise<string>
 }
 
 const withBound = <A>(promise: Promise<A>, label: string): Promise<A> =>
@@ -34,7 +36,7 @@ const withBound = <A>(promise: Promise<A>, label: string): Promise<A> =>
     )
   })
 
-const spawnServer = (): SpawnedServer => {
+const spawnServer = (environment: Readonly<NodeJS.ProcessEnv> = {}): SpawnedServer => {
   const { MCP_AUTO_EXIT: _ignoredAutoExit, ...inheritedEnvironment } = process.env
   const child = spawn(process.execPath, [builtServerPath], {
     env: {
@@ -43,7 +45,8 @@ const spawnServer = (): SpawnedServer => {
       HULY_TOKEN: SECRET,
       HULY_URL: "https://huly.example.com",
       HULY_WORKSPACE: "workspace",
-      LAZY_ENVS: "true"
+      LAZY_ENVS: "true",
+      ...environment
     }
   })
   const pid = child.pid
@@ -60,6 +63,14 @@ const spawnServer = (): SpawnedServer => {
   })
   const lines = createInterface({ input: child.stdout })
   const firstLine = once(lines, "line").then(([line]) => (typeof line === "string" ? line : ""))
+  const responseWaiters = new Map<number, (line: string) => void>()
+  lines.on("line", (line) => {
+    for (const [id, resolveResponse] of responseWaiters) {
+      if (!line.includes(`"id":${id}`)) continue
+      responseWaiters.delete(id)
+      resolveResponse(line)
+    }
+  })
   const exit = once(child, "exit").then(([code, signal]) => ({
     code: typeof code === "number" ? code : null,
     signal: typeof signal === "string" ? signal : null
@@ -80,7 +91,10 @@ const spawnServer = (): SpawnedServer => {
     })}\n`
   )
 
-  return { child, exit, firstLine, pid, stderr: () => output.stderr, stdout: () => output.stdout }
+  const responseLine = (id: number): Promise<string> =>
+    new Promise((resolveResponse) => responseWaiters.set(id, resolveResponse))
+
+  return { child, exit, firstLine, pid, responseLine, stderr: () => output.stderr, stdout: () => output.stdout }
 }
 
 const processExists = (pid: number): boolean => {
@@ -164,8 +178,7 @@ describe("built stdio process lifecycle", () => {
       server.child.kill("SIGTERM")
       const result = await withBound(server.exit, "racing shutdown")
 
-      expect([0, 1]).toContain(result.code)
-      expect(result.signal).toBeNull()
+      expect(result).toEqual({ code: 0, signal: null })
       expect(processExists(server.pid)).toBe(false)
       assertProtocolOnlyStdout(server.stdout())
       assertSanitizedStderr(server.stderr())
@@ -173,4 +186,73 @@ describe("built stdio process lifecycle", () => {
       ensureStopped(server)
     }
   })
+
+  it("delivers a response admitted immediately before EOF", async () => {
+    const server = spawnServer()
+    try {
+      await withBound(server.firstLine, "stdio discovery")
+      const response = server.responseLine(2)
+      server.child.stdin.end(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "get_huly_context", arguments: {} }
+        })}\n`
+      )
+
+      expect(await withBound(response, "in-flight response")).toContain('"id":2')
+      expect(await withBound(server.exit, "in-flight EOF shutdown")).toEqual({ code: 0, signal: null })
+      expect(processExists(server.pid)).toBe(false)
+      assertProtocolOnlyStdout(server.stdout())
+      assertSanitizedStderr(server.stderr())
+    } finally {
+      ensureStopped(server)
+    }
+  })
+
+  it("abandons a Huly request on SIGTERM and removes its PID after the drain allowance", async () => {
+    const sockets = new Set<Socket>()
+    const stalledHuly = createTcpServer((socket) => {
+      sockets.add(socket)
+      socket.on("close", () => sockets.delete(socket))
+    })
+    stalledHuly.listen(0, "127.0.0.1")
+    await once(stalledHuly, "listening")
+    const address = stalledHuly.address()
+    if (address === null || typeof address === "string") throw new Error("Stalled Huly server has no TCP port")
+    const server = spawnServer({ HULY_URL: `http://127.0.0.1:${address.port}` })
+
+    try {
+      await withBound(server.firstLine, "stdio discovery")
+      server.child.stdin.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "list_projects", arguments: {} }
+        })}\n`
+      )
+      await withBound(
+        once(stalledHuly, "connection").then(() => {}),
+        "Huly request admission"
+      )
+      server.child.kill("SIGTERM")
+
+      const exit = await withBound(server.exit, "abandoned request shutdown").catch((error: unknown) => {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}; stdout=${server.stdout()}; stderr=${server.stderr()}`
+        )
+      })
+      expect(exit).toEqual({ code: 0, signal: null })
+      expect(processExists(server.pid)).toBe(false)
+      expect(server.stdout()).not.toContain('"id":2')
+      assertProtocolOnlyStdout(server.stdout())
+      assertSanitizedStderr(server.stderr())
+    } finally {
+      ensureStopped(server)
+      for (const socket of sockets) socket.destroy()
+      stalledHuly.close()
+    }
+  }, 20_000)
 })

--- a/test/mcp/stdio-shutdown.property.test.ts
+++ b/test/mcp/stdio-shutdown.property.test.ts
@@ -1,0 +1,65 @@
+import { Effect } from "effect"
+import * as fc from "fast-check"
+import { describe, expect, it } from "vitest"
+
+import {
+  executeBoundedStdioShutdown,
+  makeStdioShutdownCoordinator,
+  type StdioShutdownReason,
+  type StdioShutdownResources
+} from "../../src/mcp/stdio-shutdown.js"
+import { propertyTestParameters } from "../helpers/property.js"
+
+const reasonArbitrary = fc.constantFrom<StdioShutdownReason>(
+  "stdin-eof",
+  "stdin-close",
+  "sigint",
+  "sigterm",
+  "stop",
+  "runtime-interruption"
+)
+
+describe("stdio shutdown coordinator properties", () => {
+  it("keeps the first reason and performs cleanup at most once for every repeated trigger sequence", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(reasonArbitrary, { minLength: 1, maxLength: 30 }), async (reasons) => {
+        const counts = { clients: 0, telemetry: 0, wire: 0 }
+        const resources: StdioShutdownResources = {
+          drain: Effect.void,
+          closeWire: Effect.sync(() => {
+            counts.wire++
+          }),
+          closeTelemetry: Effect.sync(() => {
+            counts.telemetry++
+          }),
+          closeClients: Effect.sync(() => {
+            counts.clients++
+          }),
+          forceExit: () => Effect.void,
+          writeDiagnostic: () => Effect.void
+        }
+
+        const state = await Effect.runPromise(
+          Effect.gen(function* () {
+            const coordinator = yield* makeStdioShutdownCoordinator()
+            for (const reason of reasons) yield* coordinator.request(reason)
+            yield* Effect.all(
+              [
+                executeBoundedStdioShutdown(coordinator, resources),
+                executeBoundedStdioShutdown(coordinator, resources),
+                executeBoundedStdioShutdown(coordinator, resources)
+              ],
+              { concurrency: "unbounded", discard: true }
+            )
+            yield* executeBoundedStdioShutdown(coordinator, resources)
+            return yield* coordinator.state
+          })
+        )
+
+        expect(state).toEqual({ _tag: "Complete", outcome: "graceful", reason: reasons[0] })
+        expect(counts).toEqual({ clients: 1, telemetry: 1, wire: 1 })
+      }),
+      propertyTestParameters
+    )
+  })
+})

--- a/test/mcp/stdio-shutdown.test.ts
+++ b/test/mcp/stdio-shutdown.test.ts
@@ -29,20 +29,6 @@ const makeResources = (
   })
 
 describe("bounded stdio shutdown", () => {
-  it.effect("does not signal completion from an invalid Running transition", () =>
-    Effect.gen(function* () {
-      const coordinator = yield* makeStdioShutdownCoordinator()
-
-      yield* coordinator.complete("graceful")
-      const waiter = yield* coordinator.awaitComplete.pipe(Effect.fork)
-      yield* Effect.yieldNow()
-
-      expect(yield* Fiber.poll(waiter)).toEqual(Option.none())
-      expect(yield* coordinator.state).toEqual({ _tag: "Running" })
-      yield* Fiber.interrupt(waiter)
-    })
-  )
-
   it.effect("uses the first shutdown reason and completes graceful cleanup once", () =>
     Effect.gen(function* () {
       const coordinator = yield* makeStdioShutdownCoordinator()
@@ -57,8 +43,7 @@ describe("bounded stdio shutdown", () => {
       expect(yield* coordinator.request("stdin-eof")).toBe(true)
       expect(yield* coordinator.request("sigterm")).toBe(false)
       yield* executeBoundedStdioShutdown(coordinator, probe.resources)
-      yield* coordinator.beginClosing
-      yield* coordinator.complete("forced")
+      yield* executeBoundedStdioShutdown(coordinator, probe.resources)
 
       expect(yield* coordinator.state).toEqual({ _tag: "Complete", outcome: "graceful", reason: "stdin-eof" })
       expect(yield* Ref.get(closes)).toBe(3)

--- a/test/mcp/stdio-shutdown.test.ts
+++ b/test/mcp/stdio-shutdown.test.ts
@@ -1,0 +1,84 @@
+import { it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Option, Ref, TestClock } from "effect"
+import { describe, expect } from "vitest"
+
+import {
+  executeBoundedStdioShutdown,
+  makeStdioShutdownCoordinator,
+  type StdioShutdownResources
+} from "../../src/mcp/stdio-shutdown.js"
+
+const makeResources = (
+  drain: Effect.Effect<void> = Effect.void,
+  closeWire: Effect.Effect<void> = Effect.void,
+  closeTelemetry: Effect.Effect<void> = Effect.void,
+  closeClients: Effect.Effect<void> = Effect.void
+) =>
+  Effect.gen(function* () {
+    const forcedExits = yield* Ref.make(0)
+    const diagnostics = yield* Ref.make<ReadonlyArray<string>>([])
+    const resources: StdioShutdownResources = {
+      drain,
+      closeWire,
+      closeTelemetry,
+      closeClients,
+      forceExit: () => Ref.update(forcedExits, (count) => count + 1),
+      writeDiagnostic: (message) => Ref.update(diagnostics, (messages) => [...messages, message])
+    }
+    return { diagnostics, forcedExits, resources }
+  })
+
+describe("bounded stdio shutdown", () => {
+  it.effect("uses the first shutdown reason and completes graceful cleanup once", () =>
+    Effect.gen(function* () {
+      const coordinator = yield* makeStdioShutdownCoordinator()
+      const closes = yield* Ref.make(0)
+      const probe = yield* makeResources(
+        Effect.void,
+        Ref.update(closes, (count) => count + 1),
+        Ref.update(closes, (count) => count + 1),
+        Ref.update(closes, (count) => count + 1)
+      )
+
+      expect(yield* coordinator.request("stdin-eof")).toBe(true)
+      expect(yield* coordinator.request("sigterm")).toBe(false)
+      yield* executeBoundedStdioShutdown(coordinator, probe.resources)
+      yield* coordinator.beginClosing
+      yield* coordinator.complete("forced")
+
+      expect(yield* coordinator.state).toEqual({ _tag: "Complete", outcome: "graceful", reason: "stdin-eof" })
+      expect(yield* Ref.get(closes)).toBe(3)
+      expect(yield* Ref.get(probe.forcedExits)).toBe(0)
+      expect(yield* Ref.get(probe.diagnostics)).toEqual([])
+    })
+  )
+
+  it.effect("starts cleanup after the drain allowance and forces one nonzero exit at the global deadline", () =>
+    Effect.gen(function* () {
+      const coordinator = yield* makeStdioShutdownCoordinator()
+      const closeStarted = yield* Deferred.make<void>()
+      const stuckDrain = yield* Deferred.make<void>()
+      const stuckClose = yield* Deferred.make<void>()
+      const probe = yield* makeResources(
+        Deferred.await(stuckDrain),
+        Deferred.succeed(closeStarted, undefined).pipe(Effect.zipRight(Deferred.await(stuckClose)))
+      )
+
+      yield* coordinator.request("stop")
+      const shutdownFiber = yield* executeBoundedStdioShutdown(coordinator, probe.resources).pipe(Effect.fork)
+
+      expect(yield* Deferred.poll(closeStarted)).toEqual(Option.none())
+      yield* TestClock.adjust("5 seconds")
+      expect(Option.isSome(yield* Deferred.poll(closeStarted))).toBe(true)
+
+      yield* TestClock.adjust("5 seconds")
+      yield* Fiber.join(shutdownFiber)
+
+      expect(yield* coordinator.state).toEqual({ _tag: "Complete", outcome: "forced", reason: "stop" })
+      expect(yield* Ref.get(probe.forcedExits)).toBe(1)
+      expect(yield* Ref.get(probe.diagnostics)).toEqual([
+        "Huly MCP stdio shutdown exceeded 10 seconds; forcing process exit"
+      ])
+    })
+  )
+})

--- a/test/mcp/stdio-shutdown.test.ts
+++ b/test/mcp/stdio-shutdown.test.ts
@@ -29,6 +29,20 @@ const makeResources = (
   })
 
 describe("bounded stdio shutdown", () => {
+  it.effect("does not signal completion from an invalid Running transition", () =>
+    Effect.gen(function* () {
+      const coordinator = yield* makeStdioShutdownCoordinator()
+
+      yield* coordinator.complete("graceful")
+      const waiter = yield* coordinator.awaitComplete.pipe(Effect.fork)
+      yield* Effect.yieldNow()
+
+      expect(yield* Fiber.poll(waiter)).toEqual(Option.none())
+      expect(yield* coordinator.state).toEqual({ _tag: "Running" })
+      yield* Fiber.interrupt(waiter)
+    })
+  )
+
   it.effect("uses the first shutdown reason and completes graceful cleanup once", () =>
     Effect.gen(function* () {
       const coordinator = yield* makeStdioShutdownCoordinator()

--- a/test/mcp/stdio-transport.test.ts
+++ b/test/mcp/stdio-transport.test.ts
@@ -141,7 +141,7 @@ describe("MCP 2026-07-28 stdio transport with 2025 compatibility", () => {
       const transport = new StdioClientTransport({
         command: process.execPath,
         args: [builtServerPath],
-        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true", MCP_AUTO_EXIT: "true" },
+        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true" },
         stderr: "pipe"
       })
       const client = new Client(
@@ -208,7 +208,7 @@ describe("MCP 2026-07-28 stdio transport with 2025 compatibility", () => {
       const transport = new StdioClientTransport({
         command: process.execPath,
         args: [builtServerPath],
-        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true", MCP_AUTO_EXIT: "true" },
+        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true" },
         stderr: "pipe"
       })
       const client = new Client(
@@ -234,7 +234,7 @@ describe("MCP 2026-07-28 stdio transport with 2025 compatibility", () => {
       const transport = new StdioClientTransport({
         command: process.execPath,
         args: [builtServerPath],
-        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true", MCP_AUTO_EXIT: "true" },
+        env: { ...getDefaultEnvironment(), LAZY_ENVS: "true" },
         stderr: "pipe"
       })
       try {

--- a/test/runtime/huly-clients.test.ts
+++ b/test/runtime/huly-clients.test.ts
@@ -37,7 +37,7 @@ describe("shared Huly client runtime", () => {
   })
 
   it("memoizes resolver construction and supports primed bundles", async () => {
-    const [resolve, , close] = createClientResolver(clientLayer)
+    const { close, resolve } = createClientResolver(clientLayer)
 
     const first = await resolve()
     const second = await resolve()
@@ -46,7 +46,7 @@ describe("shared Huly client runtime", () => {
     await close()
 
     const primed = await Effect.runPromise(buildScopedClientBundle(clientLayer))
-    const [resolvePrimed, prime, closePrimed] = createClientResolver(clientLayer)
+    const { close: closePrimed, prime, resolve: resolvePrimed } = createClientResolver(clientLayer)
     prime(primed)
 
     await expect(resolvePrimed()).resolves.toBe(primed.bundle)
@@ -62,7 +62,7 @@ describe("shared Huly client runtime", () => {
     const recoverableLayer = Layer.suspend(() =>
       available ? clientLayer : Layer.merge(Layer.fail(unavailable), clientLayer)
     )
-    const [resolve, , close] = createClientResolver(recoverableLayer)
+    const { close, resolve } = createClientResolver(recoverableLayer)
 
     await expect(resolve()).rejects.toBeDefined()
     available = true
@@ -76,7 +76,7 @@ describe("shared Huly client runtime", () => {
       failureKind: "refused"
     })
     const failingLayer = Layer.merge(Layer.fail(unavailable), clientLayer)
-    const [resolve, prime, close] = createClientResolver(failingLayer)
+    const { close, prime, resolve } = createClientResolver(failingLayer)
     const primed = await Effect.runPromise(buildScopedClientBundle(clientLayer))
     const failedAcquisition = resolve()
     prime(primed)
@@ -98,7 +98,7 @@ describe("shared Huly client runtime", () => {
         )
       )
     )
-    const [resolve, , close] = createClientResolver(trackedLayer)
+    const { close, resolve } = createClientResolver(trackedLayer)
 
     await resolve()
     await Promise.all([close(), close()])
@@ -109,7 +109,7 @@ describe("shared Huly client runtime", () => {
 
   it("rejects priming after process-scoped clients close", async () => {
     const scoped = await Effect.runPromise(buildScopedClientBundle(clientLayer))
-    const [, prime, close] = createClientResolver(clientLayer)
+    const { close, prime } = createClientResolver(clientLayer)
 
     await close()
 
@@ -154,7 +154,7 @@ describe("shared Huly client runtime", () => {
           )
         )
       )
-      const [resolve, , close] = createClientResolver(startupLayer)
+      const { close, resolve } = createClientResolver(startupLayer)
       const acquisition = resolve()
 
       yield* Deferred.await(started)

--- a/test/runtime/huly-clients.test.ts
+++ b/test/runtime/huly-clients.test.ts
@@ -1,12 +1,13 @@
-import { Effect, Layer } from "effect"
-import { describe, expect, it } from "vitest"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { it } from "@effect/vitest"
+import { describe, expect } from "vitest"
 
 import { HulyClient } from "../../src/huly/client.js"
 import { HulyUnavailableError } from "../../src/huly/errors.js"
 import { HulyStorageClient } from "../../src/huly/storage.js"
 import { normalizeHulyOrigin } from "../../src/huly/unavailable-diagnostics.js"
 import { WorkspaceClient } from "../../src/huly/workspace-client.js"
-import { buildClientBundle, buildScopedClientBundle, createClientResolver } from "../../src/runtime/huly-clients.js"
+import { buildScopedClientBundle, createClientResolver } from "../../src/runtime/huly-clients.js"
 
 const clientLayer = Layer.merge(
   Layer.merge(HulyClient.testLayer({}), HulyStorageClient.testLayer({})),
@@ -31,22 +32,25 @@ describe("shared Huly client runtime", () => {
       expect(await Effect.runPromise(scoped.bundle.workspaceClient.getUserWorkspaces())).toEqual([])
     } finally {
       await scoped.close()
+      await scoped.close()
     }
   })
 
   it("memoizes resolver construction and supports primed bundles", async () => {
-    const [resolve] = createClientResolver(clientLayer)
+    const [resolve, , close] = createClientResolver(clientLayer)
 
     const first = await resolve()
     const second = await resolve()
 
     expect(second).toBe(first)
+    await close()
 
-    const primedBundle = await Effect.runPromise(buildClientBundle(clientLayer))
-    const [resolvePrimed, prime] = createClientResolver(clientLayer)
-    prime(primedBundle)
+    const primed = await Effect.runPromise(buildScopedClientBundle(clientLayer))
+    const [resolvePrimed, prime, closePrimed] = createClientResolver(clientLayer)
+    prime(primed)
 
-    await expect(resolvePrimed()).resolves.toBe(primedBundle)
+    await expect(resolvePrimed()).resolves.toBe(primed.bundle)
+    await closePrimed()
   })
 
   it("evicts an unavailable acquisition so a later call can recover", async () => {
@@ -58,11 +62,12 @@ describe("shared Huly client runtime", () => {
     const recoverableLayer = Layer.suspend(() =>
       available ? clientLayer : Layer.merge(Layer.fail(unavailable), clientLayer)
     )
-    const [resolve] = createClientResolver(recoverableLayer)
+    const [resolve, , close] = createClientResolver(recoverableLayer)
 
     await expect(resolve()).rejects.toBeDefined()
     available = true
     await expect(resolve()).resolves.toBeDefined()
+    await close()
   })
 
   it("does not evict a newer primed bundle after an unavailable acquisition fails", async () => {
@@ -71,12 +76,97 @@ describe("shared Huly client runtime", () => {
       failureKind: "refused"
     })
     const failingLayer = Layer.merge(Layer.fail(unavailable), clientLayer)
-    const [resolve, prime] = createClientResolver(failingLayer)
-    const primedBundle = await Effect.runPromise(buildClientBundle(clientLayer))
+    const [resolve, prime, close] = createClientResolver(failingLayer)
+    const primed = await Effect.runPromise(buildScopedClientBundle(clientLayer))
     const failedAcquisition = resolve()
-    prime(primedBundle)
+    prime(primed)
 
     await expect(failedAcquisition).rejects.toBeDefined()
-    await expect(resolve()).resolves.toBe(primedBundle)
+    await expect(resolve()).resolves.toBe(primed.bundle)
+    await close()
   })
+
+  it("closes an acquired process-scoped client exactly once", async () => {
+    let releases = 0
+    const trackedLayer = Layer.merge(
+      clientLayer,
+      Layer.scopedDiscard(
+        Effect.acquireRelease(Effect.void, () =>
+          Effect.sync(() => {
+            releases++
+          })
+        )
+      )
+    )
+    const [resolve, , close] = createClientResolver(trackedLayer)
+
+    await resolve()
+    await Promise.all([close(), close()])
+
+    expect(releases).toBe(1)
+    await expect(resolve()).rejects.toThrow("Process-scoped Huly clients are closed")
+  })
+
+  it("rejects priming after process-scoped clients close", async () => {
+    const scoped = await Effect.runPromise(buildScopedClientBundle(clientLayer))
+    const [, prime, close] = createClientResolver(clientLayer)
+
+    await close()
+
+    expect(() => prime(scoped)).toThrow("Cannot prime closed process-scoped Huly clients")
+    await scoped.close()
+  })
+
+  it.effect("releases an acquired scope when startup is interrupted", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>()
+      const released = yield* Deferred.make<void>()
+      const continueStartup = yield* Deferred.make<void>()
+      const startupLayer = Layer.merge(
+        clientLayer,
+        Layer.scopedDiscard(
+          Effect.acquireRelease(Effect.void, () => Deferred.succeed(released, undefined)).pipe(
+            Effect.zipRight(Deferred.succeed(started, undefined)),
+            Effect.zipRight(Deferred.await(continueStartup))
+          )
+        )
+      )
+      const acquisition = yield* buildScopedClientBundle(startupLayer).pipe(Effect.fork)
+
+      yield* Deferred.await(started)
+      yield* Fiber.interrupt(acquisition)
+
+      expect(yield* Deferred.isDone(released)).toBe(true)
+    })
+  )
+
+  it.effect("interrupts a process-scoped acquisition when the resolver closes", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>()
+      const released = yield* Deferred.make<void>()
+      const continueStartup = yield* Deferred.make<void>()
+      const startupLayer = Layer.merge(
+        clientLayer,
+        Layer.scopedDiscard(
+          Effect.acquireRelease(Effect.void, () => Deferred.succeed(released, undefined)).pipe(
+            Effect.zipRight(Deferred.succeed(started, undefined)),
+            Effect.zipRight(Deferred.await(continueStartup))
+          )
+        )
+      )
+      const [resolve, , close] = createClientResolver(startupLayer)
+      const acquisition = resolve()
+
+      yield* Deferred.await(started)
+      yield* Effect.promise(close)
+
+      yield* Effect.promise(() =>
+        acquisition.then(
+          () => Promise.reject(new Error("Interrupted acquisition unexpectedly completed")),
+          () => Promise.resolve()
+        )
+      )
+      expect(yield* Deferred.isDone(released)).toBe(true)
+    })
+  )
 })


### PR DESCRIPTION
Closes #233.

## What changed

- Make stdio lifetime unconditionally owned by stdin EOF/close, SIGINT, SIGTERM, or programmatic stop while leaving HTTP ownership unchanged.
- Add one first-reason-wins shutdown coordinator with notification-based ingress draining, a five-second response allowance, concurrent resource closure, and one ten-second global forced-exit watchdog.
- Quiesce new protocol work without acquiring clients, preserve valid MCP output, and close transport, SDK servers, telemetry, and process-scoped Huly clients exactly once.
- Make client acquisition interruption-safe and process-scoped client closure idempotent.
- Add a patch changeset and update integration guidance to remove the obsolete lifecycle flag.

## Acceptance coverage

- Real built `dist/index.cjs` child-process tests cover unconditional EOF exit, SIGTERM, EOF/signal races, PID disappearance, protocol-only stdout, sanitized stderr, a response delivered before EOF exit, and abandonment of a genuinely stalled Huly request.
- Deterministic Effect TestClock tests cover the five/ten-second chronology and forced-exit port without terminating Vitest.
- Property tests cover repeated/racing shutdown reasons, first-reason wins, exact-once cleanup, and stable completion.
- Service tests cover shutdown rejection without client acquisition, notification-based drain, HTTP EOF no-op, interrupted client acquisition, stuck close, and exact-once SDK server/transport/telemetry/client cleanup.

## Verification

- `pnpm check-all`: 268 test files and 4,086 tests passed; coverage 99.52% statements, 99.00% branches, 99.05% functions, 99.57% lines; duplication 1.22%; strict TypeScript and Effect diagnostics clean.
- Full local-Huly integration suite using the documented container URL rewrite: 1,095 passed, 0 failed, 27 skipped (1,122 total).
- Parallel Standards and Spec reviews against `origin/master`: no findings after two remediation/closure rounds.
