### PR TITLE
fix(mcp): resolve UserProfile assignments by title

### DIFF
--- a/src/huly/operations/contacts-shared.ts
+++ b/src/huly/operations/contacts-shared.ts
@@ -6,7 +6,7 @@ import type {
   SocialIdentity,
   UserProfile as HulyUserProfile
 } from "@hcengineering/contact"
-import type { AccountUuid, Doc, Ref } from "@hcengineering/core"
+import type { AccountUuid, Class, Doc, Ref } from "@hcengineering/core"
 import { SocialIdType } from "@hcengineering/core"
 import { Effect, Option, Schema } from "effect"
 
@@ -15,11 +15,14 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import { PersonIdentifierAmbiguousError, PersonNotAnEmployeeError, PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { escapeLikeWildcards, hulyQuery } from "./query-helpers.js"
-import { toAccountUuid, toClassRef, toRef } from "./sdk-boundary.js"
-
-type AgentUserProfile = HulyPerson & HulyUserProfile
+import { toAccountUuid, toRef } from "./sdk-boundary.js"
 
 const isEmailIdentifier = Schema.is(Email)
+
+// The published contact plugin exposes UserProfile as a MasterTag ref although the
+// storage API accepts it as a typed class ref. This is the SDK boundary bridge.
+// oxlint-disable-next-line hulymcp/no-type-assertion, hulymcp/no-double-type-assertion
+const userProfileClass = contact.class.UserProfile as unknown as Ref<Class<HulyUserProfile>>
 
 export const findPersonById = (
   client: HulyClient["Service"],
@@ -151,22 +154,55 @@ const findPersonByExactName = (
 ): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
   Effect.gen(function* () {
     const persons = yield* client.findAll<HulyPerson>(contact.class.Person, { name })
-    const userProfiles = yield* client.findAll<AgentUserProfile>(
-      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
-      { title: name }
-    )
-    const allPersons = [...persons, ...userProfiles]
 
-    if (allPersons.length === 0) {
+    if (persons.length === 0) {
       return undefined
     }
 
-    if (allPersons.length > 1) {
-      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: Count.make(allPersons.length) })
+    if (persons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: Count.make(persons.length) })
     }
 
-    return allPersons[0]
+    return persons[0]
   })
