### PR TITLE
fix(telemetry): tag parse error responses with error_tag

### DIFF
--- a/.changeset/require-mcp-error-tag.md
+++ b/.changeset/require-mcp-error-tag.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Make the error classification on MCP error responses mandatory and closed. `createErrorResponse` and `createInvalidParamsError` now require an `McpErrorTag` — the union of domain error `_tag`s plus the protocol-level outcomes — instead of accepting an optional bare `string`. Interrupted operations report `Interrupted` rather than going out unclassified.

--- a/.changeset/tag-parse-error-responses.md
+++ b/.changeset/tag-parse-error-responses.md
@@ -1,0 +1,5 @@
+---
+"@firfi/huly-mcp": patch
+---
+
+Tag schema parse failures and parse-path defects in error telemetry. `mapParseErrorToMcp` now reports `ParseError` and `mapParseCauseToMcp` reports `UnexpectedError` for defects, matching the classification `mapDomainCauseToMcp` already applied. Interrupted operations stay untagged.

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -26,9 +26,9 @@ import {
   HOSTED_HULY_SUNSET,
   isDefaultHulyCloudOrigin
 } from "../huly/unavailable-diagnostics.js"
-import { classifyCause, findRecoverableCauseFailure } from "../runtime/cause-exit.js"
+import { type CauseClassification, classifyCause, findRecoverableCauseFailure } from "../runtime/cause-exit.js"
 import { formatParseError } from "./schema-error-format.js"
-import { createErrorResponse, McpErrorCode, type McpErrorResponseWithMeta } from "./tool-responses.js"
+import { createErrorResponse, McpErrorCode, type McpErrorResponseWithMeta, type McpErrorTag } from "./tool-responses.js"
 
 export { formatParseError } from "./schema-error-format.js"
 
@@ -402,6 +402,11 @@ export const mapParseErrorToMcp = (error: Schema.SchemaError, toolName?: string)
   return createErrorResponse(`${prefix}${message}`, McpErrorCode.InvalidParams, "ParseError")
 }
 
