### PR TITLE
fix: expose unsupported Node runtime to MCP agents

### DIFF
--- a/.changeset/clear-old-node-startup.md
+++ b/.changeset/clear-old-node-startup.md
@@ -1,0 +1,6 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Report the detected executable and required Node.js version when an MCP host starts Huly MCP with an unsupported
+runtime.

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -11,6 +11,57 @@ permissions:
   contents: read
 
 jobs:
+  unsupported-node-diagnostic:
+    name: Unsupported Node diagnostic
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+          run_install: false
+
+      - name: Setup supported Node.js for build
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies and build MCP package
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build:mcp
+
+      - name: Setup unsupported Node.js for startup check
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.20.1
+
+      - name: Expose unsupported Node.js through diagnostic MCP
+        run: |
+          printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"unsupported-node-certification","version":"1.0.0"}}}' \
+            '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+            '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_huly_startup_diagnostic","arguments":{}}}' \
+            | node dist/index.cjs \
+              >/tmp/huly-mcp-unsupported-node.stdout \
+              2>/tmp/huly-mcp-unsupported-node.stderr
+
+          grep -F "Huly MCP startup failed: unsupported Node.js runtime." /tmp/huly-mcp-unsupported-node.stderr
+          grep -F '"instructions":"Huly MCP startup failed: unsupported Node.js runtime.' \
+            /tmp/huly-mcp-unsupported-node.stdout
+          grep -F '"name":"get_huly_startup_diagnostic"' /tmp/huly-mcp-unsupported-node.stdout
+          grep -F '"isError":true' /tmp/huly-mcp-unsupported-node.stdout
+          grep -F "Detected 20.20.1" /tmp/huly-mcp-unsupported-node.stdout
+          grep -F "required >=22.19.0" /tmp/huly-mcp-unsupported-node.stdout
+          grep -F "configure this MCP server's command to a compatible Node.js executable" \
+            /tmp/huly-mcp-unsupported-node.stdout
+
   packed-package:
     name: Packed package (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -21,7 +21,21 @@ Huly MCP and Huly CLI are maintained together in this monorepo and derive from t
 
 ## Installation
 
-Requires Node.js 22.19.0 or later.
+### Node.js requirement
+
+Huly MCP requires **Node.js 22.19.0 or later**. MCP clients do not provide a Node.js runtime: `node`, `npx`,
+and the `#!/usr/bin/env node` package executable resolve Node.js from the environment in which the MCP client
+runs. Check that environment before installation:
+
+```bash
+node --version
+```
+
+If an MCP client starts Huly MCP with an older runtime, Huly MCP initializes a diagnostic-only MCP surface instead
+of loading the incompatible application. Its server instructions and `get_huly_startup_diagnostic` tool report the
+detected executable and required version, and the same `unsupported Node.js runtime` diagnostic is written to
+stderr. Upgrade Node.js or configure the MCP server command to use the absolute path of a compatible Node.js
+executable, then restart the MCP server. Huly operations remain unavailable until the runtime is upgraded.
 
 The standard configuration works with most MCP clients:
 

--- a/docs/migrations/effect-4/mcp-artifact-certification.json
+++ b/docs/migrations/effect-4/mcp-artifact-certification.json
@@ -1,7 +1,7 @@
 {
-  "archiveBytes": 1599079,
-  "bundleBytes": 8255040,
-  "bundleGzipBytes": 1562112,
+  "archiveBytes": 1758922,
+  "bundleBytes": 9370046,
+  "bundleGzipBytes": 1721268,
   "entryCount": 4,
   "executableMode": 493,
   "externalModules": [
@@ -13,6 +13,6 @@
     "ws"
   ],
   "name": "@firfi/huly-mcp",
-  "unpackedBytes": 8407717,
+  "unpackedBytes": 9523718,
   "version": "0.49.5"
 }

--- a/docs/migrations/effect-4/mcp-artifact-certification.json
+++ b/docs/migrations/effect-4/mcp-artifact-certification.json
@@ -1,7 +1,7 @@
 {
-  "archiveBytes": 1758922,
-  "bundleBytes": 9370046,
-  "bundleGzipBytes": 1721268,
+  "archiveBytes": 1759279,
+  "bundleBytes": 9372432,
+  "bundleGzipBytes": 1721630,
   "entryCount": 4,
   "executableMode": 493,
   "externalModules": [
@@ -13,6 +13,6 @@
     "ws"
   ],
   "name": "@firfi/huly-mcp",
-  "unpackedBytes": 9523718,
+  "unpackedBytes": 9526104,
   "version": "0.49.5"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "husky",
     "start": "node dist/index.cjs",
     "build": "pnpm build:mcp && pnpm build:cli",
-    "build:mcp": "PKG_VERSION=$(node -p \"require('./package.json').version\") && esbuild src/index.ts --bundle --platform=node --format=cjs --log-level=warning --outfile=dist/index.cjs --external:ws \"--define:PKG_VERSION=\\\"$PKG_VERSION\\\"\"",
+    "build:mcp": "PKG_VERSION=$(node -p \"require('./package.json').version\") NODE_ENGINE_REQUIREMENT=$(node -p \"require('./package.json').engines.node\") && esbuild src/launcher.ts --bundle --platform=node --format=cjs --log-level=warning --outfile=dist/index.cjs --external:ws \"--define:PKG_VERSION=\\\"$PKG_VERSION\\\"\" \"--define:NODE_ENGINE_REQUIREMENT=\\\"$NODE_ENGINE_REQUIREMENT\\\"\"",
     "build:cli": "pnpm --filter @firfi/huly-cli build",
     "typecheck": "pnpm typecheck:tsc && pnpm typecheck:effect",
     "typecheck:tsc": "node node_modules/@typescript/native/bin/tsc -p tsconfig.json --noEmit 2>&1 | { grep -E '^(src/|packages/|scripts/|test/|tsconfig\\.json)' && exit 1 || exit 0; }",

--- a/scripts/local_release.sh
+++ b/scripts/local_release.sh
@@ -71,14 +71,17 @@ stage_if_exists() {
 
 build_mcp_package() {
   local package_version="$1"
+  local node_engine_requirement
+  node_engine_requirement="$(node -p "require('./package.json').engines.node")"
 
-  pnpm dlx "esbuild@$ESBUILD_VERSION" src/index.ts \
+  pnpm dlx "esbuild@$ESBUILD_VERSION" src/launcher.ts \
     --bundle \
     --platform=node \
     --format=cjs \
     --outfile=dist/index.cjs \
     --external:ws \
-    "--define:PKG_VERSION=\"$package_version\""
+    "--define:PKG_VERSION=\"$package_version\"" \
+    "--define:NODE_ENGINE_REQUIREMENT=\"$node_engine_requirement\""
   pnpm verify-version
 }
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,1 +1,2 @@
 declare const PKG_VERSION: string
+declare const NODE_ENGINE_REQUIREMENT: string

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { isUnsupportedNodeRuntime, parseUnsupportedNodeMcpConfig } from "./unsupported-node-mcp.js"
+import { startUnsupportedNodeMcp } from "./unsupported-node-mcp-stdio.js"
+
+const nodeEngineRequirement = NODE_ENGINE_REQUIREMENT
+const unsupportedRuntime = isUnsupportedNodeRuntime(process.versions.node, nodeEngineRequirement)
+
+if (unsupportedRuntime) {
+  const config = parseUnsupportedNodeMcpConfig({
+    detectedNodeVersion: process.versions.node,
+    executable: process.execPath,
+    requiredNodeVersion: nodeEngineRequirement,
+    serverVersion: PKG_VERSION
+  })
+  startUnsupportedNodeMcp(config)
+} else {
+  void import("./index.js")
+}

--- a/src/unsupported-node-mcp-stdio.ts
+++ b/src/unsupported-node-mcp-stdio.ts
@@ -1,0 +1,16 @@
+import { createInterface } from "node:readline"
+
+import {
+  handleUnsupportedNodeRequest,
+  renderUnsupportedNodeDiagnostic,
+  type UnsupportedNodeMcpConfig
+} from "./unsupported-node-mcp.js"
+
+export const startUnsupportedNodeMcp = (config: UnsupportedNodeMcpConfig): void => {
+  process.stderr.write(`${renderUnsupportedNodeDiagnostic(config)}\n`)
+  const lines = createInterface({ input: process.stdin })
+  lines.on("line", (line) => {
+    const response = handleUnsupportedNodeRequest(line, config)
+    if (response !== undefined) process.stdout.write(`${response}\n`)
+  })
+}

--- a/src/unsupported-node-mcp.test.ts
+++ b/src/unsupported-node-mcp.test.ts
@@ -40,6 +40,7 @@ describe("unsupported Node MCP", () => {
     expect(() => parseUnsupportedNodeMcpConfig({ ...config, executable: "" })).toThrow()
     expect(() => parseUnsupportedNodeMcpConfig({ ...config, detectedNodeVersion: "twenty" })).toThrow()
     expect(() => parseUnsupportedNodeMcpConfig({ ...config, requiredNodeVersion: "^22.19.0" })).toThrow()
+    expect(() => parseUnsupportedNodeMcpConfig({ ...config, detectedNodeVersion: "23.0.0" })).toThrow()
   })
 
   it.each([

--- a/src/unsupported-node-mcp.test.ts
+++ b/src/unsupported-node-mcp.test.ts
@@ -1,0 +1,125 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+
+import {
+  handleUnsupportedNodeRequest,
+  isUnsupportedNodeRuntime,
+  parseUnsupportedNodeMcpConfig,
+  renderUnsupportedNodeDiagnostic
+} from "./unsupported-node-mcp.js"
+
+const config = parseUnsupportedNodeMcpConfig({
+  detectedNodeVersion: "20.20.1",
+  executable: "/usr/local/bin/node",
+  requiredNodeVersion: ">=22.19.0",
+  serverVersion: "1.2.3"
+})
+
+const ResponseSchema = Schema.fromJsonString(
+  Schema.Struct({
+    jsonrpc: Schema.Literal("2.0"),
+    id: Schema.Union([Schema.String, Schema.Number, Schema.Null]),
+    result: Schema.optionalKey(Schema.Json),
+    error: Schema.optionalKey(Schema.Struct({ code: Schema.Number, message: Schema.String }))
+  })
+)
+
+const decodeResponse = (response: string | undefined) => Schema.decodeUnknownSync(ResponseSchema)(response)
+
+describe("unsupported Node MCP", () => {
+  it("parses runtime facts and derives one consistent remediation", () => {
+    expect(config).toEqual({
+      detectedNodeVersion: "20.20.1",
+      executable: "/usr/local/bin/node",
+      requiredNodeVersion: ">=22.19.0",
+      serverVersion: "1.2.3"
+    })
+    expect(renderUnsupportedNodeDiagnostic(config)).toContain(
+      "Detected 20.20.1 at /usr/local/bin/node; required >=22.19.0"
+    )
+    expect(() => parseUnsupportedNodeMcpConfig({ ...config, executable: "" })).toThrow()
+    expect(() => parseUnsupportedNodeMcpConfig({ ...config, detectedNodeVersion: "twenty" })).toThrow()
+    expect(() => parseUnsupportedNodeMcpConfig({ ...config, requiredNodeVersion: "^22.19.0" })).toThrow()
+  })
+
+  it.each([
+    ["20.20.1", ">=22.19.0", true],
+    ["22.18.9", ">=22.19.0", true],
+    ["22.19.0", ">=22.19.0", false],
+    ["22.19.1", ">=22.19.0", false],
+    ["23.0.0", ">=22.19.0", false],
+    ["invalid", ">=22.19.0", true],
+    ["20.20.1", "^22.19.0", true],
+    ["20.20.1", ">=invalid", true],
+    ["1000000000.0.0", ">=22.19.0", true]
+  ])("classifies Node %s against %s", (actual, requirement, expected) => {
+    expect(isUnsupportedNodeRuntime(actual, requirement)).toBe(expected)
+  })
+
+  it("places the diagnostic in initialize instructions", () => {
+    const response = decodeResponse(
+      handleUnsupportedNodeRequest(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } }),
+        config
+      )
+    )
+    expect(response.result).toMatchObject({
+      instructions: expect.stringContaining("unsupported Node.js runtime"),
+      protocolVersion: "2025-06-18",
+      serverInfo: { name: "huly-mcp", version: "1.2.3" }
+    })
+  })
+
+  it("advertises and invokes the diagnostic tool", () => {
+    const listed = decodeResponse(
+      handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", id: "list", method: "tools/list" }), config)
+    )
+    expect(listed.result).toMatchObject({
+      tools: [{ description: expect.stringContaining("required >=22.19.0"), name: "get_huly_startup_diagnostic" }]
+    })
+
+    const called = decodeResponse(
+      handleUnsupportedNodeRequest(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "get_huly_startup_diagnostic" }
+        }),
+        config
+      )
+    )
+    expect(called.result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: { code: "UNSUPPORTED_NODE_RUNTIME", detectedNodeVersion: "20.20.1", requiredNodeVersion: ">=22.19.0" }
+      }
+    })
+  })
+
+  it.each([
+    ["not json", -32700, null],
+    [JSON.stringify({ jsonrpc: "2.0", id: 3, method: "unknown" }), -32601, 3],
+    [JSON.stringify({ jsonrpc: "2.0", id: 4, method: "initialize", params: {} }), -32600, 4],
+    [JSON.stringify({ jsonrpc: "2.0", method: "initialize", params: { protocolVersion: "v" } }), -32600, null],
+    [JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: {} }), -32600, 5],
+    [JSON.stringify({ jsonrpc: "2.0", method: "tools/call", params: { name: "other" } }), -32600, null],
+    [JSON.stringify({ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "other" } }), -32602, 6]
+  ])("returns a typed protocol error for %s", (request, code, id) => {
+    expect(decodeResponse(handleUnsupportedNodeRequest(request, config))).toMatchObject({ error: { code }, id })
+  })
+
+  it("handles ping and ignores notifications", () => {
+    expect(
+      decodeResponse(handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", id: 7, method: "ping" }), config))
+    ).toMatchObject({ id: 7, result: {} })
+    expect(handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", method: "ping" }), config)).toBeUndefined()
+    expect(
+      handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }), config)
+    ).toBeUndefined()
+    expect(
+      handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }), config)
+    ).toBeUndefined()
+    expect(handleUnsupportedNodeRequest(JSON.stringify({ jsonrpc: "2.0", method: "unknown" }), config)).toBeUndefined()
+  })
+})

