### PR TITLE
fix: report telemetry under the operation, not the dispatcher

### DIFF
--- a/.changeset/proxy-operation-attribution.md
+++ b/.changeset/proxy-operation-attribution.md
@@ -1,0 +1,6 @@
+---
+"@firfi/huly-mcp": patch
+"@firfi/huly-cli": patch
+---
+
+Report the underlying operation as `tool_name` in tool telemetry, and add `call_path` (`direct` or `invoke_tool`) to record how the caller reached it. Since `invoke_tool` is a dispatcher that exists to work around client tool-count limits, a dispatched call and a direct call to the same operation now share one `tool_name`. Replaces `operation_name`.

--- a/docs/diagnostics-vs-telemetry.md
+++ b/docs/diagnostics-vs-telemetry.md
@@ -8,8 +8,12 @@ MCP telemetry uses `HULY_MCP_TELEMETRY`; CLI telemetry uses `HULY_CLI_TELEMETRY`
 
 MCP and CLI share the same PostHog project, but every event includes `surface` (`mcp` or `cli`) and `package_name` (`@firfi/huly-mcp` or `@firfi/huly-cli`) so dashboards can split them cleanly.
 
-Each `tool_called` event preserves `tool_name` as the called tool (including the `invoke_tool` wrapper). `operation_name` identifies the underlying operation: the direct tool name for native MCP and CLI calls, or the catalog-resolved target for `invoke_tool`. Proxy discovery calls retain their own names. Recognized proxy targets are attributed on success and failure, including connection and target argument errors; malformed or unknown proxy targets omit `operation_name`. No additional event is emitted for the target.
+Each `tool_called` event reports the underlying operation in `tool_name`, regardless of how the client reached it. `call_path` records how: `direct` when the client called the tool by name, `invoke_tool` when it was dispatched through the `invoke_tool` wrapper, which exists because most clients cannot accept the full native tool list. Both paths run the same operation, so they share one `tool_name`.
 
-Group new per-operation charts by `operation_name`. For historical direct calls, fall back to `tool_name`; historical `invoke_tool` events have no recoverable target attribution. Filter `surface` when comparing MCP and CLI usage.
+`call_path` is not `resolved_mode`. `resolved_mode` is the tool surface the session was given; `call_path` is how one call reached its operation. A proxy-mode session calls the discovery tools (`list_tool_categories`, `search_tools`, `get_tool_schema`) with `call_path` `direct` and reaches everything else with `call_path` `invoke_tool`.
+
+Dispatch targets are attributed on success and failure, including connection and target argument errors. A malformed or unknown target has no name safe to record — arbitrary caller input may contain workspace data — so those events report `tool_name` as `invoke_tool` with `call_path` `invoke_tool`. No additional event is emitted for the target.
+
+Group per-operation charts by `tool_name` and split by `call_path` to compare dispatch paths. Filter `surface` when comparing MCP and CLI usage. Events captured by version 0.52.2 carry the target in `operation_name` and report `tool_name` as `invoke_tool` for dispatched calls; charts spanning that range need both fields.
 
 If degraded calls need aggregate measurement, telemetry may include sanitized counters or codes only, such as `warning_count` and `warning_codes`.

--- a/src/mcp/protocol-handlers.ts
+++ b/src/mcp/protocol-handlers.ts
@@ -140,18 +140,19 @@ export const fetchLatestNpmVersion = async (fetchImpl: typeof fetch = fetch): Pr
   }
 }
 
