### PR TITLE
docs: note Platform Collective and TraceX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 **Huly MCP** is a feature-complete MCP server for [Huly](https://huly.io/) integration. Published on npm as [`@firfi/huly-mcp`](https://www.npmjs.com/package/@firfi/huly-mcp).
 
+It connects to any Huly Platform deployment, so it should also work with the [Platform Collective](https://github.com/Platform-Collective/platform) fork and [TraceX](https://tracex.co) — unofficial for now.
+
 > [!IMPORTANT]
 > **Hosted Huly is shutting down.** Huly's upstream README says shutdown is expected July 20. If you use `https://huly.app`, [export and migrate your data](https://github.com/hcengineering/platform/blob/develop/README.md) as soon as possible. See the [backup and restore guide](https://github.com/hcengineering/platform/blob/develop/docs/guides/backup-restore.en.md) and [self-hosting repository](https://github.com/hcengineering/huly-selfhost). Self-hosted deployments are not affected.
 


### PR DESCRIPTION
One line in the README intro, above the hosted-shutdown notice:

> It connects to any Huly Platform deployment, so it should also work with the [Platform Collective](https://github.com/Platform-Collective/platform) fork and [TraceX](https://tracex.co) — unofficial for now.

## Basis

The connection surface is a single `HULY_URL` handed to `getWorkspaceToken` from `@hcengineering/api-client` (`src/huly/client.ts:715`), which discovers the account and transactor endpoints itself. Nothing in it is branded or distribution-specific, so compatibility is a function of platform protocol and model version.

- **Platform Collective** is a community fork of the Huly Platform under open governance, preserving the upstream licence and package names and stating technical compatibility as a goal. Its latest tag (v0.7.423) is newer than the platform version exercised locally (`s0.7.409`), so the verified version sits inside the range it ships.
- **TraceX** is not a fork — it is a separate product on the same platform, per upstream's README, adding compliance modules (eQMS/PLM) to a shared base. Shared operations should work; its own classes have no tools here and are invisible rather than broken.

## Wording

"Unofficial" rather than a support claim: neither has been exercised against a live instance, and neither vendor has endorsed this server. Research notes are in `.reference/huly-forks-and-distributions.md` (local only).