### PR TITLE
fix: sanitize operation connection diagnostics

### DIFF
--- a/src/huly/client.ts
+++ b/src/huly/client.ts
@@ -48,7 +48,13 @@ import {
   WorkspaceUrlSlug
 } from "../domain/schemas/shared.js"
 import { concatLink } from "../utils/url.js"
-import { HulyAuthError, HulyConnectionError, HulyUnavailableError } from "./errors-base.js"
+import {
+  HulyAuthError,
+  type HulyConnectionOperation,
+  type HulyConnectionError,
+  HulyUnavailableError,
+  makeOperationConnectionError
+} from "./errors-base.js"
 import { PlatformError } from "./huly-platform.js"
 import {
   markdownInputUrlConfig,
@@ -353,12 +359,9 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
 
         const withClient = <A>(
           op: (client: TxOperations) => Promise<A>,
-          errorMsg: string
+          operation: HulyConnectionOperation
         ): Effect.Effect<A, HulyClientError> =>
-          Effect.tryPromise({
-            try: () => op(client),
-            catch: (e) => new HulyConnectionError({ message: `${errorMsg}: ${String(e)}`, cause: e })
-          })
+          Effect.tryPromise({ try: () => op(client), catch: (error) => makeOperationConnectionError(operation, error) })
 
         const operations: HulyClientOperations = {
           getAccountUuid: () => accountUuid,
@@ -368,19 +371,19 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
           markupUrlConfig,
 
           findAll: <T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, options?: FindOptions<T>) =>
-            withClient((client) => client.findAll(_class, query, options), "findAll failed"),
+            withClient((client) => client.findAll(_class, query, options), "findAll"),
 
           findOne: <T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, options?: FindOptions<T>) =>
-            withClient((client) => client.findOne(_class, query, options), "findOne failed"),
+            withClient((client) => client.findOne(_class, query, options), "findOne"),
 
           findAllInModel: <T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, options?: FindOptions<T>) =>
             withClient(
               (client) => Promise.resolve(client.getModel().findAllSync(_class, query, options)),
-              "findAllInModel failed"
+              "findAllInModel"
             ),
 
           createDoc: <T extends Doc>(_class: Ref<Class<T>>, space: Ref<Space>, attributes: Data<T>, id?: Ref<T>) =>
-            withClient((client) => client.createDoc(_class, space, attributes, id), "createDoc failed"),
+            withClient((client) => client.createDoc(_class, space, attributes, id), "createDoc"),
 
           createDocIfNotMatched: <T extends Doc, M extends Doc>(
             _class: Ref<Class<T>>,
@@ -396,7 +399,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
               apply.notMatch(matchClass, matchQuery)
               await apply.createDoc(_class, space, attributes, id)
               return (await apply.commit()).result ? "applied" : "condition-not-met"
-            }, "conditional createDoc failed"),
+            }, "conditionalCreateDoc"),
 
           updateDoc: <T extends Doc>(
             _class: Ref<Class<T>>,
@@ -404,7 +407,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
             objectId: Ref<T>,
             ops: DocumentUpdate<T>,
             retrieve?: boolean
-          ) => withClient((client) => client.updateDoc(_class, space, objectId, ops, retrieve), "updateDoc failed"),
+          ) => withClient((client) => client.updateDoc(_class, space, objectId, ops, retrieve), "updateDoc"),
 
           updateDocIfMatched: <T extends Doc>(
             _class: Ref<Class<T>>,
@@ -419,7 +422,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
               apply.match(_class, matchQuery)
               await apply.updateDoc(_class, space, objectId, operations)
               return (await apply.commit()).result ? "applied" : "condition-not-met"
-            }, "conditional updateDoc failed"),
+            }, "conditionalUpdateDoc"),
 
           addCollection: <T extends Doc, P extends AttachedDoc>(
             _class: Ref<Class<P>>,
@@ -432,7 +435,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
           ) =>
             withClient(
               (client) => client.addCollection(_class, space, attachedTo, attachedToClass, collection, attributes, id),
-              "addCollection failed"
+              "addCollection"
             ),
 
           updateCollection: <T extends Doc, P extends AttachedDoc>(
@@ -457,7 +460,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
                   operations,
                   retrieve
                 ),