+// An interrupt is a distinct outcome from a defect, and both must stay
+// distinguishable in telemetry from an error that was never classified at all.
+const unclassifiedCauseTag = <E>(classification: CauseClassification<E>): McpErrorTag =>
+  classification._tag === "Fatal" && classification.reason === "Interrupt" ? "Interrupted" : "UnexpectedError"
+
 export const mapParseCauseToMcp = (
   cause: Cause.Cause<Schema.SchemaError>,
   toolName?: string
@@ -412,7 +417,7 @@ export const mapParseCauseToMcp = (
     : createErrorResponse(
         "An unexpected error occurred",
         McpErrorCode.InternalError,
-        classification._tag === "Fatal" && classification.reason !== "Interrupt" ? "UnexpectedError" : undefined
+        unclassifiedCauseTag(classification)
       )
 }
 
@@ -430,7 +435,7 @@ export const mapDomainCauseToMcp = (
   return createErrorResponse(
     "An unexpected error occurred",
     McpErrorCode.InternalError,
-    classification._tag === "Fatal" && classification.reason !== "Interrupt" ? "UnexpectedError" : undefined,
+    unclassifiedCauseTag(classification),
     warnings
   )
 }

--- a/src/mcp/error-mapping.ts
+++ b/src/mcp/error-mapping.ts
@@ -399,7 +399,7 @@ export const mapParseErrorToMcp = (error: Schema.SchemaError, toolName?: string)
   const prefix = toolName ? `Invalid parameters for ${toolName}: ` : "Invalid parameters: "
   const message = formatParseError(error)
 
-  return createErrorResponse(`${prefix}${message}`, McpErrorCode.InvalidParams)
+  return createErrorResponse(`${prefix}${message}`, McpErrorCode.InvalidParams, "ParseError")
 }
 
 export const mapParseCauseToMcp = (
@@ -409,7 +409,11 @@ export const mapParseCauseToMcp = (
   const classification = classifyCause(cause)
   return classification._tag === "Failure"
     ? mapParseErrorToMcp(classification.firstFailure, toolName)
-    : createErrorResponse("An unexpected error occurred", McpErrorCode.InternalError)
+    : createErrorResponse(
+        "An unexpected error occurred",
+        McpErrorCode.InternalError,
+        classification._tag === "Fatal" && classification.reason !== "Interrupt" ? "UnexpectedError" : undefined
+      )
 }
 
 export const mapDomainCauseToMcp = (

--- a/src/mcp/tool-responses.ts
+++ b/src/mcp/tool-responses.ts
@@ -2,13 +2,30 @@ import { Schema } from "effect"
 
 import { type McpImageContent, McpImageContentSchema } from "../domain/schemas/attachments.js"
 import type { ToolWarning } from "../domain/schemas/tool-warnings.js"
+import type { HulyDomainError } from "../huly/errors.js"
 
 export const McpErrorCode = { InvalidParams: -32602, InternalError: -32603 } as const
 export type McpErrorCode = (typeof McpErrorCode)[keyof typeof McpErrorCode]
 
+/**
+ * How an error response is classified for telemetry. Domain failures report their
+ * own `_tag`; the literals cover protocol-level outcomes that have no domain error.
+ * Every error response carries one, so an absent tag cannot mean "nobody set it".
+ */
+export type McpErrorTag =
+  | HulyDomainError["_tag"]
+  | "ParseError"
+  | "UnexpectedError"
+  | "Interrupted"
+  | "UnknownTool"
+  | "ServerShuttingDown"
+  | "MissingArguments"
+  | "UnexpectedArguments"
+  | "ProxyClientsMissing"
+
 interface ErrorMetadata {
   errorCode: McpErrorCode
-  errorTag?: string | undefined
+  errorTag: McpErrorTag
 }
 
 type McpTextContent = { readonly type: "text"; readonly text: string }
@@ -55,7 +72,7 @@ const encodeJsonText = (value: unknown): string => {
 export const createErrorResponse = (
   text: string,
   errorCode: McpErrorCode,
-  errorTag?: string,
+  errorTag: McpErrorTag,
   warnings: ReadonlyArray<ToolWarning> = []
 ): McpErrorResponseWithMeta => ({
   content: [
@@ -121,7 +138,7 @@ export const SERVER_SHUTTING_DOWN_MESSAGE = "Huly MCP is shutting down; start a 
 export const createServerShuttingDownError = (): McpErrorResponseWithMeta =>
   createErrorResponse(SERVER_SHUTTING_DOWN_MESSAGE, McpErrorCode.InternalError, "ServerShuttingDown")
 
-export const createInvalidParamsError = (message: string, errorTag?: string): McpErrorResponseWithMeta =>
+export const createInvalidParamsError = (message: string, errorTag: McpErrorTag): McpErrorResponseWithMeta =>
   createErrorResponse(message, McpErrorCode.InvalidParams, errorTag)
 
 export function toMcpResponse(response: McpToolErrorResponse): McpWireErrorResponse

--- a/test/mcp/error-mapping-branches.test.ts
+++ b/test/mcp/error-mapping-branches.test.ts
@@ -48,7 +48,19 @@ describe("Error Mapping Branch Coverage", () => {
 
         expect(response.isError).toBe(true)
         expect(response._meta.errorCode).toBe(McpErrorCode.InternalError)
+        expect(response._meta.errorTag).toBe("UnexpectedError")
         expect(assertAt(response.content, 0).text).toBe("An unexpected error occurred")
+      })
+    )
+
+    // Interruption is not a fault worth classifying, so it stays untagged.
+    it.effect("leaves an interrupt cause untagged", () =>
+      Effect.sync(function () {
+        const response = mapParseCauseToMcp(Cause.interrupt())
+
+        expect(response.isError).toBe(true)
+        expect(response._meta.errorCode).toBe(McpErrorCode.InternalError)
+        expect(response._meta.errorTag).toBeUndefined()
       })
     )
   })

--- a/test/mcp/error-mapping-branches.test.ts
+++ b/test/mcp/error-mapping-branches.test.ts
@@ -53,14 +53,15 @@ describe("Error Mapping Branch Coverage", () => {
       })
     )
 
-    // Interruption is not a fault worth classifying, so it stays untagged.
-    it.effect("leaves an interrupt cause untagged", () =>
+    // An interrupt is a distinct outcome from a defect, so it gets its own tag
+    // rather than sharing "UnexpectedError" or going out unclassified.
+    it.effect("tags an interrupt cause as Interrupted", () =>
       Effect.sync(function () {
         const response = mapParseCauseToMcp(Cause.interrupt())
 
         expect(response.isError).toBe(true)
         expect(response._meta.errorCode).toBe(McpErrorCode.InternalError)
-        expect(response._meta.errorTag).toBeUndefined()
+        expect(response._meta.errorTag).toBe("Interrupted")
       })
     )
   })

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -809,6 +809,7 @@ describe("Error Mapping to MCP", () => {
 
         expect(response.isError).toBe(true)
         expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+        expect(response._meta.errorTag).toBe("ParseError")
         expect(assertAt(response.content, 0).text).toBe(
           "Invalid parameters for create_issue: name: Expected string, actual 123"
         )
@@ -836,6 +837,7 @@ describe("Error Mapping to MCP", () => {
 
         expect(response.isError).toBe(true)
         expect(response._meta.errorCode).toBe(McpErrorCode.InvalidParams)
+        expect(response._meta.errorTag).toBe("ParseError")
         expect(assertAt(response.content, 0).text).toContain("Invalid parameters:")
       })
     )

--- a/test/mcp/error-mapping.test.ts
+++ b/test/mcp/error-mapping.test.ts
@@ -1164,7 +1164,7 @@ describe("Error Mapping to MCP", () => {
       Effect.sync(function () {
         const wire = toMcpResponse({
           content: [{ type: "text", text: "ok" }],
-          _meta: { errorCode: McpErrorCode.InternalError }
+          _meta: { errorCode: McpErrorCode.InternalError, errorTag: "UnexpectedError" }
         })
 
         expect(wire).toEqual({ content: [{ type: "text", text: "ok" }] })
@@ -1176,7 +1176,7 @@ describe("Error Mapping to MCP", () => {
         const wire = toMcpResponse({
           content: [{ type: "text", text: "ok" }],
           isError: false,
-          _meta: { errorCode: McpErrorCode.InternalError }
+          _meta: { errorCode: McpErrorCode.InternalError, errorTag: "UnexpectedError" }
         })
 
         expect(wire).toEqual({ content: [{ type: "text", text: "ok" }], isError: false })

--- a/test/mcp/protocol-handlers.test.ts
+++ b/test/mcp/protocol-handlers.test.ts
@@ -640,7 +640,7 @@ const imageProxyRegistry: ToolRegistry = {
 
 const errorProxyRegistry: ToolRegistry = {
   ...diagnosticProbeRegistry,
-  handleToolCall: async () => createInvalidParamsError("target rejected arguments", "TargetRejected")
+  handleToolCall: async () => createInvalidParamsError("target rejected arguments", "ParseError")
 }
 
 const nullDispatchProxyRegistry: ToolRegistry = { ...diagnosticProbeRegistry, handleToolCall: async () => null }
@@ -1626,7 +1626,7 @@ describe("createMcpProtocolHandlers — proxy mode", () => {
       ...diagnosticProbeRegistry,
       handleToolCall: async (_toolName, args) => {
         receivedArguments.push(args)
-        return createInvalidParamsError("captured target arguments", "CapturedArguments")
+        return createInvalidParamsError("captured target arguments", "ParseError")
       }
     }
     const clients = await resolveStubClients()


### PR DESCRIPTION
## What

Tags the two error paths that reached PostHog unclassified.

- `mapParseErrorToMcp` → `"ParseError"` (every schema parse failure)
- `mapParseCauseToMcp` defect branch → `"UnexpectedError"`

Interrupted operations stay untagged — interruption is not a fault worth classifying, matching the existing behaviour at `mapDomainCauseToMcp`.

## Why

`errorTag` is an optional third positional argument to `createErrorResponse` (`src/mcp/tool-responses.ts:55`), so a call site that omits it silently produces an untagged error. Two sites omitted it. `mapDomainCauseToMcp` already handled the identical defect case correctly:

```ts
classification._tag === "Fatal" && classification.reason !== "Interrupt" ? "UnexpectedError" : undefined
```

The parse path just never got the same treatment. This change makes the two consistent.

## Impact

Untagged errors were roughly 40% of genuine client error volume. Past 7 days, restricted to identified editor clients (excludes bot sessions and our own harness traffic):

| tool | errors | sessions | versions | clients |
|---|---|---|---|---|
| get_issue | 9 | 4 | 3 | claude-code |
| add_comment | 5 | 3 | 3 | claude-code |
| update_issue | 4 | 3 | 3 | claude-code |
| invoke_tool | 4 | 4 | 3 | codex, cursor |
| get_custom_field_values | 4 | 2 | 2 | claude-code |
| list_comments | 3 | 3 | 2 | claude-code |

Spread across 3 versions, so not a single bad release. Until this lands, the largest genuine error class is unclassifiable and any further error investigation is guesswork.

## Verification

`pnpm check-all` green (coverage 99.51% statements / 99.01% branches). Two test assertions added for the new tags plus a new case covering the interrupt branch.

Not verified: no integration run against live Huly — the change is in pure error-mapping functions with no I/O, and the affected branches are covered by unit tests.

## Related

Part of the telemetry-quality set: #275 (harness emits live telemetry), #276 (no test/CI dimension), #277 (`CliInputError` too coarse). This is the same defect shape as #277, one layer up.


---

## Follow-up commit: the tag is now required

The first commit fixed two call sites but left `errorTag?: string`, which is the affordance that produced them — the next site that forgets it fails silently again. Closed in `c8c738c2`:

- `createErrorResponse` / `createInvalidParamsError` now **require** the tag.
- It is typed `McpErrorTag` — `HulyDomainError["_tag"]` plus the protocol-level literals (`ParseError`, `UnexpectedError`, `Interrupted`, `UnknownTool`, `ServerShuttingDown`, `MissingArguments`, `UnexpectedArguments`, `ProxyClientsMissing`) — rather than a bare `string`, which also admitted `""`.
- Interrupts report `"Interrupted"` instead of `undefined`, so an absent tag can no longer mean either "interrupted" or "nobody set it". This reverses the assertion added in the first commit, which had encoded the weaker design.
- The duplicated `classification._tag === "Fatal" && ...` expression in `mapParseCauseToMcp` and `mapDomainCauseToMcp` is now one `unclassifiedCauseTag` helper.

Making the parameter required broke **zero production call sites** — only four test fixtures, two of which used invented tags (`"TargetRejected"`, `"CapturedArguments"`). That confirms the optionality was pure footgun with no legitimate user.

`pnpm check-all` green again after the change (99.51% statements, 99.01% branches).