### PR TITLE
fix: match employee lifecycle IDs with portable sed

### DIFF
--- a/scripts/integration_test_full.sh
+++ b/scripts/integration_test_full.sh
@@ -1895,8 +1895,10 @@ extract_employee_lifecycle_person_id() {
     printf '%s\n' "$text" | jq -r '.personId'
     return 0
   fi
+  # Extended regex: `\+` and `\|` are GNU-only BRE extensions that BSD sed on macOS
+  # silently fails to match, which would report a missing Person ID on a valid response.
   printf '%s\n' "$text" \
-    | sed -n "s/^Employee '\([^']\+\)' was prepared for '[^']\+', but \(sendInvite\|resendInvite\) failed after:.*$/\1/p"
+    | sed -nE "s/^Employee '([^']+)' was prepared for '[^']+', but (sendInvite|resendInvite) failed after:.*$/\1/p"
 }
 
 capture_paginated_hr_reports() {


### PR DESCRIPTION
Fixes #270.

## Cause

`extract_employee_lifecycle_person_id` (`scripts/integration_test_full.sh:1891`) parsed the provider-failure message with:

```bash
sed -n "s/^Employee '\([^']\+\)' was prepared for '[^']\+', but \(sendInvite\|resendInvite\) failed after:.*$/\1/p"
```

`\+` and `\|` are GNU-only BRE extensions. BSD sed on macOS supports neither and fails silently, so the helper returned an empty string and the caller reported a valid response as missing a Person ID.

## Fix

Extended regex, which both implementations accept. Verified on the same input:

| | as written | with `-nE` |
|---|---|---|
| BSD sed (macOS) | *(empty)* | `person-partial` |
| GNU sed (Linux container) | `person-partial` | `person-partial` |

Replacing only `\+` is insufficient — the `\|` alternation fails independently — so both had to move together, which extended regex does in one change.

Audited the rest of the shell scripts for `\+`, `\|`, `\s`, `\b` in sed expressions and for `grep -P`: this was the only occurrence.

## Effect

- `test/scripts/integration-full-transport-contract.test.ts` passes on macOS (25/25). It covers this helper directly and needs no Huly instance.
- `pnpm check-all` is green on macOS: exit 0, 4831/4831 tests, coverage 99.51% statements / 99.01% branches. It was failing on every macOS run before this, which also blocked `prepublishOnly` and therefore releasing from a Mac.
- Unblocks the employee lifecycle branch of the full integration suite (`inactive resend`, `reactivate and restore`), which was skipped whenever the extraction returned empty.

## Not addressed

The container's `integration:cli:full` failed this same assertion on Linux, where GNU sed works — so that path has a separate cause producing an identical message. Tracked in #269 along with two host-only `jq` assertion failures that remain undiagnosed.