-              "updateCollection failed"
+              "updateCollection"
             ),
 
           removeCollection: <T extends Doc, P extends AttachedDoc>(
@@ -470,11 +473,11 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
           ) =>
             withClient(
               (client) => client.removeCollection(_class, space, objectId, attachedTo, attachedToClass, collection),
-              "removeCollection failed"
+              "removeCollection"
             ),
 
           removeDoc: <T extends Doc>(_class: Ref<Class<T>>, space: Ref<Space>, objectId: Ref<T>) =>
-            withClient((client) => client.removeDoc(_class, space, objectId), "removeDoc failed"),
+            withClient((client) => client.removeDoc(_class, space, objectId), "removeDoc"),
 
           removeDocIfMatched: <T extends Doc>(
             _class: Ref<Class<T>>,
@@ -488,7 +491,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
               apply.match(_class, matchQuery)
               await apply.removeDoc(_class, space, objectId)
               return (await apply.commit()).result ? "applied" : "condition-not-met"
-            }, "conditional removeDoc failed"),
+            }, "conditionalRemoveDoc"),
 
           createMixin: <D extends Doc, M extends D>(
             objectId: Ref<D>,
@@ -499,7 +502,7 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
           ) =>
             withClient(
               (client) => client.createMixin(objectId, objectClass, objectSpace, mixin, attributes),
-              "createMixin failed"
+              "createMixin"
             ),
 
           updateMixin: <D extends Doc, M extends D>(
@@ -511,29 +514,29 @@ export class HulyClient extends Context.Service<HulyClient, HulyClientOperations
           ) =>
             withClient(
               (client) => client.updateMixin(objectId, objectClass, objectSpace, mixin, attributes),
-              "updateMixin failed"
+              "updateMixin"
             ),
 
           uploadMarkup: (objectClass, objectId, objectAttr, markup, format) =>
             Effect.tryPromise({
               try: () => markupOps.uploadMarkup(objectClass, objectId, objectAttr, markup, format),
-              catch: (e) => new HulyConnectionError({ message: `uploadMarkup failed: ${String(e)}`, cause: e })
+              catch: (error) => makeOperationConnectionError("uploadMarkup", error)
             }),
 
           fetchMarkup: (objectClass, objectId, objectAttr, id, format) =>
             Effect.tryPromise({
               try: () => markupOps.fetchMarkup(objectClass, objectId, objectAttr, id, format),
-              catch: (e) => new HulyConnectionError({ message: `fetchMarkup failed: ${String(e)}`, cause: e })
+              catch: (error) => makeOperationConnectionError("fetchMarkup", error)
             }),
 
           updateMarkup: (objectClass, objectId, objectAttr, markup, format) =>
             Effect.tryPromise({
               try: () => markupOps.updateMarkup(objectClass, objectId, objectAttr, markup, format),
-              catch: (e) => new HulyConnectionError({ message: `updateMarkup failed: ${String(e)}`, cause: e })
+              catch: (error) => makeOperationConnectionError("updateMarkup", error)
             }),
 
           searchFulltext: (query, options) =>
-            withClient((client) => client.searchFulltext(query, options), "searchFulltext failed")
+            withClient((client) => client.searchFulltext(query, options), "searchFulltext")
         }
 
         return operations

--- a/src/huly/errors-base.ts
+++ b/src/huly/errors-base.ts
@@ -34,10 +34,79 @@ export class NoUpdateFieldsError extends Schema.TaggedError<NoUpdateFieldsError>
 /**
  * Connection error - network/transport failures.
  */