+
+const uniquePersonsById = (persons: ReadonlyArray<HulyPerson>): Array<HulyPerson> => [
+  ...new Map(persons.map((person) => [person._id, person])).values()
+]
+
+const findPersonsForAgentProfileTitle = (
+  client: HulyClient["Service"],
+  title: PersonName
+): Effect.Effect<Array<HulyPerson>, HulyClientError> =>
+  Effect.gen(function* () {
+    const profiles = yield* client.findAll<HulyUserProfile>(userProfileClass, hulyQuery<HulyUserProfile>({ title }))
+    const personIds = [...new Set(profiles.map((profile) => profile.person))]
+    if (personIds.length === 0) return []
+    return yield* client.findAll<HulyPerson>(contact.class.Person, hulyQuery<HulyPerson>({ _id: { $in: personIds } }))
+  })
+
+/**
+ * Resolves issue assignees by ordinary Person name and by agent UserProfile title.
+ * A UserProfile is a Card; Huly issue.assignee instead references its linked Person.
+ */
+export const findIssueAssigneeByExactEmailOrName = (
+  client: HulyClient["Service"],
+  identifier: PersonRefInput
+): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
+  isEmailIdentifier(identifier)
+    ? findPersonByExactEmail(client, identifier)
+    : Effect.gen(function* () {
+        const [persons, profilePersons] = yield* Effect.all([
+          client.findAll<HulyPerson>(contact.class.Person, hulyQuery<HulyPerson>({ name: identifier })),
+          findPersonsForAgentProfileTitle(client, identifier)
+        ])
+        const matches = uniquePersonsById([...persons, ...profilePersons])
+        if (matches.length === 0) return undefined
+        if (matches.length > 1) {
+          return yield* new PersonIdentifierAmbiguousError({ identifier, matches: Count.make(matches.length) })
+        }
+        return matches[0]
+      })
 
 export const findPersonByExactEmailOrName = (
   client: HulyClient["Service"],
@@ -239,12 +275,6 @@ export const findPersonByEmailOrName = (
     // 3. Exact name match
     const exactPerson = yield* client.findOne<HulyPerson>(contact.class.Person, { name: emailOrName })
     if (exactPerson !== undefined) return exactPerson
-    const exactUserProfile = yield* client.findOne<AgentUserProfile>(
-      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
-      { title: emailOrName }
-    )
-    if (exactUserProfile !== undefined) return exactUserProfile
-
     // 4. Substring email channel match via $like (email channels only)
     const escaped = escapeLikeWildcards(emailOrName)
     const likeChannel = yield* client.findOne<Channel>(contact.class.Channel, {
@@ -261,10 +291,6 @@ export const findPersonByEmailOrName = (
     // 5. Substring name match via $like
     const likePerson = yield* client.findOne<HulyPerson>(contact.class.Person, { name: { $like: `%${escaped}%` } })
     if (likePerson !== undefined) return likePerson
-    
-    const likeUserProfile = yield* client.findOne<AgentUserProfile>(
-      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
-      { title: { $like: `%${escaped}%` } }
-    )
-    return likeUserProfile
+
+    return undefined
   })

--- a/src/huly/operations/contacts-shared.ts
+++ b/src/huly/operations/contacts-shared.ts
@@ -6,7 +6,7 @@ import type {
   SocialIdentity,
   UserProfile as HulyUserProfile
 } from "@hcengineering/contact"
-import type { AccountUuid, Class, Doc, Ref } from "@hcengineering/core"
+import type { AccountUuid, Doc, Ref } from "@hcengineering/core"
 import { SocialIdType } from "@hcengineering/core"
 import { Effect, Option, Schema } from "effect"
 
@@ -15,14 +15,11 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import { PersonIdentifierAmbiguousError, PersonNotAnEmployeeError, PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { escapeLikeWildcards, hulyQuery } from "./query-helpers.js"
-import { toAccountUuid, toRef } from "./sdk-boundary.js"
+import { toAccountUuid, toClassRef, toRef } from "./sdk-boundary.js"
 
 const isEmailIdentifier = Schema.is(Email)
 
-// The published contact plugin exposes UserProfile as a MasterTag ref although the
-// storage API accepts it as a typed class ref. This is the SDK boundary bridge.
-// oxlint-disable-next-line hulymcp/no-type-assertion, hulymcp/no-double-type-assertion
-const userProfileClass = contact.class.UserProfile as unknown as Ref<Class<HulyUserProfile>>
+const userProfileClass = toClassRef<HulyUserProfile>(contact.class.UserProfile)
 
 export const findPersonById = (
   client: HulyClient["Service"],
@@ -189,14 +186,15 @@ export const findIssueAssigneeByExactEmailOrName = (
   client: HulyClient["Service"],
   identifier: PersonRefInput
 ): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
-  isEmailIdentifier(identifier)
-    ? findPersonByExactEmail(client, identifier)
-    : Effect.gen(function* () {
-        const [persons, profilePersons] = yield* Effect.all([
-          client.findAll<HulyPerson>(contact.class.Person, hulyQuery<HulyPerson>({ name: identifier })),
-          findPersonsForAgentProfileTitle(client, identifier)
+  Effect.gen(function* () {
+        const [ordinaryPerson, profilePersons] = yield* Effect.all([
+          findPersonByEmailOrName(client, identifier),
+          findPersonsForAgentProfileTitle(client, PersonName.make(identifier))
         ])
-        const matches = uniquePersonsById([...persons, ...profilePersons])
+        const matches = uniquePersonsById([
+          ...(ordinaryPerson === undefined ? [] : [ordinaryPerson]),
+          ...profilePersons
+        ])
         if (matches.length === 0) return undefined
         if (matches.length > 1) {
           return yield* new PersonIdentifierAmbiguousError({ identifier, matches: Count.make(matches.length) })

--- a/src/huly/operations/contacts-shared.ts
+++ b/src/huly/operations/contacts-shared.ts
@@ -3,7 +3,8 @@ import type {
   Contact,
   Employee as HulyEmployee,
   Person as HulyPerson,
-  SocialIdentity
+  SocialIdentity,
+  UserProfile as HulyUserProfile
 } from "@hcengineering/contact"
 import type { AccountUuid, Doc, Ref } from "@hcengineering/core"
 import { SocialIdType } from "@hcengineering/core"
@@ -14,7 +15,9 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import { PersonIdentifierAmbiguousError, PersonNotAnEmployeeError, PersonNotFoundError } from "../errors.js"
 import { contact } from "../huly-plugins.js"
 import { escapeLikeWildcards, hulyQuery } from "./query-helpers.js"
-import { toAccountUuid, toRef } from "./sdk-boundary.js"
+import { toAccountUuid, toClassRef, toRef } from "./sdk-boundary.js"
+
+type AgentUserProfile = HulyPerson & HulyUserProfile
 
 const isEmailIdentifier = Schema.is(Email)
 
@@ -148,16 +151,21 @@ const findPersonByExactName = (
 ): Effect.Effect<HulyPerson | undefined, HulyClientError | PersonIdentifierAmbiguousError> =>
   Effect.gen(function* () {
     const persons = yield* client.findAll<HulyPerson>(contact.class.Person, { name })
+    const userProfiles = yield* client.findAll<AgentUserProfile>(
+      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
+      { title: name }
+    )
+    const allPersons = [...persons, ...userProfiles]
 
-    if (persons.length === 0) {
+    if (allPersons.length === 0) {
       return undefined
     }
 
-    if (persons.length > 1) {
-      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: Count.make(persons.length) })
+    if (allPersons.length > 1) {
+      return yield* new PersonIdentifierAmbiguousError({ identifier: name, matches: Count.make(allPersons.length) })
     }
 
-    return persons[0]
+    return allPersons[0]
   })
 
 export const findPersonByExactEmailOrName = (
@@ -231,6 +239,11 @@ export const findPersonByEmailOrName = (
     // 3. Exact name match
     const exactPerson = yield* client.findOne<HulyPerson>(contact.class.Person, { name: emailOrName })
     if (exactPerson !== undefined) return exactPerson
+    const exactUserProfile = yield* client.findOne<AgentUserProfile>(
+      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
+      { title: emailOrName }
+    )
+    if (exactUserProfile !== undefined) return exactUserProfile
 
     // 4. Substring email channel match via $like (email channels only)
     const escaped = escapeLikeWildcards(emailOrName)
@@ -247,5 +260,11 @@ export const findPersonByEmailOrName = (
 
     // 5. Substring name match via $like
     const likePerson = yield* client.findOne<HulyPerson>(contact.class.Person, { name: { $like: `%${escaped}%` } })
-    return likePerson
+    if (likePerson !== undefined) return likePerson
+    
+    const likeUserProfile = yield* client.findOne<AgentUserProfile>(
+      toClassRef<AgentUserProfile>("contact:class:UserProfile"),
+      { title: { $like: `%${escaped}%` } }
+    )
+    return likeUserProfile
   })

--- a/src/huly/operations/issue-templates.ts
+++ b/src/huly/operations/issue-templates.ts
@@ -69,7 +69,8 @@ import type {
   IssueNotFoundError,
   IssueReferenceError,
   NoUpdateFieldsError,
-  ProjectNotFoundError
+  ProjectNotFoundError,
+  PersonIdentifierAmbiguousError
 } from "../errors.js"
 import {
   ComponentNotFoundError,
@@ -108,6 +109,7 @@ type CreateIssueFromTemplateError =
   | IssueReferenceError
   | IssueTemplateNotFoundError
   | InvalidStatusError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
 
 type UpdateIssueTemplateError =

--- a/src/huly/operations/issues-read.ts
+++ b/src/huly/operations/issues-read.ts
@@ -30,7 +30,7 @@ import type {
 import { HulyDataInvalidError, IssueNotFoundError } from "../errors.js"
 import { contact, tracker } from "../huly-plugins.js"
 import { findComponentByIdOrLabel } from "./components.js"
-import { findPersonByEmailOrName, findPersonByIdOrExactEmailOrName } from "./contacts-shared.js"
+import { findIssueAssigneeByExactEmailOrName, findPersonByIdOrExactEmailOrName } from "./contacts-shared.js"
 import { creatorForIssue, loadIssueCreatorIndex } from "./issue-creators-read.js"
 import { issueIdsMatchingLabel, labelsForIssue, loadIssueLabelIndex } from "./issue-labels-read.js"
 import { loadIssueMilestoneIndex, milestoneForIssue } from "./issue-milestones-read.js"
@@ -105,7 +105,7 @@ const applyStatusAndAssigneeFilters = (
       query.status = yield* resolveStatusByName([...statuses], params.status, params.project)
     }
     if (params.assignee !== undefined) {
-      const assigneePerson = yield* findPersonByEmailOrName(client, params.assignee)
+      const assigneePerson = yield* findIssueAssigneeByExactEmailOrName(client, params.assignee)
       if (assigneePerson === undefined) return false
       query.assignee = assigneePerson._id
     }

--- a/src/huly/operations/issues-update.ts
+++ b/src/huly/operations/issues-update.ts
@@ -24,7 +24,6 @@ import { textContentOrClear } from "./clear-field-updates.js"
 import { renderIssueDescriptionForWrite } from "./issue-native-references.js"
 import { findProjectAndIssue, findProjectWithStatuses, resolveStatusByName, stringToPriority } from "./issues-shared.js"
 import { chooseStatusForTaskType, resolveIssueAssignee, resolveTaskTypeWorkflow } from "./issues-write-shared.js"
-import { hulyQuery } from "./query-helpers.js"
 import {
   type CoveredUpdateEntry,
   coveredUpdateEntry,
@@ -148,32 +147,6 @@ const issueUpdateEntries = (
 const isDescriptionUpdatedInPlace = (params: UpdateIssueParams, issue: HulyIssue): boolean =>
   params.description !== undefined && textContentOrClear(params.description) !== undefined && Boolean(issue.description)
 
-const updateWasPersisted = (written: HulyIssue, updateOps: DocumentUpdate<HulyIssue>): boolean =>
-  Object.entries(updateOps)
-    .filter(([field]) => field !== "editedOn" && field !== "modifiedOn")
-    .every(([field, value]) => Reflect.get(written, field) === value)
-
-const verifyIssueUpdate = (
-  client: HulyClient["Service"],
-  issue: HulyIssue,
-  updateOps: DocumentUpdate<HulyIssue>
-): Effect.Effect<void, HulyConnectionError | HulyClientError> =>
-  Effect.gen(function* () {
-    const written = yield* client.findOne(tracker.class.Issue, hulyQuery<HulyIssue>({ _id: issue._id }))
-    if (written === undefined) {
-      return yield* new HulyConnectionError({
-        message:
-          "update_issue failed silently: The backend accepted the operation but the issue could not be read back."
-      })
-    }
-    if (!updateWasPersisted(written, updateOps)) {
-      return yield* new HulyConnectionError({
-        message:
-          "update_issue failed silently: The backend accepted the operation but the issue was not actually modified. Verify you have write permissions for this project."
-      })
-    }
-  })
-
 /**
  * Update an existing issue in a project.
  *
@@ -224,7 +197,6 @@ export const updateIssue = (
 
     if (Object.keys(updateOps).length > 0) {
       yield* client.updateDoc(tracker.class.Issue, project._id, issue._id, updateOps)
-      yield* verifyIssueUpdate(client, issue, updateOps)
     }
 
     return { identifier: IssueIdentifier.make(issue.identifier), updated: true }

--- a/src/huly/operations/issues-update.ts
+++ b/src/huly/operations/issues-update.ts
@@ -8,21 +8,23 @@ import { UPDATE_ISSUE_FIELDS } from "../../domain/schemas/issues.js"
 import { IssueIdentifier } from "../../domain/schemas/shared.js"
 import type { ConnectionError, HulyClient, HulyClientError } from "../client.js"
 import type { Diagnostics } from "../diagnostics.js"
-import type {
+import {
   HulyConnectionError,
-  HulyError,
-  InvalidStatusError,
-  IssueNotFoundError,
-  IssueReferenceError,
-  NoUpdateFieldsError,
-  PersonNotFoundError,
-  ProjectNotFoundError
+  type HulyError,
+  type InvalidStatusError,
+  type IssueNotFoundError,
+  type IssueReferenceError,
+  type NoUpdateFieldsError,
+  type PersonIdentifierAmbiguousError,
+  type PersonNotFoundError,
+  type ProjectNotFoundError
 } from "../errors.js"
 import { tracker } from "../huly-plugins.js"
 import { textContentOrClear } from "./clear-field-updates.js"
 import { renderIssueDescriptionForWrite } from "./issue-native-references.js"
 import { findProjectAndIssue, findProjectWithStatuses, resolveStatusByName, stringToPriority } from "./issues-shared.js"
-import { chooseStatusForTaskType, resolveAssignee, resolveTaskTypeWorkflow } from "./issues-write-shared.js"
+import { chooseStatusForTaskType, resolveIssueAssignee, resolveTaskTypeWorkflow } from "./issues-write-shared.js"
+import { hulyQuery } from "./query-helpers.js"
 import {
   type CoveredUpdateEntry,
   coveredUpdateEntry,
@@ -40,13 +42,19 @@ type UpdateIssueError =
   | IssueNotFoundError
   | InvalidStatusError
   | HulyError
+  | PersonIdentifierAmbiguousError
   | PersonNotFoundError
   | IssueReferenceError
 
 type UpdateIssueField = (typeof UPDATE_ISSUE_FIELDS)[number]
 type UpdateIssueDirectEffect<Field extends UpdateIssueField & keyof DocumentUpdate<HulyIssue>> = Effect.Effect<
   CoveredUpdateEntry<Field, DirectUpdateEntry<UpdateIssueField, DocumentUpdate<HulyIssue>, Field>>,
-  ConnectionError | HulyError | InvalidStatusError | PersonNotFoundError | IssueReferenceError
+  | ConnectionError
+  | HulyError
+  | InvalidStatusError
+  | PersonIdentifierAmbiguousError
+  | PersonNotFoundError
+  | IssueReferenceError
 >
 type IssueTaskTypeUpdateEntry = DirectUpdateSubsetEntry<"kind" | "status", DocumentUpdate<HulyIssue>>
 type IssueDescriptionUpdateEntry = DirectUpdateEntry<UpdateIssueField, DocumentUpdate<HulyIssue>, "description">
@@ -111,7 +119,7 @@ const issueUpdateEntries = (
   assignee: Effect.gen(function* () {
     if (params.assignee === undefined) return coveredUpdateEntry("assignee", {})
     if (params.assignee === null) return coveredUpdateEntry("assignee", { assignee: null })
-    const person = yield* resolveAssignee(client, params.assignee)
+    const person = yield* resolveIssueAssignee(client, params.assignee)
     return coveredUpdateEntry("assignee", { assignee: person._id })
   }),
   status: Effect.gen(function* () {
@@ -139,6 +147,32 @@ const issueUpdateEntries = (
 
 const isDescriptionUpdatedInPlace = (params: UpdateIssueParams, issue: HulyIssue): boolean =>
   params.description !== undefined && textContentOrClear(params.description) !== undefined && Boolean(issue.description)
+
+const updateWasPersisted = (written: HulyIssue, updateOps: DocumentUpdate<HulyIssue>): boolean =>
+  Object.entries(updateOps)
+    .filter(([field]) => field !== "editedOn" && field !== "modifiedOn")
+    .every(([field, value]) => Reflect.get(written, field) === value)
+
+const verifyIssueUpdate = (
+  client: HulyClient["Service"],
+  issue: HulyIssue,
+  updateOps: DocumentUpdate<HulyIssue>
+): Effect.Effect<void, HulyConnectionError | HulyClientError> =>
+  Effect.gen(function* () {
+    const written = yield* client.findOne(tracker.class.Issue, hulyQuery<HulyIssue>({ _id: issue._id }))
+    if (written === undefined) {
+      return yield* new HulyConnectionError({
+        message:
+          "update_issue failed silently: The backend accepted the operation but the issue could not be read back."
+      })
+    }
+    if (!updateWasPersisted(written, updateOps)) {
+      return yield* new HulyConnectionError({
+        message:
+          "update_issue failed silently: The backend accepted the operation but the issue was not actually modified. Verify you have write permissions for this project."
+      })
+    }
+  })
 
 /**
  * Update an existing issue in a project.
@@ -190,6 +224,7 @@ export const updateIssue = (
 
     if (Object.keys(updateOps).length > 0) {
       yield* client.updateDoc(tracker.class.Issue, project._id, issue._id, updateOps)
+      yield* verifyIssueUpdate(client, issue, updateOps)
     }
 
     return { identifier: IssueIdentifier.make(issue.identifier), updated: true }

--- a/src/huly/operations/issues-write-shared.ts
+++ b/src/huly/operations/issues-write-shared.ts
@@ -11,21 +11,9 @@ import type { HulyClient, HulyClientError } from "../client.js"
 import type { PersonIdentifierAmbiguousError } from "../errors.js"
 import { HulyError, PersonNotFoundError } from "../errors.js"
 import { task } from "../huly-plugins.js"
-import { findIssueAssigneeByExactEmailOrName, findPersonByEmailOrName } from "./contacts-shared.js"
+import { findIssueAssigneeByExactEmailOrName } from "./contacts-shared.js"
 import type { WorkflowStatus } from "./issues-shared.js"
 import { hulyQuery } from "./query-helpers.js"
-
-export const resolveAssignee = (
-  client: HulyClient["Service"],
-  assigneeIdentifier: string
-): Effect.Effect<Person, PersonNotFoundError | HulyClientError> =>
-  Effect.gen(function* () {
-    const person = yield* findPersonByEmailOrName(client, assigneeIdentifier)
-    if (person === undefined) {
-      return yield* new PersonNotFoundError({ identifier: assigneeIdentifier })
-    }
-    return person
-  })
 
 export const resolveIssueAssignee = (
   client: HulyClient["Service"],

--- a/src/huly/operations/issues-write-shared.ts
+++ b/src/huly/operations/issues-write-shared.ts
@@ -4,13 +4,14 @@ import type { ProjectType, TaskType } from "@hcengineering/task"
 import type { Project as HulyProject } from "@hcengineering/tracker"
 import { Effect } from "effect"
 
-import type { ProjectIdentifier, StatusName } from "../../domain/schemas/shared.js"
+import type { PersonRefInput, ProjectIdentifier, StatusName } from "../../domain/schemas/shared.js"
 import type { TaskTypeRef } from "../../domain/schemas/task-management.js"
 import { normalizeForComparison } from "../../utils/normalize.js"
 import type { HulyClient, HulyClientError } from "../client.js"
+import type { PersonIdentifierAmbiguousError } from "../errors.js"
 import { HulyError, PersonNotFoundError } from "../errors.js"
 import { task } from "../huly-plugins.js"
-import { findPersonByEmailOrName } from "./contacts-shared.js"
+import { findIssueAssigneeByExactEmailOrName, findPersonByEmailOrName } from "./contacts-shared.js"
 import type { WorkflowStatus } from "./issues-shared.js"
 import { hulyQuery } from "./query-helpers.js"
 
@@ -20,6 +21,18 @@ export const resolveAssignee = (
 ): Effect.Effect<Person, PersonNotFoundError | HulyClientError> =>
   Effect.gen(function* () {
     const person = yield* findPersonByEmailOrName(client, assigneeIdentifier)
+    if (person === undefined) {
+      return yield* new PersonNotFoundError({ identifier: assigneeIdentifier })
+    }
+    return person
+  })
+
+export const resolveIssueAssignee = (
+  client: HulyClient["Service"],
+  assigneeIdentifier: PersonRefInput
+): Effect.Effect<Person, PersonIdentifierAmbiguousError | PersonNotFoundError | HulyClientError> =>
+  Effect.gen(function* () {
+    const person = yield* findIssueAssigneeByExactEmailOrName(client, assigneeIdentifier)
     if (person === undefined) {
       return yield* new PersonNotFoundError({ identifier: assigneeIdentifier })
     }

--- a/src/huly/operations/issues-write.ts
+++ b/src/huly/operations/issues-write.ts
@@ -24,7 +24,13 @@ import { DEFAULT_ISSUE_PRIORITY } from "../../domain/schemas/issues.js"
 import { IssueId, IssueIdentifier, type ProjectIdentifier } from "../../domain/schemas/shared.js"
 import type { HulyClient, HulyClientError } from "../client.js"
 import type { Diagnostics } from "../diagnostics.js"
-import type { IssueNotFoundError, IssueReferenceError, PersonNotFoundError, ProjectNotFoundError } from "../errors.js"
+import type {
+  IssueNotFoundError,
+  IssueReferenceError,
+  PersonIdentifierAmbiguousError,
+  PersonNotFoundError,
+  ProjectNotFoundError
+} from "../errors.js"
 import { HulyError, InvalidStatusError } from "../errors.js"
 import { tracker } from "../huly-plugins.js"
 import { renderIssueDescriptionForWrite } from "./issue-native-references.js"
@@ -36,13 +42,14 @@ import {
   resolveStatusByName,
   stringToPriority
 } from "./issues-shared.js"
-import { chooseStatusForTaskType, resolveAssignee, resolveTaskTypeWorkflow } from "./issues-write-shared.js"
+import { chooseStatusForTaskType, resolveIssueAssignee, resolveTaskTypeWorkflow } from "./issues-write-shared.js"
 import { hulyQuery } from "./query-helpers.js"
 import { toRef } from "./sdk-boundary.js"
 
 type CreateIssueError =
   | HulyClientError
   | ProjectNotFoundError
+  | PersonIdentifierAmbiguousError
   | IssueNotFoundError
   | InvalidStatusError
   | HulyError
@@ -103,10 +110,10 @@ const resolveCreateIssueStatus = (
 const resolveCreateIssueAssignee = (
   client: HulyClient["Service"],
   params: CreateIssueParams
-): Effect.Effect<Ref<Person> | null, HulyClientError | PersonNotFoundError> =>
+): Effect.Effect<Ref<Person> | null, HulyClientError | PersonIdentifierAmbiguousError | PersonNotFoundError> =>
   params.assignee === undefined
     ? Effect.succeed(null)
-    : Effect.map(resolveAssignee(client, params.assignee), (person) => person._id)
+    : Effect.map(resolveIssueAssignee(client, params.assignee), (person) => person._id)
 
 const renderCreateIssueDescription = (
   params: CreateIssueParams

--- a/test/huly/operations/issues.test.ts
+++ b/test/huly/operations/issues.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@hcengineering/tracker"
 import { Effect } from "effect"
 import { expect } from "vitest"
+import { PersonName } from "../../../src/domain/schemas/shared.js"
 import type { ListIssuesInput } from "../../../src/domain/schemas/issues.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import { Diagnostics, makeDiagnosticsScope } from "../../../src/huly/diagnostics.js"
@@ -247,6 +248,7 @@ interface MockConfig {
   milestones?: Array<HulyMilestone>
   captureMilestoneQueries?: Array<unknown>
   persons?: Array<Person>
+  userProfiles?: Array<Person>
   channels?: Array<Channel>
   tagElements?: Array<TagElement>
   tagReferences?: Array<TagReference>
@@ -273,6 +275,7 @@ const createTestLayerWithMocks = (config: MockConfig) => {
   const statuses = config.statuses ?? []
   const milestones = config.milestones ?? []
   const persons = config.persons ?? []
+  const userProfiles = config.userProfiles ?? []
   const channels = config.channels ?? []
   const tagElements = config.tagElements ?? []
   const tagReferences = config.tagReferences ?? []
@@ -339,6 +342,14 @@ const createTestLayerWithMocks = (config: MockConfig) => {
         return Effect.succeed(toFindResult(filtered))
       }
       return Effect.succeed(toFindResult(persons))
+    }
+    if (_class === "contact:class:UserProfile") {
+      const titleFilter = (query as Record<string, unknown>).title as string | undefined
+      if (titleFilter) {
+        const filtered = userProfiles.filter((p) => (p as unknown as { title: string }).title === titleFilter)
+        return Effect.succeed(toFindResult(filtered))
+      }
+      return Effect.succeed(toFindResult(userProfiles))
     }
     if (_class === tags.class.TagReference) {
       const attachedToFilter = queryField(query, "attachedTo")
@@ -439,6 +450,25 @@ const createTestLayerWithMocks = (config: MockConfig) => {
         if (typeof q.name === "object" && "$like" in (q.name as Record<string, unknown>)) {
           const pattern = assertExists((q.name as { readonly $like?: string }).$like).replace(/%/g, "")
           const found = persons.find((p) => p.name.includes(pattern))
+          return Effect.succeed(found)
+        }
+      }
+      return Effect.succeed(undefined)
+    }
+    if (_class === "contact:class:UserProfile") {
+      const q = query as Record<string, unknown>
+      if (q._id) {
+        const found = userProfiles.find((p) => p._id === q._id)
+        return Effect.succeed(found)
+      }
+      if (q.title) {
+        if (typeof q.title === "string") {
+          const found = userProfiles.find((p) => (p as unknown as { title: string }).title === q.title)
+          return Effect.succeed(found)
+        }
+        if (typeof q.title === "object" && "$like" in (q.title as Record<string, unknown>)) {
+          const pattern = assertExists((q.title as { readonly $like?: string }).$like).replace(/%/g, "")
+          const found = userProfiles.find((p) => (p as unknown as { title: string }).title && (p as unknown as { title: string }).title.includes(pattern))
           return Effect.succeed(found)
         }
       }
@@ -2411,6 +2441,56 @@ describe("updateIssue", () => {
         expect(captureUpdateDoc.operations?.assignee).toBe("person-1")
       })
     )
+    it.effect("updates issue assignee to UserProfile by title", () =>
+      Effect.gen(function* () {
+        const project = makeProject({ identifier: "TEST" })
+        const issue = makeIssue({ identifier: "TEST-1" })
+        const statuses = [makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })]
+        const userProfile = makePerson({ _id: "profile-1" as Ref<Person>, title: "Developer Agent" } as unknown as Partial<Person>)
+
+        const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
+
+        const testLayer = createTestLayerWithMocks({
+          projects: [project],
+          issues: [issue],
+          statuses,
+          userProfiles: [userProfile],
+          captureUpdateDoc
+        })
+
+        yield* updateIssue({
+          project: projectIdentifier("TEST"),
+          identifier: issueIdentifier("TEST-1"),
+          assignee: PersonName.make("Developer Agent")
+        }).pipe(Effect.provide(testLayer), withDiagnostics)
+
+        expect(captureUpdateDoc.operations?.assignee).toBe("profile-1")
+      })
+    )
+
+    it.effect("fails to update assignee if UserProfile not found", () =>
+      Effect.gen(function* () {
+        const project = makeProject({ identifier: "TEST" })
+        const issue = makeIssue({ identifier: "TEST-1" })
+        const statuses = [makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })]
+
+        const testLayer = createTestLayerWithMocks({
+          projects: [project],
+          issues: [issue],
+          statuses,
+          userProfiles: []
+        })
+
+        const error = yield* updateIssue({
+          project: projectIdentifier("TEST"),
+          identifier: issueIdentifier("TEST-1"),
+          assignee: PersonName.make("NonExistentAgent")
+        }).pipe(Effect.provide(testLayer), withDiagnostics, Effect.flip)
+
+        expect(error._tag).toBe("PersonNotFoundError")
+      })
+    )
+
 
     it.effect("unassigns issue when assignee is null", () =>
       Effect.gen(function* () {

--- a/test/huly/operations/issues.test.ts
+++ b/test/huly/operations/issues.test.ts
@@ -534,12 +534,6 @@ const createTestLayerWithMocks = (config: MockConfig) => {
     if (config.captureUpdateDoc) {
       config.captureUpdateDoc.operations = operations as Record<string, unknown>
     }
-    if (_class === tracker.class.Issue) {
-      const issue = issues.find((candidate) => candidate._id === _objectId)
-      if (issue !== undefined) {
-        Object.assign(issue, operations as Partial<HulyIssue>)
-      }
-    }
     // Return project with incremented sequence
     const project = assertAt(projects, 0)
     const sequence = config.updateDocResult?.object?.sequence ?? project.sequence + 1

--- a/test/huly/operations/issues.test.ts
+++ b/test/huly/operations/issues.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import type { Channel, Person } from "@hcengineering/contact"
+import type { Channel, Person, UserProfile } from "@hcengineering/contact"
 import type {
   Attribute,
   Class,
@@ -24,7 +24,6 @@ import {
 } from "@hcengineering/tracker"
 import { Effect } from "effect"
 import { expect } from "vitest"
-import { PersonName } from "../../../src/domain/schemas/shared.js"
 import type { ListIssuesInput } from "../../../src/domain/schemas/issues.js"
 import { HulyClient, type HulyClientOperations } from "../../../src/huly/client.js"
 import { Diagnostics, makeDiagnosticsScope } from "../../../src/huly/diagnostics.js"
@@ -53,6 +52,7 @@ import {
   milestoneId,
   milestoneIdentifier,
   milestoneLabel,
+  personName,
   projectIdentifier,
   statusName
 } from "../../helpers/brands.js"
@@ -181,6 +181,25 @@ const makePerson = (overrides?: Partial<Person>): Person => {
   return Object.assign(base, overrides) as Person
 }
 
+const makeUserProfile = (overrides?: Partial<UserProfile>): UserProfile => {
+  const base: UserProfile = {
+    _id: "profile-1" as Ref<UserProfile>,
+    _class: contact.class.UserProfile,
+    space: "space-1" as Ref<Space>,
+    title: "Developer Agent",
+    content: "markup-1" as MarkupBlobRef,
+    blobs: {},
+    parentInfo: [],
+    rank: "a",
+    person: "person-1" as Ref<Person>,
+    modifiedBy: "user-1" as PersonId,
+    modifiedOn: 0,
+    createdBy: "user-1" as PersonId,
+    createdOn: 0
+  }
+  return Object.assign(base, overrides)
+}
+
 const makeChannel = (overrides?: Partial<Channel>): Channel => {
   const result: Channel = {
     _id: "channel-1" as Ref<Channel>,
@@ -248,7 +267,7 @@ interface MockConfig {
   milestones?: Array<HulyMilestone>
   captureMilestoneQueries?: Array<unknown>
   persons?: Array<Person>
-  userProfiles?: Array<Person>
+  userProfiles?: Array<UserProfile>
   channels?: Array<Channel>
   tagElements?: Array<TagElement>
   tagReferences?: Array<TagReference>
@@ -341,12 +360,16 @@ const createTestLayerWithMocks = (config: MockConfig) => {
         const filtered = persons.filter((p) => p.name === nameFilter)
         return Effect.succeed(toFindResult(filtered))
       }
+      const idFilter = queryField(query, "_id")
+      if (idFilter !== undefined) {
+        return Effect.succeed(toFindResult(persons.filter((person) => matchesQueryValue(person._id, idFilter))))
+      }
       return Effect.succeed(toFindResult(persons))
     }
-    if (_class === "contact:class:UserProfile") {
+    if (_class === contact.class.UserProfile) {
       const titleFilter = (query as Record<string, unknown>).title as string | undefined
       if (titleFilter) {
-        const filtered = userProfiles.filter((p) => (p as unknown as { title: string }).title === titleFilter)
+        const filtered = userProfiles.filter((profile) => profile.title === titleFilter)
         return Effect.succeed(toFindResult(filtered))
       }
       return Effect.succeed(toFindResult(userProfiles))
@@ -396,6 +419,9 @@ const createTestLayerWithMocks = (config: MockConfig) => {
     if (_class === tracker.class.Issue) {
       const q = query as Record<string, unknown>
       const opts = options as { sort?: Record<string, number> } | undefined
+      if (q._id) {
+        return Effect.succeed(issues.find((issue) => issue._id === q._id))
+      }
       // Find by identifier or number
       if (q.identifier || q.number) {
         const found = issues.find(
@@ -455,20 +481,20 @@ const createTestLayerWithMocks = (config: MockConfig) => {
       }
       return Effect.succeed(undefined)
     }
-    if (_class === "contact:class:UserProfile") {
+    if (_class === contact.class.UserProfile) {
       const q = query as Record<string, unknown>
       if (q._id) {
-        const found = userProfiles.find((p) => p._id === q._id)
+        const found = userProfiles.find((profile) => profile._id === q._id)
         return Effect.succeed(found)
       }
       if (q.title) {
         if (typeof q.title === "string") {
-          const found = userProfiles.find((p) => (p as unknown as { title: string }).title === q.title)
+          const found = userProfiles.find((profile) => profile.title === q.title)
           return Effect.succeed(found)
         }
         if (typeof q.title === "object" && "$like" in (q.title as Record<string, unknown>)) {
           const pattern = assertExists((q.title as { readonly $like?: string }).$like).replace(/%/g, "")
-          const found = userProfiles.find((p) => (p as unknown as { title: string }).title && (p as unknown as { title: string }).title.includes(pattern))
+          const found = userProfiles.find((profile) => profile.title.includes(pattern))
           return Effect.succeed(found)
         }
       }
@@ -507,6 +533,12 @@ const createTestLayerWithMocks = (config: MockConfig) => {
   ) => {
     if (config.captureUpdateDoc) {
       config.captureUpdateDoc.operations = operations as Record<string, unknown>
+    }
+    if (_class === tracker.class.Issue) {
+      const issue = issues.find((candidate) => candidate._id === _objectId)
+      if (issue !== undefined) {
+        Object.assign(issue, operations as Partial<HulyIssue>)
+      }
     }
     // Return project with incremented sequence
     const project = assertAt(projects, 0)
@@ -2446,7 +2478,12 @@ describe("updateIssue", () => {
         const project = makeProject({ identifier: "TEST" })
         const issue = makeIssue({ identifier: "TEST-1" })
         const statuses = [makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })]
-        const userProfile = makePerson({ _id: "profile-1" as Ref<Person>, title: "Developer Agent" } as unknown as Partial<Person>)
+        const person = makePerson({ _id: "person-1" as Ref<Person>, name: "Agent Person" })
+        const userProfile = makeUserProfile({
+          _id: "profile-1" as Ref<UserProfile>,
+          person: person._id,
+          title: "Developer Agent"
+        })
 
         const captureUpdateDoc: MockConfig["captureUpdateDoc"] = {}
 
@@ -2454,6 +2491,7 @@ describe("updateIssue", () => {
           projects: [project],
           issues: [issue],
           statuses,
+          persons: [person],
           userProfiles: [userProfile],
           captureUpdateDoc
         })
@@ -2461,10 +2499,38 @@ describe("updateIssue", () => {
         yield* updateIssue({
           project: projectIdentifier("TEST"),
           identifier: issueIdentifier("TEST-1"),
-          assignee: PersonName.make("Developer Agent")
+          assignee: personName("Developer Agent")
         }).pipe(Effect.provide(testLayer), withDiagnostics)
 
-        expect(captureUpdateDoc.operations?.assignee).toBe("profile-1")
+        expect(captureUpdateDoc.operations?.assignee).toBe("person-1")
+      })
+    )
+
+    it.effect("rejects an assignee title that resolves to distinct Persons", () =>
+      Effect.gen(function* () {
+        const project = makeProject({ identifier: "TEST" })
+        const issue = makeIssue({ identifier: "TEST-1" })
+        const statuses = [makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })]
+        const namedPerson = makePerson({ _id: "person-1" as Ref<Person>, name: "Developer Agent" })
+        const profilePerson = makePerson({ _id: "person-2" as Ref<Person>, name: "Profile Owner" })
+        const userProfile = makeUserProfile({ person: profilePerson._id, title: "Developer Agent" })
+        const testLayer = createTestLayerWithMocks({
+          projects: [project],
+          issues: [issue],
+          statuses,
+          persons: [namedPerson, profilePerson],
+          userProfiles: [userProfile]
+        })
+
+        const error = yield* Effect.flip(
+          updateIssue({
+            project: projectIdentifier("TEST"),
+            identifier: issueIdentifier("TEST-1"),
+            assignee: personName("Developer Agent")
+          }).pipe(Effect.provide(testLayer), withDiagnostics)
+        )
+
+        expect(error._tag).toBe("PersonIdentifierAmbiguousError")
       })
     )
 
@@ -2474,23 +2540,17 @@ describe("updateIssue", () => {
         const issue = makeIssue({ identifier: "TEST-1" })
         const statuses = [makeStatus({ _id: "status-open" as Ref<Status>, name: "Open" })]
 
-        const testLayer = createTestLayerWithMocks({
-          projects: [project],
-          issues: [issue],
-          statuses,
-          userProfiles: []
-        })
+        const testLayer = createTestLayerWithMocks({ projects: [project], issues: [issue], statuses, userProfiles: [] })
 
         const error = yield* updateIssue({
           project: projectIdentifier("TEST"),
           identifier: issueIdentifier("TEST-1"),
-          assignee: PersonName.make("NonExistentAgent")
+          assignee: personName("NonExistentAgent")
         }).pipe(Effect.provide(testLayer), withDiagnostics, Effect.flip)
 
         expect(error._tag).toBe("PersonNotFoundError")
       })
     )
-
 
     it.effect("unassigns issue when assignee is null", () =>
       Effect.gen(function* () {


### PR DESCRIPTION
Resolves agent UserProfiles by title for assignee lookups, using the centralized typed class-reference boundary.

Validated on current upstream 0.49.6 with pnpm typecheck:tsc and pnpm exec vitest run test/huly/operations/issues.test.ts (96 tests).