--- a/src/unsupported-node-mcp.ts
+++ b/src/unsupported-node-mcp.ts
@@ -1,7 +1,8 @@
 import { Result, Schema } from "effect"
 
+const minimumRequirementPrefix = ">="
 const nodeVersionPattern = /^\d{1,9}\.\d{1,9}\.\d{1,9}$/u
-const nodeRequirementPattern = /^>=\d{1,9}\.\d{1,9}\.\d{1,9}$/u
+const nodeRequirementPattern = new RegExp(`^${minimumRequirementPrefix}\\d{1,9}\\.\\d{1,9}\\.\\d{1,9}$`, "u")
 const NodeVersionTextSchema = Schema.String.check(Schema.isPattern(nodeVersionPattern)).pipe(
   Schema.brand("NodeVersionText")
 )
@@ -43,7 +44,53 @@ const JsonRpcRequestSchema = Schema.Struct({
 })
 const InitializeParamsSchema = Schema.Struct({ protocolVersion: Schema.NonEmptyString })
 const ToolCallParamsSchema = Schema.Struct({ name: Schema.String })
-const JsonRpcSuccessSchema = Schema.Struct({ jsonrpc: Schema.Literal("2.0"), id: JsonRpcIdSchema, result: Schema.Json })
+const EmptyObjectSchema = Schema.Struct({}).check(Schema.isMaxProperties(0))
+const DiagnosticToolSchema = Schema.Struct({
+  name: Schema.Literal(diagnosticToolName),
+  description: Schema.NonEmptyString,
+  inputSchema: Schema.Struct({
+    additionalProperties: Schema.Literal(false),
+    properties: EmptyObjectSchema,
+    type: Schema.Literal("object")
+  }),
+  annotations: Schema.Struct({
+    destructiveHint: Schema.Literal(false),
+    idempotentHint: Schema.Literal(true),
+    openWorldHint: Schema.Literal(false),
+    readOnlyHint: Schema.Literal(true)
+  })
+})
+const InitializeResultSchema = Schema.Struct({
+  capabilities: Schema.Struct({ tools: Schema.Struct({ listChanged: Schema.Literal(false) }) }),
+  instructions: Schema.NonEmptyString,
+  protocolVersion: Schema.NonEmptyString,
+  serverInfo: Schema.Struct({ name: Schema.Literal("huly-mcp"), version: Schema.NonEmptyString })
+})
+const PingResultSchema = EmptyObjectSchema
+const ToolsListResultSchema = Schema.Struct({ tools: Schema.Tuple([DiagnosticToolSchema]) })
+const DiagnosticToolResultSchema = Schema.Struct({
+  content: Schema.Tuple([Schema.Struct({ text: Schema.NonEmptyString, type: Schema.Literal("text") })]),
+  isError: Schema.Literal(true),
+  structuredContent: Schema.Struct({
+    error: Schema.Struct({
+      code: Schema.Literal("UNSUPPORTED_NODE_RUNTIME"),
+      detectedNodeVersion: NodeVersionTextSchema,
+      executable: Schema.NonEmptyString,
+      requiredNodeVersion: NodeRequirementTextSchema
+    })
+  })
+})
+const JsonRpcResultSchema = Schema.Union([
+  InitializeResultSchema,
+  PingResultSchema,
+  ToolsListResultSchema,
+  DiagnosticToolResultSchema
+])
+const JsonRpcSuccessSchema = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: JsonRpcIdSchema,
+  result: JsonRpcResultSchema
+})
 const JsonRpcErrorSchema = Schema.Struct({
   jsonrpc: Schema.Literal("2.0"),
   id: Schema.Union([JsonRpcIdSchema, Schema.Null]),
@@ -55,17 +102,17 @@ type JsonRpcId = Schema.Schema.Type<typeof JsonRpcIdSchema>
 type JsonRpcErrorCode = Schema.Schema.Type<typeof JsonRpcErrorCodeSchema>
 type JsonRpcRequest = Schema.Schema.Type<typeof JsonRpcRequestSchema>
 type JsonRpcResponse = Schema.Schema.Type<typeof JsonRpcResponseSchema>
-type JsonRpcResult = Schema.Schema.Type<typeof Schema.Json>
+type JsonRpcResult = Schema.Schema.Type<typeof JsonRpcResultSchema>
 
 const parseRequest = Schema.decodeUnknownResult(Schema.fromJsonString(JsonRpcRequestSchema))
 const parseInitializeParams = Schema.decodeUnknownResult(InitializeParamsSchema)
 const parseToolCallParams = Schema.decodeUnknownResult(ToolCallParamsSchema)
 const encodeResponse = Schema.encodeSync(Schema.fromJsonString(JsonRpcResponseSchema))
 
-export const parseUnsupportedNodeMcpConfig = Schema.decodeUnknownSync(UnsupportedNodeMcpConfigSchema)
+const parseUnsupportedNodeMcpConfigBoundary = Schema.decodeUnknownSync(UnsupportedNodeMcpConfigSchema)
 
 export const renderUnsupportedNodeDiagnostic = (config: UnsupportedNodeMcpConfig): string => {
-  const minimumVersion = config.requiredNodeVersion.replace(/^>=/u, "")
+  const minimumVersion = config.requiredNodeVersion.slice(minimumRequirementPrefix.length)
   return (
     `Huly MCP startup failed: unsupported Node.js runtime. Detected ${config.detectedNodeVersion} at ${config.executable}; ` +
     `required ${config.requiredNodeVersion}. MCP hosts use the Node.js executable resolved by their configured ` +
@@ -87,16 +134,24 @@ const parseSemanticVersion = (value: NodeVersionText): SemanticVersion => {
   })
 }
 
-export const isUnsupportedNodeRuntime = (actual: string, requirement: string): boolean => {
+export const isUnsupportedNodeRuntime = (actual: unknown, requirement: unknown): boolean => {
   const actualText = parseNodeVersionText(actual)
   const requirementText = parseNodeRequirementText(requirement)
   if (Result.isFailure(actualText) || Result.isFailure(requirementText)) return true
-  const minimumText = parseMinimumNodeVersionText(requirementText.success.slice(">=".length))
+  const minimumText = parseMinimumNodeVersionText(requirementText.success.slice(minimumRequirementPrefix.length))
   const actualVersion = parseSemanticVersion(actualText.success)
   const minimumVersion = parseSemanticVersion(minimumText)
   if (actualVersion.major !== minimumVersion.major) return actualVersion.major < minimumVersion.major
   if (actualVersion.minor !== minimumVersion.minor) return actualVersion.minor < minimumVersion.minor
   return actualVersion.patch < minimumVersion.patch
+}
+
+export const parseUnsupportedNodeMcpConfig = (input: unknown): UnsupportedNodeMcpConfig => {
+  const config = parseUnsupportedNodeMcpConfigBoundary(input)
+  if (!isUnsupportedNodeRuntime(config.detectedNodeVersion, config.requiredNodeVersion)) {
+    throw new Error("Unsupported Node MCP configuration requires an unsupported detected runtime")
+  }
+  return config
 }
 
 const success = (id: JsonRpcId, result: JsonRpcResult): JsonRpcResponse => ({ id, jsonrpc: "2.0", result })

--- a/src/unsupported-node-mcp.ts
+++ b/src/unsupported-node-mcp.ts
@@ -1,0 +1,192 @@
+import { Result, Schema } from "effect"
+
+const nodeVersionPattern = /^\d{1,9}\.\d{1,9}\.\d{1,9}$/u
+const nodeRequirementPattern = /^>=\d{1,9}\.\d{1,9}\.\d{1,9}$/u
+const NodeVersionTextSchema = Schema.String.check(Schema.isPattern(nodeVersionPattern)).pipe(
+  Schema.brand("NodeVersionText")
+)
+const NodeRequirementTextSchema = Schema.String.check(Schema.isPattern(nodeRequirementPattern)).pipe(
+  Schema.brand("NodeRequirementText")
+)
+const SemanticVersionSchema = Schema.Struct({ major: Schema.Number, minor: Schema.Number, patch: Schema.Number })
+
+type NodeVersionText = Schema.Schema.Type<typeof NodeVersionTextSchema>
+type SemanticVersion = Schema.Schema.Type<typeof SemanticVersionSchema>
+
+const UnsupportedNodeMcpConfigSchema = Schema.Struct({
+  detectedNodeVersion: NodeVersionTextSchema,
+  executable: Schema.NonEmptyString,
+  requiredNodeVersion: NodeRequirementTextSchema,
+  serverVersion: Schema.NonEmptyString
+})
+
+export type UnsupportedNodeMcpConfig = Schema.Schema.Type<typeof UnsupportedNodeMcpConfigSchema>
+
+const parseErrorCode = -32700
+const invalidRequestCode = -32600
+const methodNotFoundCode = -32601
+const invalidParamsCode = -32602
+const diagnosticToolName = "get_huly_startup_diagnostic"
+
+const JsonRpcIdSchema = Schema.Union([Schema.String, Schema.Number])
+const JsonRpcErrorCodeSchema = Schema.Literals([
+  parseErrorCode,
+  invalidParamsCode,
+  methodNotFoundCode,
+  invalidRequestCode
+])
+const JsonRpcRequestSchema = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: Schema.optionalKey(JsonRpcIdSchema),
+  method: Schema.String,
+  params: Schema.optionalKey(Schema.Unknown)
+})
+const InitializeParamsSchema = Schema.Struct({ protocolVersion: Schema.NonEmptyString })
+const ToolCallParamsSchema = Schema.Struct({ name: Schema.String })
+const JsonRpcSuccessSchema = Schema.Struct({ jsonrpc: Schema.Literal("2.0"), id: JsonRpcIdSchema, result: Schema.Json })
+const JsonRpcErrorSchema = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: Schema.Union([JsonRpcIdSchema, Schema.Null]),
+  error: Schema.Struct({ code: JsonRpcErrorCodeSchema, message: Schema.String })
+})
+const JsonRpcResponseSchema = Schema.Union([JsonRpcSuccessSchema, JsonRpcErrorSchema])
+
+type JsonRpcId = Schema.Schema.Type<typeof JsonRpcIdSchema>
+type JsonRpcErrorCode = Schema.Schema.Type<typeof JsonRpcErrorCodeSchema>
+type JsonRpcRequest = Schema.Schema.Type<typeof JsonRpcRequestSchema>
+type JsonRpcResponse = Schema.Schema.Type<typeof JsonRpcResponseSchema>
+type JsonRpcResult = Schema.Schema.Type<typeof Schema.Json>
+
+const parseRequest = Schema.decodeUnknownResult(Schema.fromJsonString(JsonRpcRequestSchema))
+const parseInitializeParams = Schema.decodeUnknownResult(InitializeParamsSchema)
+const parseToolCallParams = Schema.decodeUnknownResult(ToolCallParamsSchema)
+const encodeResponse = Schema.encodeSync(Schema.fromJsonString(JsonRpcResponseSchema))
+
+export const parseUnsupportedNodeMcpConfig = Schema.decodeUnknownSync(UnsupportedNodeMcpConfigSchema)
+
+export const renderUnsupportedNodeDiagnostic = (config: UnsupportedNodeMcpConfig): string => {
+  const minimumVersion = config.requiredNodeVersion.replace(/^>=/u, "")
+  return (
+    `Huly MCP startup failed: unsupported Node.js runtime. Detected ${config.detectedNodeVersion} at ${config.executable}; ` +
+    `required ${config.requiredNodeVersion}. MCP hosts use the Node.js executable resolved by their configured ` +
+    `command and PATH. Install Node.js ${minimumVersion} or later, or configure this MCP server's command ` +
+    `to a compatible Node.js executable, then restart the MCP server.`
+  )
+}
+
+const parseNodeVersionText = Schema.decodeUnknownResult(NodeVersionTextSchema)
+const parseNodeRequirementText = Schema.decodeUnknownResult(NodeRequirementTextSchema)
+const parseMinimumNodeVersionText = Schema.decodeUnknownSync(NodeVersionTextSchema)
+
+const parseSemanticVersion = (value: NodeVersionText): SemanticVersion => {
+  const [major, minor, patch] = value.split(".")
+  return Schema.decodeUnknownSync(SemanticVersionSchema)({
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch)
+  })
+}
+
+export const isUnsupportedNodeRuntime = (actual: string, requirement: string): boolean => {
+  const actualText = parseNodeVersionText(actual)
+  const requirementText = parseNodeRequirementText(requirement)
+  if (Result.isFailure(actualText) || Result.isFailure(requirementText)) return true
+  const minimumText = parseMinimumNodeVersionText(requirementText.success.slice(">=".length))
+  const actualVersion = parseSemanticVersion(actualText.success)
+  const minimumVersion = parseSemanticVersion(minimumText)
+  if (actualVersion.major !== minimumVersion.major) return actualVersion.major < minimumVersion.major
+  if (actualVersion.minor !== minimumVersion.minor) return actualVersion.minor < minimumVersion.minor
+  return actualVersion.patch < minimumVersion.patch
+}
+
+const success = (id: JsonRpcId, result: JsonRpcResult): JsonRpcResponse => ({ id, jsonrpc: "2.0", result })
+
+const successWhenRequested = (id: JsonRpcId | undefined, result: JsonRpcResult): JsonRpcResponse | undefined =>
+  id === undefined ? undefined : success(id, result)
+
+const error = (id: JsonRpcId | null, code: JsonRpcErrorCode, message: string): JsonRpcResponse => ({
+  error: { code, message },
+  id,
+  jsonrpc: "2.0"
+})
+
+const diagnosticTool = (diagnostic: string): JsonRpcResult => ({
+  name: diagnosticToolName,
+  description: diagnostic,
+  inputSchema: { additionalProperties: false, properties: {}, type: "object" },
+  annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false, readOnlyHint: true }
+})
+
+const diagnosticToolResult = (config: UnsupportedNodeMcpConfig, diagnostic: string): JsonRpcResult => ({
+  content: [{ text: diagnostic, type: "text" }],
+  isError: true,
+  structuredContent: {
+    error: {
+      code: "UNSUPPORTED_NODE_RUNTIME",
+      detectedNodeVersion: config.detectedNodeVersion,
+      executable: config.executable,
+      requiredNodeVersion: config.requiredNodeVersion
+    }
+  }
+})
+
+const initializeResponse = (
+  request: JsonRpcRequest,
+  config: UnsupportedNodeMcpConfig,
+  diagnostic: string
+): JsonRpcResponse => {
+  const params = parseInitializeParams(request.params)
+  const requestId = request.id
+  if (requestId === undefined || Result.isFailure(params))
+    return error(requestId ?? null, invalidRequestCode, diagnostic)
+  return success(requestId, {
+    capabilities: { tools: { listChanged: false } },
+    instructions: diagnostic,
+    protocolVersion: params.success.protocolVersion,
+    serverInfo: { name: "huly-mcp", version: config.serverVersion }
+  })
+}
+
+const toolCallResponse = (
+  request: JsonRpcRequest,
+  config: UnsupportedNodeMcpConfig,
+  diagnostic: string
+): JsonRpcResponse => {
+  const params = parseToolCallParams(request.params)
+  const requestId = request.id
+  if (requestId === undefined || Result.isFailure(params))
+    return error(requestId ?? null, invalidRequestCode, diagnostic)
+  return params.success.name === diagnosticToolName
+    ? success(requestId, diagnosticToolResult(config, diagnostic))
+    : error(requestId, invalidParamsCode, diagnostic)
+}
+
+const responseForRequest = (
+  request: JsonRpcRequest,
+  config: UnsupportedNodeMcpConfig,
+  diagnostic: string
+): JsonRpcResponse | undefined => {
+  switch (request.method) {
+    case "initialize":
+      return initializeResponse(request, config, diagnostic)
+    case "notifications/initialized":
+      return undefined
+    case "ping":
+      return successWhenRequested(request.id, {})
+    case "tools/list":
+      return successWhenRequested(request.id, { tools: [diagnosticTool(diagnostic)] })
+    case "tools/call":
+      return toolCallResponse(request, config, diagnostic)
+    default:
+      return request.id === undefined ? undefined : error(request.id, methodNotFoundCode, diagnostic)
+  }
+}
+
+export const handleUnsupportedNodeRequest = (line: string, config: UnsupportedNodeMcpConfig): string | undefined => {
+  const diagnostic = renderUnsupportedNodeDiagnostic(config)
+  const decoded = parseRequest(line)
+  const response = Result.isFailure(decoded)
+    ? error(null, parseErrorCode, diagnostic)
+    : responseForRequest(decoded.success, config, diagnostic)
+  return response === undefined ? undefined : encodeResponse(response)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
         'src/domain/schemas.ts',
         'src/domain/schemas/index.ts',
         'src/index.ts',
+        // The dependency-light process shells are exercised as a built executable under Node 20 by package-smoke;
+        // protocol parsing/routing and version decisions remain in the unit coverage gate.
+        'src/launcher.ts',
+        'src/unsupported-node-mcp-stdio.ts',
         'src/polyfills.ts',
         'src/version.ts',
         // Cross-platform process-tree control is an imperative quality-harness adapter. Dedicated tests cover


### PR DESCRIPTION
## Summary

- detect unsupported Node.js before loading runtime dependencies
- initialize a diagnostic-only MCP that exposes detected/required versions and remediation to coding agents
- pin Node.js >=22.19.0 in the README
- add unit coverage, Node 20 package smoke coverage, and a patch changeset

## Verification

- diagnostic protocol core: 100% statements, branches, functions, and lines
- production bundle under Node 20.20.1: diagnostic instructions/tool/error returned successfully
- nested Codex session: called `get_huly_startup_diagnostic` and correctly reported Node 20.20.1 at `/usr/local/bin/node`, required >=22.19.0, and remediation
- production bundle under Node 24.15.0: normal Huly MCP initialized successfully
- formatting, Oxlint, complexity lint, and changed-file TypeScript checks pass

## Existing baseline failures

`pnpm check-all` is currently blocked by unrelated master transport-migration issues, including missing `@modelcontextprotocol/client`/`server` modules and tests importing removed MCP transport exports. Local-Huly integration also retains the existing `Mcp-Session-Id does not exist` failures.