+export const HulyConnectionOperation = Schema.Literals([
+  "findAll",
+  "findOne",
+  "findAllInModel",
+  "createDoc",
+  "conditionalCreateDoc",
+  "updateDoc",
+  "conditionalUpdateDoc",
+  "addCollection",
+  "updateCollection",
+  "removeCollection",
+  "removeDoc",
+  "conditionalRemoveDoc",
+  "createMixin",
+  "updateMixin",
+  "uploadMarkup",
+  "fetchMarkup",
+  "updateMarkup",
+  "searchFulltext",
+  "getWorkspaceMembers",
+  "getPersonInfo",
+  "updateWorkspaceRole",
+  "getWorkspaceInfo",
+  "getUserWorkspaces",
+  "createWorkspace",
+  "deleteWorkspace",
+  "getUserProfile",
+  "setMyProfile",
+  "createAccessLink",
+  "updateAllowReadOnlyGuests",
+  "updateAllowGuestSignUp",
+  "getRegionInfo"
+])
+export type HulyConnectionOperation = Schema.Schema.Type<typeof HulyConnectionOperation>
+
+export const HulyHttpStatus = Schema.Int.check(Schema.isBetween({ minimum: 100, maximum: 599 })).pipe(
+  Schema.brand("HulyHttpStatus")
+)
+export type HulyHttpStatus = Schema.Schema.Type<typeof HulyHttpStatus>
+
+export const HulyConnectionDiagnostic = Schema.Struct({
+  operation: HulyConnectionOperation,
+  httpStatus: Schema.optionalKey(HulyHttpStatus)
+})
+export type HulyConnectionDiagnostic = Schema.Schema.Type<typeof HulyConnectionDiagnostic>
+
 export class HulyConnectionError extends Schema.TaggedError<HulyConnectionError>()("HulyConnectionError", {
   message: Schema.String,
-  cause: Schema.optional(Schema.Defect())
+  cause: Schema.optional(Schema.Defect()),
+  diagnostic: Schema.optionalKey(HulyConnectionDiagnostic)
 }) {}