-const proxyCallTelemetry = (
-  toolName: string,
-  args: unknown,
-  registry: ToolRegistry
-): Pick<ToolCalledProps, "operationName" | "editMode"> => {
-  if (toolName !== INVOKE_TOOL_TOOL_NAME) return {}
+type ToolCallAttribution = Pick<ToolCalledProps, "toolName" | "callPath" | "editMode">
+
+const proxyCallTelemetry = (toolName: string, args: unknown, registry: ToolRegistry): ToolCallAttribution => {
+  if (toolName !== INVOKE_TOOL_TOOL_NAME) return { toolName, callPath: "direct" }
   const decoded = Schema.decodeUnknownResult(InvokeToolParamsSchema)(args)
-  if (Result.isFailure(decoded)) return {}
-  // Only catalog names are safe analytics dimensions; arbitrary input may contain workspace data.
+  if (Result.isFailure(decoded)) return { toolName, callPath: "invoke_tool" }
+  const target = decoded.success.toolName
+  // Only catalog names are safe analytics dimensions; arbitrary input may contain
+  // workspace data, so an unknown target stays attributed to the dispatcher.
   return {
-    editMode: deriveEditMode(decoded.success.toolName, decoded.success.arguments),
-    ...(registry.tools.has(decoded.success.toolName) ? { operationName: decoded.success.toolName } : {})
+    toolName: registry.tools.has(target) ? target : toolName,
+    callPath: "invoke_tool",
+    editMode: deriveEditMode(target, decoded.success.arguments)
   }
 }
 
@@ -272,20 +273,21 @@ export const createMcpProtocolHandlers = (
         return responseWithNotice
       }
 
-      const returnError = (errorResponse: McpToolResponse, editMode?: string, operationName?: string) => {
+      const returnError = (
+        errorResponse: McpToolResponse,
+        attribution: ToolCallAttribution = { toolName: name, callPath: "direct" }
+      ) => {
         const responseWithNotice = withClaimedNotice(errorResponse)
         const durationMs = clock.currentTimeMillis() - start
         telemetry.toolCalled({
-          toolName: name,
-          ...(operationName === undefined ? {} : { operationName }),
+          ...attribution,
           status: "error",
           clientKind: exposure.context.clientKind,
           resolvedMode: exposure.context.resolvedMode,
           errorTag: responseWithNotice._meta?.errorTag,
           durationMs,
           inputBytes,
-          outputBytes: computeOutputBytes(responseWithNotice),
-          editMode
+          outputBytes: computeOutputBytes(responseWithNotice)
         })
         return toMcpResponse(responseWithNotice)
       }
@@ -345,10 +347,10 @@ export const createMcpProtocolHandlers = (
       ): Promise<McpWireResponse> => {
         if (exposure.context.resolvedMode !== "proxy") return returnError(createUnknownToolError(toolName))
 
-        const { editMode, operationName } = proxyCallTelemetry(toolName, args, exposure.proxyCandidateRegistry)
+        const attribution = proxyCallTelemetry(toolName, args, exposure.proxyCandidateRegistry)
         const clientResolution = await resolveProxyClients(toolName, resolveClients)
         if (clientResolution?._tag === "Failure") {
-          return returnError(clientResolution.response, editMode, operationName)
+          return returnError(clientResolution.response, attribution)
         }
 
         const response = await handleProxyToolCall({
@@ -360,16 +362,14 @@ export const createMcpProtocolHandlers = (
         const responseWithNotice = withClaimedNotice(response)
         const durationMs = clock.currentTimeMillis() - start
         telemetry.toolCalled({
-          toolName,
-          ...(operationName === undefined ? {} : { operationName }),
+          ...attribution,
           status: responseStatus(responseWithNotice),
           clientKind: exposure.context.clientKind,
           resolvedMode: exposure.context.resolvedMode,
           errorTag: responseWithNotice._meta?.errorTag,
           durationMs,
           inputBytes,
-          outputBytes: computeOutputBytes(responseWithNotice),
-          editMode
+          outputBytes: computeOutputBytes(responseWithNotice)
         })
         return toMcpResponse(responseWithNotice)
       }
@@ -385,9 +385,13 @@ export const createMcpProtocolHandlers = (
         const argumentError = nativeArgumentError(tool, args)
         if (argumentError !== undefined) return returnError(argumentError)
 
-        const editMode = deriveEditMode(hulyToolName, args)
+        const attribution: ToolCallAttribution = {
+          toolName: hulyToolName,
+          callPath: "direct",
+          editMode: deriveEditMode(hulyToolName, args)
+        }
         const clientResolution = await resolveClientBundle(resolveClients)
-        if (clientResolution._tag === "Failure") return returnError(clientResolution.response, editMode)
+        if (clientResolution._tag === "Failure") return returnError(clientResolution.response, attribution)
         const { clients } = clientResolution
 
         const response = await nativeCallRegistry.handleToolCall(
@@ -398,19 +402,18 @@ export const createMcpProtocolHandlers = (
           clients.workspaceClient
         )
         const durationMs = clock.currentTimeMillis() - start
-        if (response === null) return returnError(createUnknownToolError(name), editMode)
+        if (response === null) return returnError(createUnknownToolError(name), attribution)
 
         const responseWithNotice = withClaimedNotice(response)
         telemetry.toolCalled({
-          toolName: hulyToolName,
+          ...attribution,
           status: responseStatus(responseWithNotice),
           clientKind: exposure.context.clientKind,
           resolvedMode: exposure.context.resolvedMode,
           errorTag: responseWithNotice._meta?.errorTag,
           durationMs,
           inputBytes,
-          outputBytes: computeOutputBytes(responseWithNotice),
-          editMode
+          outputBytes: computeOutputBytes(responseWithNotice)
         })
 
         return toMcpResponse(responseWithNotice)

--- a/src/telemetry/posthog.ts
+++ b/src/telemetry/posthog.ts
@@ -18,7 +18,7 @@ type SessionStartProperties = {
 
 const ToolCalledPropertiesSchema = Schema.Struct({
   tool_name: Schema.String,
-  operation_name: Schema.optionalKey(Schema.String),
+  call_path: Schema.Literals(["direct", "invoke_tool"]),
   status: Schema.Literals(["success", "error"]),
   duration_ms: Schema.Number,
   client_kind: Schema.optionalKey(Schema.String),
@@ -29,14 +29,6 @@ const ToolCalledPropertiesSchema = Schema.Struct({
   edit_mode: Schema.optionalKey(Schema.String)
 })
 type ToolCalledProperties = Schema.Schema.Type<typeof ToolCalledPropertiesSchema>
-
-const operationProperties = (
-  toolName: string,
-  targetName: string | undefined
-): Pick<ToolCalledProperties, "operation_name"> => {
-  const operationName = targetName ?? (toolName === "invoke_tool" ? undefined : toolName)
-  return operationName === undefined ? {} : { operation_name: operationName }
-}
 
 type FirstListToolsProperties = { readonly client_kind?: string; readonly resolved_mode?: string }
 
@@ -138,7 +130,7 @@ export const createPostHogTelemetry = (
         event: "tool_called",
         properties: {
           tool_name: props.toolName,
-          ...operationProperties(props.toolName, props.operationName),
+          call_path: props.callPath ?? "direct",
           status: props.status,
           duration_ms: props.durationMs,
           ...(props.clientKind !== undefined && { client_kind: props.clientKind }),

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -19,10 +19,19 @@ export type SessionStartProps = {
   readonly toolsets: ReadonlyArray<string> | null
 }
 
+/**
+ * How the caller reached the operation. Distinct from the exposure mode in
+ * `resolvedMode`: a proxy-mode session calls discovery tools directly and reaches
+ * every other operation through the `invoke_tool` dispatcher.
+ */
+export type ToolCallPath = "direct" | "invoke_tool"
+
 // Internal port input; the PostHog adapter schema owns the serialized event properties.
 export type ToolCalledProps = {
+  // The underlying operation, not the dispatcher: a call routed through invoke_tool
+  // reports the resolved target here, so one dimension covers both call paths.
   readonly toolName: string
-  readonly operationName?: string | undefined
+  readonly callPath?: ToolCallPath | undefined
   readonly status: "success" | "error"
   readonly clientKind?: ClientKind | undefined
   readonly resolvedMode?: ToolExposureMode | undefined

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -1555,15 +1555,15 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(schema.isError).toBe(true)
     expect(invoked.isError).toBe(true)
     expect(assertAt(probe.toolCalled, 2).editMode).toBeUndefined()
-    expect(assertAt(probe.toolCalled, 2)).not.toHaveProperty("operationName")
+    expect(assertAt(probe.toolCalled, 2)).toMatchObject({ toolName: "invoke_tool", callPath: "invoke_tool" })
   })
 
   it.each([
-    { toolName: "diagnostic_probe", arguments: "{malformed", operationName: "diagnostic_probe" },
-    { toolName: "private_workspace_content", arguments: {}, operationName: undefined }
+    { toolName: "diagnostic_probe", arguments: "{malformed", reportedToolName: "diagnostic_probe" },
+    { toolName: "private_workspace_content", arguments: {}, reportedToolName: "invoke_tool" }
   ])(
-    "attributes target validation failures without recording unknown target names ($toolName)",
-    async ({ arguments: args, operationName, toolName }) => {
+    "attributes dispatch validation failures without recording unknown target names ($toolName)",
+    async ({ arguments: args, reportedToolName, toolName }) => {
       const probe = createTelemetryProbe()
       const handlers = createMcpProtocolHandlers(
         buildStubClients(),
@@ -1579,8 +1579,11 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
       })
       expect(response.isError).toBe(true)
       expect(probe.toolCalled).toHaveLength(1)
-      expect(probe.toolCalled[0]).toMatchObject({ toolName: "invoke_tool", status: "error" })
-      expect(assertAt(probe.toolCalled, 0).operationName).toBe(operationName)
+      expect(probe.toolCalled[0]).toMatchObject({
+        toolName: reportedToolName,
+        callPath: "invoke_tool",
+        status: "error"
+      })
     }
   )
 
@@ -1606,8 +1609,8 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
     expect(response.isError).not.toBe(true)
     expect(probe.toolCalled).toHaveLength(1)
     expect(probe.toolCalled[0]).toMatchObject({
-      toolName: "invoke_tool",
-      operationName: "diagnostic_probe",
+      toolName: "diagnostic_probe",
+      callPath: "invoke_tool",
       status: "success"
     })
     expect(response.structuredContent?.result).toEqual({
@@ -1732,9 +1735,11 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
       }
     })
     expect(probe.toolCalled).toHaveLength(2)
-    expect(probe.toolCalled.every((call) => call.operationName === "diagnostic_probe" && call.status === "error")).toBe(
-      true
-    )
+    expect(
+      probe.toolCalled.every(
+        (call) => call.toolName === "diagnostic_probe" && call.callPath === "invoke_tool" && call.status === "error"
+      )
+    ).toBe(true)
 
     expect(errorResponse.isError).toBe(true)
     expect(firstText(errorResponse.content)).toBe("Failed to initialize Huly clients")

--- a/test/telemetry/posthog.property.test.ts
+++ b/test/telemetry/posthog.property.test.ts
@@ -46,7 +46,8 @@ const toolCalledArbitrary = fc.record(
     outputBytes: fc.integer({ min: 0, max: 10_000_000 }),
     resolvedMode: fc.constantFrom("native", "proxy"),
     status: fc.constantFrom("success", "error"),
-    toolName: fc.stringMatching(/^[a-z][a-z0-9_]{0,40}$/)
+    toolName: fc.stringMatching(/^[a-z][a-z0-9_]{0,40}$/),
+    callPath: fc.constantFrom("direct", "invoke_tool")
   },
   { requiredKeys: ["durationMs", "status", "toolName"] }
 ) satisfies fc.Arbitrary<ToolCalledProps>
@@ -136,7 +137,7 @@ const expectedEventProperties = (
           duration_ms: operation.props.durationMs,
           status: operation.props.status,
           tool_name: operation.props.toolName,
-          ...(operation.props.toolName === "invoke_tool" ? {} : { operation_name: operation.props.toolName }),
+          call_path: operation.props.callPath ?? "direct",
           ...(operation.props.clientKind === undefined ? {} : { client_kind: operation.props.clientKind }),
           ...(operation.props.editMode === undefined ? {} : { edit_mode: operation.props.editMode }),
           ...(operation.props.errorTag === undefined ? {} : { error_tag: operation.props.errorTag }),

--- a/test/telemetry/posthog.test.ts
+++ b/test/telemetry/posthog.test.ts
@@ -117,24 +117,27 @@ describe("createPostHogTelemetry", () => {
       const call = assertAt(mockCapture.mock.calls, 0)[0]
       expect(call.event).toBe("tool_called")
       expect(call.properties).toMatchObject({ tool_name: "list_issues", status: "success", duration_ms: 42 })
-      expect(call.properties.operation_name).toBe("list_issues")
+      expect(call.properties.call_path).toBe("direct")
     })
 
-    it("preserves the proxy wrapper while attributing the target operation", () => {
+    it("reports a dispatched call under the target operation with the invoke_tool call path", () => {
       const telemetry = createTelemetry(false)
-      telemetry.toolCalled({ toolName: "invoke_tool", operationName: "list_projects", status: "error", durationMs: 42 })
+      telemetry.toolCalled({ toolName: "list_projects", callPath: "invoke_tool", status: "error", durationMs: 42 })
       expect(mockCapture.mock.calls).toHaveLength(1)
       expect(assertAt(mockCapture.mock.calls, 0)[0].properties).toMatchObject({
-        tool_name: "invoke_tool",
-        operation_name: "list_projects",
+        tool_name: "list_projects",
+        call_path: "invoke_tool",
         status: "error"
       })
     })
 
-    it("omits operation attribution for an unresolved proxy target", () => {
+    it("keeps an unresolved dispatch target attributed to the dispatcher", () => {
       const telemetry = createTelemetry(false)
-      telemetry.toolCalled({ toolName: "invoke_tool", status: "error", durationMs: 0 })
-      expect(assertAt(mockCapture.mock.calls, 0)[0].properties).not.toHaveProperty("operation_name")
+      telemetry.toolCalled({ toolName: "invoke_tool", callPath: "invoke_tool", status: "error", durationMs: 0 })
+      expect(assertAt(mockCapture.mock.calls, 0)[0].properties).toMatchObject({
+        tool_name: "invoke_tool",
+        call_path: "invoke_tool"
+      })
     })
 
     it("captures client classification when provided", () => {


### PR DESCRIPTION
## Why

`invoke_tool` is not an operation — it is a transport workaround for clients that cannot accept the full native tool list. `DEFAULT_MODE_BY_CLIENT_KIND` (`src/mcp/tool-mode.ts:84`) defaults every client except Claude Code to proxy mode:

```
claude-code:     native
claude-ai:       proxy
cursor:          proxy
windsurf:        proxy
github-copilot:  proxy
codex:           proxy
opencode:        proxy
unknown:         proxy
```

So the majority of real traffic reported `tool_name: "invoke_tool"`, and any chart grouped by the obvious dimension collapsed most usage into one meaningless bucket. The proxy path dispatches into the same `registry.handleToolCall` as the native path — same operation, same arguments, same result.

`operation_name` (shipped in 0.52.2) made the wrapper the primary dimension and the operation the secondary one. This inverts that.

## What changed

- `tool_name` is now always the underlying operation, on both call paths.
- New `call_path`: `"direct" | "invoke_tool"`, replacing `operation_name`. Non-optional in the PostHog schema, defaulting to `"direct"`, so every event carries it.
- `proxyCallTelemetry` returns a `ToolCallAttribution` that both the success and error paths spread, which is what shrinks the diff: `returnError` drops from three positional parameters to one attribution object.
- The hardcoded `"invoke_tool"` string in `posthog.ts` is gone with the helper it lived in. The adapter no longer knows any tool name; `protocol-handlers.ts` decides the path using `INVOKE_TOOL_TOOL_NAME`.

Net −17 lines against the commit that introduced `operation_name`.

### Why not `via_proxy`

It collides with `resolved_mode`. `resolved_mode: "proxy"` already means the exposure surface the session was given, so a `search_tools` call would carry `resolved_mode: proxy` with `via_proxy: false` — one word, two meanings, in one row. `call_path` names the dispatch path instead, and an enum needs no convention about which direction `true` points.

### Safety

The registry guard is preserved and matters more now that the target becomes `tool_name`: an unresolved target is never recorded, because arbitrary caller input may contain workspace data. Those events report `tool_name: "invoke_tool"` with `call_path: "invoke_tool"`.

## Breaking

`operation_name` is removed, not deprecated. It shipped in 0.52.2 only. Dashboards built on it need updating; `docs/diagnostics-vs-telemetry.md` documents how to span the version boundary.

## Verification

- `pnpm check-all`: build, both typecheckers (0 errors/warnings, 1012 files), circular, complexity, Oxlint, dprint, jscpd pass. 4830/4831 tests pass.
- The single test failure is #270, which fails identically on clean master and is unrelated to telemetry.
- Full local-Huly integration suite: 1428 passed, 3 failed, 32 skipped. All three failures are host-only environment issues documented in #269 and #270; the same suite is 1440/0 on Linux.
- Event property mapping is covered by 133 unit tests across the four affected files. The integration harness runs with `HULY_MCP_TELEMETRY=0` by design — a test suite must not emit events into real analytics — so end-to-end emission is deliberately out of its scope.

