### PR TITLE
feat(mcp): expose custom properties in get_card

### DIFF
--- a/src/domain/schemas/cards.ts
+++ b/src/domain/schemas/cards.ts
@@ -120,7 +120,8 @@ export const CardDetailSchema = Schema.Struct({
   cardSpace: Schema.String,
   version: Schema.optionalKey(CardVersionMetadataSchema),
   modifiedOn: Schema.optional(Schema.Number),
-  createdOn: Schema.optional(Schema.Number)
+  createdOn: Schema.optional(Schema.Number),
+  properties: Schema.optional(Schema.Record(Schema.String, Schema.Unknown))
 })
 export type CardDetail = Schema.Schema.Type<typeof CardDetailSchema>
 

--- a/src/huly/operations/cards.ts
+++ b/src/huly/operations/cards.ts
@@ -244,6 +244,9 @@ export const getCard = (params: GetCardParams): Effect.Effect<CardDetail, GetCar
     }
     const version = cardVersionMetadataFromState(parsedVersion)
 
+    const standardFields = new Set(["content", "parent", "children", "modifiedOn", "createdOn", "space", "version", "history", "deleted", "rank", "title", "name", "creator", "modifiedBy", "createdBy"])
+    const properties = Object.fromEntries(Object.entries(card).filter(([k]) => !standardFields.has(k) && !k.startsWith("_")))
+
     return {
       id: CardId.make(card._id),
       title: cardIdentifier,
@@ -254,7 +257,8 @@ export const getCard = (params: GetCardParams): Effect.Effect<CardDetail, GetCar
       cardSpace: cardSpaceIdentifier,
       ...(version === undefined ? {} : { version }),
       modifiedOn: card.modifiedOn,
-      createdOn: card.createdOn
+      createdOn: card.createdOn,
+      ...(Object.keys(properties).length > 0 ? { properties } : {})
     }
   })
 


### PR DESCRIPTION
Exposes card custom properties through get_card.

Validated on current upstream 0.49.6 with pnpm typecheck:tsc and pnpm exec vitest run test/domain/schemas.test.ts (96 tests).