+
+const HTTP_ERROR_STATUS_PATTERN = /\bHTTP(?: error)?\s+(?<status>[1-5]\d{2})\b/i
+
+const hulyHttpStatusFromCause = (cause: unknown): HulyHttpStatus | undefined => {
+  if (!(cause instanceof Error)) return undefined
+  const statusText = HTTP_ERROR_STATUS_PATTERN.exec(cause.message)?.groups?.status
+  if (statusText === undefined) return undefined
+  return HulyHttpStatus.make(Number(statusText))
+}
+
+/** Convert an untrusted SDK rejection into caller-safe operation diagnostics. */
+export const makeOperationConnectionError = (
+  operation: HulyConnectionOperation,
+  cause: unknown
+): HulyConnectionError => {
+  const httpStatus = hulyHttpStatusFromCause(cause)
+  const message = `${operation} failed${httpStatus === undefined ? "" : ` with HTTP ${httpStatus}`}`
+  return new HulyConnectionError({
+    message,
+    diagnostic: { operation, ...(httpStatus === undefined ? {} : { httpStatus }) }
+  })
+}
 
 /** Huly returned persisted or runtime data that does not satisfy its expected boundary contract. */
 export class HulyDataInvalidError extends Schema.TaggedError<HulyDataInvalidError>()("HulyDataInvalidError", {

--- a/src/huly/workspace-client.ts
+++ b/src/huly/workspace-client.ts
@@ -34,7 +34,7 @@ import { Context, Effect, Layer } from "effect"
 import { HulyConfigService } from "../config/config.js"
 import type { SpaceId } from "../domain/schemas/shared.js"
 import { authToOptions, type ConnectionConfig, type ConnectionError, connectWithRetry } from "./client.js"
-import { HulyConnectionError } from "./errors-base.js"
+import { type HulyConnectionOperation, makeOperationConnectionError } from "./errors-base.js"
 import { HulySdk, type HulySdkDependencies } from "./sdk-deps.js"
 
 export type WorkspaceClientError = ConnectionError
@@ -105,12 +105,9 @@ export class WorkspaceClient extends Context.Service<WorkspaceClient, WorkspaceC
 
       const withClient = <A>(
         op: (client: AccountClient) => Promise<A>,
-        errorMsg: string
+        operation: HulyConnectionOperation
       ): Effect.Effect<A, WorkspaceClientError> =>
-        Effect.tryPromise({
-          try: () => op(client),
-          catch: (e) => new HulyConnectionError({ message: `${errorMsg}: ${String(e)}`, cause: e })
-        })
+        Effect.tryPromise({ try: () => op(client), catch: (error) => makeOperationConnectionError(operation, error) })
 
       type AccountClientAccessLinkOptions = NonNullable<Parameters<AccountClient["createAccessLink"]>[1]>
 
@@ -135,31 +132,24 @@ export class WorkspaceClient extends Context.Service<WorkspaceClient, WorkspaceC
           : { ...accessLinkIdentityOptions(options), ...accessLinkTimingOptions(options) }
 
       const operations: WorkspaceClientOperations = {
-        getWorkspaceMembers: () => withClient((c) => c.getWorkspaceMembers(), "Failed to get workspace members"),
-        getPersonInfo: (account) => withClient((c) => c.getPersonInfo(account), "Failed to get person info"),
+        getWorkspaceMembers: () => withClient((c) => c.getWorkspaceMembers(), "getWorkspaceMembers"),
+        getPersonInfo: (account) => withClient((c) => c.getPersonInfo(account), "getPersonInfo"),
         updateWorkspaceRole: (account, role) =>
-          withClient((c) => c.updateWorkspaceRole(account, role), "Failed to update workspace role"),
+          withClient((c) => c.updateWorkspaceRole(account, role), "updateWorkspaceRole"),
         getWorkspaceInfo: (updateLastVisit) =>
-          withClient((c) => c.getWorkspaceInfo(updateLastVisit), "Failed to get workspace info"),
-        getUserWorkspaces: () => withClient((c) => c.getUserWorkspaces(), "Failed to get user workspaces"),
-        createWorkspace: (name, region) =>
-          withClient((c) => c.createWorkspace(name, region), "Failed to create workspace"),
-        deleteWorkspace: () => withClient((c) => c.deleteWorkspace(), "Failed to delete workspace"),
-        getUserProfile: (personUuid) => withClient((c) => c.getUserProfile(personUuid), "Failed to get user profile"),
-        setMyProfile: (profile) => withClient((c) => c.setMyProfile(profile), "Failed to set my profile"),
+          withClient((c) => c.getWorkspaceInfo(updateLastVisit), "getWorkspaceInfo"),
+        getUserWorkspaces: () => withClient((c) => c.getUserWorkspaces(), "getUserWorkspaces"),
+        createWorkspace: (name, region) => withClient((c) => c.createWorkspace(name, region), "createWorkspace"),
+        deleteWorkspace: () => withClient((c) => c.deleteWorkspace(), "deleteWorkspace"),
+        getUserProfile: (personUuid) => withClient((c) => c.getUserProfile(personUuid), "getUserProfile"),
+        setMyProfile: (profile) => withClient((c) => c.setMyProfile(profile), "setMyProfile"),
         createAccessLink: (role, options) =>
-          withClient(
-            (c) => c.createAccessLink(role, toAccountClientAccessLinkOptions(options)),
-            "Failed to create access link"
-          ),
+          withClient((c) => c.createAccessLink(role, toAccountClientAccessLinkOptions(options)), "createAccessLink"),
         updateAllowReadOnlyGuests: (readOnlyGuestsAllowed) =>
-          withClient(
-            (c) => c.updateAllowReadOnlyGuests(readOnlyGuestsAllowed),
-            "Failed to update read-only guest setting"
-          ),
+          withClient((c) => c.updateAllowReadOnlyGuests(readOnlyGuestsAllowed), "updateAllowReadOnlyGuests"),
         updateAllowGuestSignUp: (guestSignUpAllowed) =>
-          withClient((c) => c.updateAllowGuestSignUp(guestSignUpAllowed), "Failed to update guest sign-up setting"),
-        getRegionInfo: () => withClient((c) => c.getRegionInfo(), "Failed to get region info")
+          withClient((c) => c.updateAllowGuestSignUp(guestSignUpAllowed), "updateAllowGuestSignUp"),
+        getRegionInfo: () => withClient((c) => c.getRegionInfo(), "getRegionInfo")
       }
 
       return operations

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -247,9 +247,21 @@ const INVALID_PARAMS_TAGS: ReadonlySet<HulyDomainError["_tag"]> = new Set<HulyDo
 const INTERNAL_ERROR_PREFIX: Partial<Record<HulyDomainError["_tag"], string>> = {
   FileUploadError: "File upload error",
   HulyStorageConfigError: "Storage configuration error",
-  HulyConnectionError: "Connection error",
   HulyAuthError: "Authentication error"
 }
+
+const CONNECTION_ERROR_GUIDANCE = "Verify HULY_URL, workspace, and network connectivity before retrying."
+
+/**
+ * Connection failures reach the caller through this single message, so the underlying cause has to
+ * survive: markup operations (issue descriptions, comments) run against the collaborator service
+ * rather than the transactor, and without the cause an HTTP 502 there is indistinguishable from a
+ * misconfigured HULY_URL.
+ */
+const hulyConnectionMessage = (error: HulyConnectionError): string =>
+  error.message.trim() === ""
+    ? `Connection error while communicating with Huly. ${CONNECTION_ERROR_GUIDANCE}`
+    : `Connection error while communicating with Huly: ${error.message}. ${CONNECTION_ERROR_GUIDANCE}`
 
 const hulyUnavailableMessage = (error: HulyUnavailableError): string => {
   const failureGuidance =
@@ -272,12 +284,7 @@ export const mapDomainErrorToMcp = (
     return createErrorResponse(hulyUnavailableMessage(error), McpErrorCode.InternalError, error._tag, warnings)
   }
   if (error instanceof HulyConnectionError) {
-    return createErrorResponse(
-      "Connection error while communicating with Huly. Verify HULY_URL, workspace, and network connectivity before retrying.",
-      McpErrorCode.InternalError,
-      error._tag,
-      warnings
-    )
+    return createErrorResponse(hulyConnectionMessage(error), McpErrorCode.InternalError, error._tag, warnings)
   }
   if (INVALID_PARAMS_TAGS.has(error._tag)) {
     return createErrorResponse(error.message, McpErrorCode.InvalidParams, error._tag, warnings)
@@ -289,28 +296,34 @@ export const mapDomainErrorToMcp = (
 
 export const domainErrorMessage = (error: HulyDomainError): string => mapDomainErrorToMcp(error).content[0].text
 
-const isClientResolutionError = (
-  value: unknown
-): value is HulyUnavailableError | HulyConnectionError | HulyAuthError | HulyStorageConfigError =>
+type ClientResolutionError = HulyUnavailableError | HulyConnectionError | HulyAuthError | HulyStorageConfigError
+
+const isClientResolutionError = (value: unknown): value is ClientResolutionError =>
   value instanceof HulyUnavailableError ||
   value instanceof HulyConnectionError ||
   value instanceof HulyAuthError ||
   value instanceof HulyStorageConfigError
 
-const clientResolutionFailure = (
-  error: unknown
-): HulyUnavailableError | HulyConnectionError | HulyAuthError | HulyStorageConfigError | undefined => {
+const clientResolutionFailure = (error: unknown): ClientResolutionError | undefined => {
   if (isClientResolutionError(error)) return error
   if (!Cause.isCause(error)) return undefined
   return findRecoverableCauseFailure(error, isClientResolutionError)
 }
+
+/**
+ * Client resolution happens while credentials and endpoint URLs are still in play, so a connection
+ * failure raised there is reported without its message; operation-time connection failures keep
+ * theirs through mapDomainErrorToMcp.
+ */
+const redactResolutionDetail = (failure: ClientResolutionError): ClientResolutionError =>
+  failure instanceof HulyConnectionError ? new HulyConnectionError({ message: "" }) : failure
 
 /** Safely preserve known, schema-owned resolver errors and hide all other rejection details. */
 export const mapClientResolutionErrorToMcp = (error: unknown): McpErrorResponseWithMeta => {
   const failure = clientResolutionFailure(error)
   return failure === undefined
     ? mapDomainErrorToMcp(new HulyError({ message: "Failed to initialize Huly clients" }))
-    : mapDomainErrorToMcp(failure)
+    : mapDomainErrorToMcp(redactResolutionDetail(failure))
 }
 
 export const mapClientResolutionCauseToMcp = (cause: Cause.Cause<unknown>): McpErrorResponseWithMeta =>

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -253,15 +253,16 @@ const INTERNAL_ERROR_PREFIX: Partial<Record<HulyDomainError["_tag"], string>> = 
 const CONNECTION_ERROR_GUIDANCE = "Verify HULY_URL, workspace, and network connectivity before retrying."
 
 /**
- * Connection failures reach the caller through this single message, so the underlying cause has to
- * survive: markup operations (issue descriptions, comments) run against the collaborator service
- * rather than the transactor, and without the cause an HTTP 502 there is indistinguishable from a
- * misconfigured HULY_URL.
+ * Markup operations (issue descriptions, comments) run against the collaborator service rather
+ * than the transactor. Preserve only their schema-owned operation and HTTP status diagnostics;
+ * arbitrary SDK exception text can contain credentials, URLs, headers, or response bodies.
  */
-const hulyConnectionMessage = (error: HulyConnectionError): string =>
-  error.message.trim() === ""
+const hulyConnectionMessage = (error: HulyConnectionError): string => {
+  const diagnostic = error.diagnostic
+  return diagnostic === undefined
     ? `Connection error while communicating with Huly. ${CONNECTION_ERROR_GUIDANCE}`
-    : `Connection error while communicating with Huly: ${error.message}. ${CONNECTION_ERROR_GUIDANCE}`
+    : `Connection error while communicating with Huly: ${diagnostic.operation} failed${diagnostic.httpStatus === undefined ? "" : ` with HTTP ${diagnostic.httpStatus}`}. ${CONNECTION_ERROR_GUIDANCE}`
+}
 
 const hulyUnavailableMessage = (error: HulyUnavailableError): string => {
   const failureGuidance =

--- a/test/huly/client.test.ts
+++ b/test/huly/client.test.ts
@@ -31,7 +31,12 @@ import { beforeEach, expect } from "vitest"
 import { HulyConfigService } from "../../src/config/config.js"
 import { HulyTransactionScope } from "../../src/domain/schemas/shared.js"
 import { HulyClient, type HulyClientError } from "../../src/huly/client.js"
-import { HulyAuthError, HulyConnectionError, HulyUnavailableError } from "../../src/huly/errors.js"
+import {
+  HulyAuthError,
+  HulyConnectionError,
+  HulyUnavailableError,
+  makeOperationConnectionError
+} from "../../src/huly/errors.js"
 import { INLINE_COMMENT_MARK_TYPE } from "../../src/huly/operations/inline-comment-mark.js"
 import { MARKDOWN_INPUT_REF_URL } from "../../src/huly/operations/markup.js"
 import { toClassRef, toRef } from "../../src/huly/operations/sdk-boundary.js"
@@ -641,6 +646,16 @@ describe("Connection error classification", () => {
         expect(error.cause).toBe(cause)
       })
     )
+
+    it.effect("drops non-Error operation rejection details", () =>
+      Effect.sync(function () {
+        const error = makeOperationConnectionError("findAll", "token=secret")
+
+        expect(error.message).toBe("findAll failed")
+        expect(error.diagnostic).toEqual({ operation: "findAll" })
+        expect(JSON.stringify(error)).not.toContain("token=secret")
+      })
+    )
   })
 
   describe("HulyAuthError", () => {
@@ -714,14 +729,15 @@ describe("HulyClient.layer (live layer with mocked externals)", () => {
 
     it.effect("wraps errors in HulyConnectionError", () =>
       Effect.gen(function* () {
-        mockFindAll.mockRejectedValue(new Error("network failure"))
+        mockFindAll.mockRejectedValue(new Error("network failure token=secret"))
 
         const client = yield* HulyClient.pipe(Effect.provide(liveClientLayer))
         const error = yield* Effect.flip(client.findAll("c" as DocRef<Class<TestDoc>>, {} as DocumentQuery<TestDoc>))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("findAll failed")
-        expect(error.message).toContain("network failure")
+        expect(error.message).toBe("findAll failed")
+        expect(error).toMatchObject({ diagnostic: { operation: "findAll" } })
+        expect(JSON.stringify(error)).not.toContain("token=secret")
       })
     )
   })
@@ -785,7 +801,8 @@ describe("HulyClient.layer (live layer with mocked externals)", () => {
 
         expect(error._tag).toBe("HulyConnectionError")
         expect(error.message).toContain("findAllInModel failed")
-        expect(error.message).toContain("model query failure")
+        expect(error).toMatchObject({ diagnostic: { operation: "findAllInModel" } })
+        expect(error.message).not.toContain("model query failure")
       })
     )
   })

--- a/test/huly/workspace-client.test.ts
+++ b/test/huly/workspace-client.test.ts
@@ -343,14 +343,15 @@ describe("WorkspaceClient.layer (real layer)", () => {
   describe("error handling (withClient)", () => {
     it.effect("wraps operation rejection as HulyConnectionError", () =>
       Effect.gen(function* () {
-        mockGetWorkspaceMembers.mockRejectedValue(new Error("network failure"))
+        mockGetWorkspaceMembers.mockRejectedValue(new Error("network failure token=secret"))
 
         const client = yield* WorkspaceClient
         const error = yield* Effect.flip(client.getWorkspaceMembers())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get workspace members")
-        expect(error.message).toContain("network failure")
+        expect(error.message).toBe("getWorkspaceMembers failed")
+        expect(error).toMatchObject({ diagnostic: { operation: "getWorkspaceMembers" } })
+        expect(JSON.stringify(error)).not.toContain("token=secret")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -362,7 +363,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.getPersonInfo("p1" as PersonUuid))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get person info")
+        expect(error.message).toContain("getPersonInfo failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -374,7 +375,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.updateWorkspaceRole("acc", AccountRole.User))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to update workspace role")
+        expect(error.message).toContain("updateWorkspaceRole failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -386,7 +387,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.getWorkspaceInfo())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get workspace info")
+        expect(error.message).toContain("getWorkspaceInfo failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -398,7 +399,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.getUserWorkspaces())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get user workspaces")
+        expect(error.message).toContain("getUserWorkspaces failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -410,7 +411,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.createWorkspace("new"))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to create workspace")
+        expect(error.message).toContain("createWorkspace failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -422,7 +423,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.deleteWorkspace())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to delete workspace")
+        expect(error.message).toContain("deleteWorkspace failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -434,7 +435,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.getUserProfile())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get user profile")
+        expect(error.message).toContain("getUserProfile failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -446,7 +447,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.setMyProfile({}))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to set my profile")
+        expect(error.message).toContain("setMyProfile failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -458,7 +459,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.createAccessLink(AccountRole.Guest))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to create access link")
+        expect(error.message).toContain("createAccessLink failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -470,7 +471,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.updateAllowReadOnlyGuests(true))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to update read-only guest setting")
+        expect(error.message).toContain("updateAllowReadOnlyGuests failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -482,7 +483,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.updateAllowGuestSignUp(false))
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to update guest sign-up setting")
+        expect(error.message).toContain("updateAllowGuestSignUp failed")
       }).pipe(Effect.provide(liveLayer))
     )
 
@@ -494,7 +495,7 @@ describe("WorkspaceClient.layer (real layer)", () => {
         const error = yield* Effect.flip(client.getRegionInfo())
 
         expect(error._tag).toBe("HulyConnectionError")
-        expect(error.message).toContain("Failed to get region info")
+        expect(error.message).toContain("getRegionInfo failed")
       }).pipe(Effect.provide(liveLayer))
     )
   })

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -521,14 +521,25 @@ describe("Error Mapping to MCP", () => {
         })
       )
 
-      it.effect("maps HulyConnectionError with errorTag", () =>
+      it.effect("maps HulyConnectionError with errorTag and keeps the underlying cause", () =>
         Effect.sync(function () {
-          const error = new HulyConnectionError({ message: "Network timeout" })
+          const error = new HulyConnectionError({ message: "updateMarkup failed: Error: HTTP error 502" })
           const response = mapDomainErrorToMcp(error)
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InternalError)
           expect(response._meta.errorTag).toBe("HulyConnectionError")
+          expect(assertAt(response.content, 0).text).toBe(
+            "Connection error while communicating with Huly: updateMarkup failed: Error: HTTP error 502. Verify HULY_URL, workspace, and network connectivity before retrying."
+          )
+        })
+      )
+
+      it.effect("maps HulyConnectionError without a message to guidance alone", () =>
+        Effect.sync(function () {
+          const error = new HulyConnectionError({ message: "  " })
+          const response = mapDomainErrorToMcp(error)
+
           expect(assertAt(response.content, 0).text).toBe(
             "Connection error while communicating with Huly. Verify HULY_URL, workspace, and network connectivity before retrying."
           )

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -84,7 +84,8 @@ import {
   TagIdentifierAmbiguousError,
   TagNotFoundError,
   TelegramChannelIdentifierAmbiguousError,
-  WorkbenchApplicationAliasAmbiguousError
+  WorkbenchApplicationAliasAmbiguousError,
+  makeOperationConnectionError
 } from "../../src/huly/errors.js"
 import { normalizeHulyOrigin } from "../../src/huly/unavailable-diagnostics.js"
 import {
@@ -521,28 +522,36 @@ describe("Error Mapping to MCP", () => {
         })
       )
 
-      it.effect("maps HulyConnectionError with errorTag and keeps the underlying cause", () =>
+      it.effect("maps only schema-owned connection diagnostics", () =>
         Effect.sync(function () {
-          const error = new HulyConnectionError({ message: "updateMarkup failed: Error: HTTP error 502" })
+          const error = makeOperationConnectionError(
+            "updateMarkup",
+            new Error("HTTP error 502 from https://user:password@example.test/path?token=secret")
+          )
           const response = mapDomainErrorToMcp(error)
 
           expect(response.isError).toBe(true)
           expect(response._meta.errorCode).toBe(McpErrorCode.InternalError)
           expect(response._meta.errorTag).toBe("HulyConnectionError")
           expect(assertAt(response.content, 0).text).toBe(
-            "Connection error while communicating with Huly: updateMarkup failed: Error: HTTP error 502. Verify HULY_URL, workspace, and network connectivity before retrying."
+            "Connection error while communicating with Huly: updateMarkup failed with HTTP 502. Verify HULY_URL, workspace, and network connectivity before retrying."
           )
+          expect(error.message).toBe("updateMarkup failed with HTTP 502")
+          expect(error.cause).toBeUndefined()
+          expect(JSON.stringify(response)).not.toContain("password")
+          expect(JSON.stringify(response)).not.toContain("token=secret")
         })
       )
 
-      it.effect("maps HulyConnectionError without a message to guidance alone", () =>
+      it.effect("does not expose an arbitrary connection error message", () =>
         Effect.sync(function () {
-          const error = new HulyConnectionError({ message: "  " })
+          const error = new HulyConnectionError({ message: "token=secret" })
           const response = mapDomainErrorToMcp(error)
 
           expect(assertAt(response.content, 0).text).toBe(
             "Connection error while communicating with Huly. Verify HULY_URL, workspace, and network connectivity before retrying."
           )
+          expect(JSON.stringify(response)).not.toContain("token=secret")
         })
       )
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #242.

- replace arbitrary SDK exception text in MCP responses with schema-owned operation diagnostics
- preserve an allowlisted operation name and validated HTTP status while dropping URLs, credentials, headers, response bodies, and non-Error rejection details
- keep resolution-time and resource error redaction unchanged
- add adapter and MCP regression tests covering credential/token-bearing failures

## Merge order

#242 was merged into `master` first with its original commit preserved; this PR then contributed only the hardening commit.

## Validation

- focused adapter/mapping/protocol suite: 258 tests passed
- TypeScript and Effect diagnostics: 0 errors, 0 warnings across 858 files
- build, circular dependency, complexity, schema/registry, behavioral oracle, CLI coverage/package, generated docs, lint, and gitleaks checks passed under Node 22.22.1
- full suite under Node 22: 4,299 tests passed; five spawned-process tests timed out only under all-suite contention and passed when rerun in isolation

Refs #238.